### PR TITLE
test: stabilize e2e tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig, devices } from '@playwright/test'
 import dotenv from 'dotenv'
-import type { AuthUsersOptions } from './tests/fixtures/auth-users'
-import { users } from './tests/data'
 import { minutesToMilliseconds } from 'date-fns'
 
 dotenv.config()
@@ -9,7 +7,7 @@ dotenv.config()
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-export default defineConfig<AuthUsersOptions>({
+export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
@@ -23,10 +21,6 @@ export default defineConfig<AuthUsersOptions>({
   use: {
     baseURL: 'http://localhost:3000',
     trace: 'retain-on-failure',
-    video: {
-      mode: 'retain-on-failure',
-      size: { width: 1280, height: 720 },
-    },
   },
 
   projects: [
@@ -36,12 +30,12 @@ export default defineConfig<AuthUsersOptions>({
     },
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'], steamIds: users.map(u => u.steamId) },
+      use: { ...devices['Desktop Chrome'] },
       dependencies: ['setup database'],
     },
     {
       name: 'firefox',
-      use: { ...devices['Desktop Firefox'], steamIds: users.map(u => u.steamId) },
+      use: { ...devices['Desktop Firefox'] },
       dependencies: ['setup database'],
     },
 

--- a/src/queue/views/html/queue-slot.tsx
+++ b/src/queue/views/html/queue-slot.tsx
@@ -36,6 +36,7 @@ export async function QueueSlot(props: { slot: QueueSlotModel; actor?: SteamId64
       class="queue-slot"
       id={`queue-slot-${props.slot.id}`}
       aria-label={`Queue slot ${props.slot.id}`}
+      data-player={props.slot.player}
     >
       {slotContent}
     </div>

--- a/tests/10-queue/01-update-player-count.spec.ts
+++ b/tests/10-queue/01-update-player-count.spec.ts
@@ -1,7 +1,14 @@
+import { mergeTests } from '@playwright/test'
 import { authUsers, expect } from '../fixtures/auth-users'
 import { QueuePage } from '../pages/queue.page'
+import { queuePage } from '../fixtures/queue-page'
 
-authUsers('update player count', async ({ page, users }) => {
+const test = mergeTests(authUsers, queuePage)
+test.beforeEach(async ({ queue }) => {
+  await queue.waitToBeEmpty()
+})
+
+test('update player count', async ({ page, users }) => {
   const queuePage = new QueuePage(page)
   const p1 = await users.getNext().queuePage()
   const p2 = await users.getNext().queuePage()

--- a/tests/10-queue/02-vote-for-map.spec.ts
+++ b/tests/10-queue/02-vote-for-map.spec.ts
@@ -1,7 +1,14 @@
+import { mergeTests } from '@playwright/test'
 import { authUsers, expect } from '../fixtures/auth-users'
+import { queuePage } from '../fixtures/queue-page'
 
-authUsers('vote for map', async ({ users }) => {
-  const page = await users.getFirst().queuePage()
+const test = mergeTests(authUsers, queuePage)
+test.beforeEach(async ({ queue }) => {
+  await queue.waitToBeEmpty()
+})
+
+test('vote for map', async ({ users }) => {
+  const page = await users.byName('SlitherTuft').queuePage()
   await page.goto()
   const mapBtn = page.voteForMapButton(0)
   expect(await mapBtn.getAttribute('aria-checked')).toBe('false')

--- a/tests/10-queue/03-mark-as-friend.spec.ts
+++ b/tests/10-queue/03-mark-as-friend.spec.ts
@@ -1,7 +1,15 @@
+import { mergeTests } from '@playwright/test'
 import { authUsers, expect } from '../fixtures/auth-users'
 import type { QueuePage } from '../pages/queue.page'
+import { queuePage } from '../fixtures/queue-page'
 
-authUsers('mark as friend', async ({ users }) => {
+const test = mergeTests(authUsers, queuePage)
+
+test.beforeEach(async ({ queue }) => {
+  await queue.waitToBeEmpty()
+})
+
+test('mark as friend', async ({ users }) => {
   const [medic1, medic2, soldier] = (await Promise.all(
     users.getMany(3).map(async user => {
       const page = await user.queuePage()

--- a/tests/10-queue/04-everybody-leaves.spec.ts
+++ b/tests/10-queue/04-everybody-leaves.spec.ts
@@ -1,7 +1,15 @@
+import { mergeTests } from '@playwright/test'
 import { authUsers } from '../fixtures/auth-users'
 import { minutesToMilliseconds } from 'date-fns'
+import { queuePage } from '../fixtures/queue-page'
 
-authUsers('everybody leaves', async ({ steamIds, users }) => {
+const test = mergeTests(authUsers, queuePage)
+
+test.beforeEach(async ({ queue }) => {
+  await queue.waitToBeEmpty()
+})
+
+test('everybody leaves', async ({ steamIds, users }) => {
   authUsers.setTimeout(minutesToMilliseconds(2))
   const queueUsers = steamIds.slice(0, 12)
   for (let i = 0; i < queueUsers.length; ++i) {

--- a/tests/10-queue/05-late-for-ready-up.spec.ts
+++ b/tests/10-queue/05-late-for-ready-up.spec.ts
@@ -1,7 +1,15 @@
+import { mergeTests } from '@playwright/test'
 import { authUsers, expect } from '../fixtures/auth-users'
 import { minutesToMilliseconds } from 'date-fns'
+import { queuePage } from '../fixtures/queue-page'
 
-authUsers('player is late for ready up', async ({ steamIds, users, page }) => {
+const test = mergeTests(authUsers, queuePage)
+
+test.beforeEach(async ({ queue }) => {
+  await queue.waitToBeEmpty()
+})
+
+test('player is late for ready up', async ({ steamIds, users, page }) => {
   authUsers.setTimeout(minutesToMilliseconds(2))
   const queueUsers = steamIds.slice(0, 12)
   await Promise.all(

--- a/tests/10-queue/07-pre-ready-up.spec.ts
+++ b/tests/10-queue/07-pre-ready-up.spec.ts
@@ -2,16 +2,18 @@ import { mergeTests } from '@playwright/test'
 import { accessMongoDb } from '../fixtures/access-mongo-db'
 import { secondsToMilliseconds } from 'date-fns'
 import { launchGame, expect } from '../fixtures/launch-game'
+import { queuePage } from '../fixtures/queue-page'
 
-const test = mergeTests(accessMongoDb, launchGame)
+const test = mergeTests(accessMongoDb, launchGame, queuePage)
 
-test.beforeEach(async ({ db }) => {
+test.beforeEach(async ({ db, queue }) => {
   const configuration = db.collection('configuration')
   await configuration.updateOne(
     { key: 'queue.pre_ready_up_timeout' },
     { $set: { value: secondsToMilliseconds(10) } },
     { upsert: true },
   )
+  await queue.waitToBeEmpty()
 })
 
 test('pre-ready up button is visible for logged-in-users', async ({ users }) => {

--- a/tests/20-game/02-free-players.spec.ts
+++ b/tests/20-game/02-free-players.spec.ts
@@ -5,7 +5,7 @@ import { launchGameAndInitialize } from '../fixtures/launch-game-and-initialize'
 
 launchGameAndInitialize(
   'free players when the game ends',
-  async ({ players, gameNumber, gameServer }) => {
+  async ({ players, gameServer, gameNumber }) => {
     await Promise.all(
       players.map(async player => {
         const page = await player.queuePage()

--- a/tests/20-game/04-cleanup-game-server.spec.ts
+++ b/tests/20-game/04-cleanup-game-server.spec.ts
@@ -2,7 +2,7 @@ import { minutesToMilliseconds, secondsToMilliseconds } from 'date-fns'
 import { waitABit } from '../utils/wait-a-bit'
 import { expect, launchGameAndStartMatch } from '../fixtures/launch-game-and-start-match'
 
-launchGameAndStartMatch('cleanup game server', async ({ gameNumber, gameServer }) => {
+launchGameAndStartMatch('cleanup game server', async ({ gameServer, gameNumber }) => {
   launchGameAndStartMatch.setTimeout(minutesToMilliseconds(2))
 
   await waitABit(secondsToMilliseconds(3))

--- a/tests/30-player-substitutes/01-substitute-self.spec.ts
+++ b/tests/30-player-substitutes/01-substitute-self.spec.ts
@@ -3,30 +3,25 @@ import { launchGame, expect } from '../fixtures/launch-game'
 launchGame('substitute self', async ({ gameNumber, users, page }) => {
   const admin = users.getAdmin()
   const adminsPage = await admin.gamePage(gameNumber)
-  const mayflower = users.byName('Mayflower')
-  const mayflowersPage = await mayflower.gamePage(gameNumber)
+  const mayflowersPage = await users.byName('Mayflower').gamePage(gameNumber)
 
-  await expect(adminsPage.playerLink(mayflower.playerName)).toBeVisible()
-  await adminsPage.requestSubstitute(mayflower.playerName)
-  await expect(adminsPage.playerLink(mayflower.playerName)).not.toBeVisible()
+  await expect(adminsPage.playerLink('Mayflower')).toBeVisible()
+  await adminsPage.requestSubstitute('Mayflower')
+  await expect(adminsPage.playerLink('Mayflower')).not.toBeVisible()
 
   await expect(adminsPage.gameEvent(`${admin.playerName} requested substitute`)).toBeVisible()
-  await expect(adminsPage.playerLink(mayflower.playerName)).not.toBeVisible()
+  await expect(adminsPage.playerLink('Mayflower')).not.toBeVisible()
   await expect(mayflowersPage.gameEvent(`${admin.playerName} requested substitute`)).toBeVisible()
-  await expect(mayflowersPage.playerLink(mayflower.playerName)).not.toBeVisible()
+  await expect(mayflowersPage.playerLink('Mayflower')).not.toBeVisible()
 
   await expect(
     page.getByText(`Team BLU needs a substitute for scout in game #${mayflowersPage.gameNumber}`),
   ).toBeVisible()
 
-  await mayflowersPage.replacePlayer(mayflower.playerName)
+  await mayflowersPage.replacePlayer('Mayflower')
 
-  await expect(adminsPage.playerLink(mayflower.playerName)).toBeVisible()
-  await expect(
-    adminsPage.gameEvent(`${mayflower.playerName} replaced ${mayflower.playerName}`),
-  ).toBeVisible()
-  await expect(mayflowersPage.playerLink(mayflower.playerName)).toBeVisible()
-  await expect(
-    mayflowersPage.gameEvent(`${mayflower.playerName} replaced ${mayflower.playerName}`),
-  ).toBeVisible()
+  await expect(adminsPage.playerLink('Mayflower')).toBeVisible()
+  await expect(adminsPage.gameEvent(`Mayflower replaced Mayflower`)).toBeVisible()
+  await expect(mayflowersPage.playerLink('Mayflower')).toBeVisible()
+  await expect(mayflowersPage.gameEvent(`Mayflower replaced Mayflower`)).toBeVisible()
 })

--- a/tests/30-player-substitutes/02-substitute-other.spec.ts
+++ b/tests/30-player-substitutes/02-substitute-other.spec.ts
@@ -2,34 +2,27 @@ import { launchGame, expect } from '../fixtures/launch-game'
 
 launchGame('substitute other', async ({ gameNumber, users, page }) => {
   const admin = users.getAdmin()
-  const mayflower = users.byName('Mayflower')
-  const tommyGun = users.byName('TommyGun')
-
   const adminsPage = await admin.gamePage(gameNumber)
-  const tommyGunsPage = await tommyGun.gamePage(gameNumber)
+  const tommyGunsPage = await users.byName('TommyGun').gamePage(gameNumber)
   await tommyGunsPage.goto()
 
-  await expect(adminsPage.playerLink(mayflower.playerName)).toBeVisible()
-  await adminsPage.requestSubstitute(mayflower.playerName)
-  await expect(adminsPage.playerLink(mayflower.playerName)).not.toBeVisible()
+  await expect(adminsPage.playerLink('Mayflower')).toBeVisible()
+  await adminsPage.requestSubstitute('Mayflower')
+  await expect(adminsPage.playerLink('Mayflower')).not.toBeVisible()
 
   await expect(adminsPage.gameEvent(`${admin.playerName} requested substitute`)).toBeVisible()
-  await expect(adminsPage.playerLink(mayflower.playerName)).not.toBeVisible()
+  await expect(adminsPage.playerLink('Mayflower')).not.toBeVisible()
   await expect(tommyGunsPage.gameEvent(`${admin.playerName} requested substitute`)).toBeVisible()
-  await expect(tommyGunsPage.playerLink(mayflower.playerName)).not.toBeVisible()
+  await expect(tommyGunsPage.playerLink('Mayflower')).not.toBeVisible()
 
   await expect(
     page.getByText(`Team BLU needs a substitute for scout in game #${adminsPage.gameNumber}`),
   ).toBeVisible()
 
-  await tommyGunsPage.replacePlayer(mayflower.playerName)
+  await tommyGunsPage.replacePlayer('Mayflower')
 
-  await expect(adminsPage.playerLink(tommyGun.playerName)).toBeVisible()
-  await expect(
-    adminsPage.gameEvent(`${tommyGun.playerName} replaced ${mayflower.playerName}`),
-  ).toBeVisible()
-  await expect(tommyGunsPage.playerLink(tommyGun.playerName)).toBeVisible()
-  await expect(
-    tommyGunsPage.gameEvent(`${tommyGun.playerName} replaced ${mayflower.playerName}`),
-  ).toBeVisible()
+  await expect(adminsPage.playerLink('TommyGun')).toBeVisible()
+  await expect(adminsPage.gameEvent(`TommyGun replaced Mayflower`)).toBeVisible()
+  await expect(tommyGunsPage.playerLink('TommyGun')).toBeVisible()
+  await expect(tommyGunsPage.gameEvent(`TommyGun replaced Mayflower`)).toBeVisible()
 })

--- a/tests/30-player-substitutes/03-manages-in-game.spec.ts
+++ b/tests/30-player-substitutes/03-manages-in-game.spec.ts
@@ -3,26 +3,21 @@ import { expect, launchGameAndStartMatch } from '../fixtures/launch-game-and-sta
 
 launchGameAndStartMatch('manages in-game', async ({ gameNumber, users, gameServer }) => {
   const admin = users.getAdmin()
-  const mayflower = users.byName('Mayflower')
-  const tommyGun = users.byName('TommyGun')
 
   const adminsPage = await admin.gamePage(gameNumber)
-  const tommyGunsPage = await tommyGun.gamePage(gameNumber)
+  const tommyGunsPage = await users.byName('TommyGun').gamePage(gameNumber)
   await tommyGunsPage.goto()
 
-  await expect(adminsPage.playerLink(mayflower.playerName)).toBeVisible()
-  await adminsPage.requestSubstitute(mayflower.playerName)
+  await expect(adminsPage.playerLink('Mayflower')).toBeVisible()
+  await adminsPage.requestSubstitute('Mayflower')
 
-  await expect(gameServer).toHaveCommand(
-    `say Looking for replacement for ${mayflower.playerName}...`,
-    { timeout: secondsToMilliseconds(1) },
-  )
+  await expect(gameServer).toHaveCommand(`say Looking for replacement for Mayflower...`, {
+    timeout: secondsToMilliseconds(1),
+  })
 
-  await tommyGunsPage.replacePlayer(mayflower.playerName)
+  await tommyGunsPage.replacePlayer('Mayflower')
 
-  await expect(gameServer).toHaveCommand(`sm_game_player_add ${tommyGun.steamId}`)
-  await expect(gameServer).toHaveCommand(`sm_game_player_del ${mayflower.steamId}`)
-  await expect(gameServer).toHaveCommand(
-    `say ${mayflower.playerName} has been replaced by ${tommyGun.playerName}`,
-  )
+  await expect(gameServer).toHaveCommand(`sm_game_player_add ${users.byName('TommyGun').steamId}`)
+  await expect(gameServer).toHaveCommand(`sm_game_player_del ${users.byName('Mayflower').steamId}`)
+  await expect(gameServer).toHaveCommand(`say Mayflower has been replaced by TommyGun`)
 })

--- a/tests/40-bans/01-lock-queue.spec.ts
+++ b/tests/40-bans/01-lock-queue.spec.ts
@@ -1,17 +1,23 @@
+import { mergeTests } from '@playwright/test'
 import { authUsers, expect } from '../fixtures/auth-users'
+import { queuePage } from '../fixtures/queue-page'
 
-authUsers('banned player gets kicked from the queue', async ({ users }) => {
-  const player = users.getNext(u => !u.isAdmin)
-  const playerPage = await player.queuePage()
+const test = mergeTests(authUsers, queuePage)
+
+test.beforeEach(async ({ queue }) => {
+  await queue.waitToBeEmpty()
+})
+
+test('banned player gets kicked from the queue', async ({ users }) => {
+  const playerPage = await users.byName('AstraGirl').queuePage()
   await playerPage.goto()
   await playerPage.joinQueue(0)
 
   const adminPage = await users.getAdmin().adminPage()
-  await adminPage.banPlayer(player.steamId, { reason: 'test' })
+  await adminPage.banPlayer(users.byName('AstraGirl').steamId, { reason: 'test' })
 
   await expect(playerPage.slot(0).joinButton()).toBeDisabled()
 
-  await adminPage.revokeAllBans(player.steamId)
-
+  await adminPage.revokeAllBans(users.byName('AstraGirl').steamId)
   await expect(playerPage.slot(0).joinButton()).toBeEnabled()
 })

--- a/tests/40-bans/02-ban-alert.spec.ts
+++ b/tests/40-bans/02-ban-alert.spec.ts
@@ -1,14 +1,14 @@
 import { authUsers, expect } from '../fixtures/auth-users'
 
 authUsers('banned player sees ban alert', async ({ users }) => {
-  const player = users.getNext(u => !u.isAdmin)
+  const player = users.byName('AstraGirl')
   const playerPage = await player.queuePage()
   await playerPage.goto()
 
   const adminPage = await users.getAdmin().adminPage()
   await adminPage.banPlayer(player.steamId, { reason: 'testing' })
 
-  const banAlert = (await player.page()).getByText('You are banned')
+  const banAlert = playerPage.page.getByText('You are banned')
   await expect(banAlert).toBeVisible()
   await expect(banAlert).toHaveText(/^You are banned until\s*.+\s*for\s*testing\s*$/)
 

--- a/tests/90-admin/01-admin-panel.spec.ts
+++ b/tests/90-admin/01-admin-panel.spec.ts
@@ -1,7 +1,5 @@
-import { users } from '../data'
 import { authUsers } from '../fixtures/auth-users'
 
-authUsers.use({ steamIds: [users[0].steamId] })
 authUsers('admin panel is visible & accessible', async ({ users }) => {
   const adminsPage = await users.getAdmin().page()
   await adminsPage.goto('/')

--- a/tests/fixtures/queue-page.ts
+++ b/tests/fixtures/queue-page.ts
@@ -1,0 +1,10 @@
+import test from '@playwright/test'
+import { QueuePage } from '../pages/queue.page'
+
+export const queuePage = test.extend<{ queue: QueuePage }>({
+  queue: async ({ page }, use) => {
+    const q = new QueuePage(page)
+    await q.goto()
+    use(q)
+  },
+})

--- a/tests/pages/game.page.ts
+++ b/tests/pages/game.page.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test'
+import type { UserName } from '../user-manager'
 
 export class GamePage {
   constructor(
@@ -25,11 +26,11 @@ export class GamePage {
     )
   }
 
-  playerSlot(playerName: string) {
+  playerSlot(playerName: UserName) {
     return this.page.getByLabel(`${playerName}'s slot`)
   }
 
-  playerLink(playerName: string) {
+  playerLink(playerName: UserName) {
     return this.playerSlot(playerName).getByRole('link', { name: playerName })
   }
 
@@ -49,12 +50,12 @@ export class GamePage {
     return this.page.getByRole('link', { name: 'watch stv' })
   }
 
-  async requestSubstitute(playerName: string) {
+  async requestSubstitute(playerName: UserName) {
     const btn = this.playerSlot(playerName).getByLabel('Request substitute')
     await btn.click()
   }
 
-  async replacePlayer(playerName: string) {
+  async replacePlayer(playerName: UserName) {
     const btn = this.playerSlot(playerName).getByRole('button', { name: 'Replace player' })
     await btn.click()
   }

--- a/tests/user-manager.ts
+++ b/tests/user-manager.ts
@@ -7,12 +7,15 @@ import type { BrowserContext, Page } from '@playwright/test'
 // https://stackoverflow.com/questions/52489261/can-i-define-an-n-length-tuple-type
 type Tuple<T, N, R extends T[] = []> = R['length'] extends N ? Readonly<R> : Tuple<T, N, [...R, T]>
 
+export type UserSteamId = (typeof users)[number]['steamId']
+export type UserName = (typeof users)[number]['name']
+
 export class UserContext {
-  readonly playerName: string
+  readonly playerName: UserName
   private _page?: Page
 
   constructor(
-    public readonly steamId: string,
+    public readonly steamId: UserSteamId,
     public readonly browserContext: BrowserContext,
   ) {
     const playerName = users.find(u => u.steamId === steamId)?.name
@@ -95,7 +98,7 @@ export class UserManager {
     return player
   }
 
-  bySteamId(steamId: string): UserContext {
+  bySteamId(steamId: UserSteamId): UserContext {
     const user = this.users.find(user => user.steamId === steamId)
     if (user === undefined) {
       throw new Error(`user with steamId ${steamId} not found`)
@@ -103,7 +106,7 @@ export class UserManager {
     return user
   }
 
-  byName(name: string): UserContext {
+  byName(name: UserName): UserContext {
     const user = this.users.find(user => user.playerName === name)
     if (user === undefined) {
       throw new Error(`user with name ${name} not found`)


### PR DESCRIPTION
* always wait for the queue to be empty before starting another test
* remove `steamIds` test option