### PR TITLE
feat: add WebSocket connection status indicator to footer

### DIFF
--- a/src/html/@client/main.ts
+++ b/src/html/@client/main.ts
@@ -9,6 +9,7 @@ import './copy-to-clipboard'
 import './notifications'
 import './play-sound'
 import './sync-attribute'
+import './ws-status-indicator'
 
 import * as hyperscript from 'hyperscript.org'
 hyperscript.browserInit()

--- a/src/html/@client/ws-status-indicator.ts
+++ b/src/html/@client/ws-status-indicator.ts
@@ -1,0 +1,28 @@
+import htmx from './htmx.js'
+
+type WsStatus = 'connecting' | 'connected' | 'disconnected'
+
+const tooltipText: Record<WsStatus, string> = {
+  connecting: 'Connecting...',
+  connected: 'Connected',
+  disconnected: 'Disconnected',
+}
+
+function setStatus(status: WsStatus) {
+  const indicator = document.querySelector<HTMLElement>('#ws-status')
+  if (!indicator) return
+  indicator.dataset['wsStatus'] = status
+  indicator.setAttribute('aria-label', tooltipText[status])
+  const tooltip = indicator.querySelector(':scope > .tooltip')
+  if (tooltip) tooltip.textContent = tooltipText[status]
+}
+
+htmx.on('htmx:wsConnecting', () => {
+  setStatus('connecting')
+})
+htmx.on('htmx:wsOpen', () => {
+  setStatus('connected')
+})
+htmx.on('htmx:wsClose', () => {
+  setStatus('disconnected')
+})

--- a/src/html/components/footer.tsx
+++ b/src/html/components/footer.tsx
@@ -32,6 +32,10 @@ export function Footer() {
             </a>
 
             {user?.player.roles.includes(PlayerRole.admin) && <a href="/admin">Admin panel</a>}
+            <div id="ws-status" data-ws-status="connecting" role="status" aria-label="Connecting...">
+              <span class="ball" />
+              <span class="tooltip tooltip--bottom whitespace-nowrap">Connecting...</span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/html/components/footer.tsx
+++ b/src/html/components/footer.tsx
@@ -32,7 +32,13 @@ export function Footer() {
             </a>
 
             {user?.player.roles.includes(PlayerRole.admin) && <a href="/admin">Admin panel</a>}
-            <div id="ws-status" data-ws-status="connecting" role="status" aria-label="Connecting...">
+            <div
+              id="ws-status"
+              data-ws-status="connecting"
+              role="status"
+              aria-label="Connecting..."
+              hx-preserve
+            >
               <span class="ball" />
               <span class="tooltip whitespace-nowrap">Connecting...</span>
             </div>

--- a/src/html/components/footer.tsx
+++ b/src/html/components/footer.tsx
@@ -34,7 +34,7 @@ export function Footer() {
             {user?.player.roles.includes(PlayerRole.admin) && <a href="/admin">Admin panel</a>}
             <div id="ws-status" data-ws-status="connecting" role="status" aria-label="Connecting...">
               <span class="ball" />
-              <span class="tooltip tooltip--bottom whitespace-nowrap">Connecting...</span>
+              <span class="tooltip whitespace-nowrap">Connecting...</span>
             </div>
           </div>
         </div>

--- a/src/html/styles/main.css
+++ b/src/html/styles/main.css
@@ -16,6 +16,7 @@
 @import './switch.css';
 @import './tabs.css';
 @import './tooltip.css';
+@import './ws-status-indicator.css';
 
 @theme {
   --font-sans:

--- a/src/html/styles/ws-status-indicator.css
+++ b/src/html/styles/ws-status-indicator.css
@@ -1,0 +1,33 @@
+@layer components {
+  #ws-status {
+    .ball {
+      display: block;
+      width: 0.75rem;
+      height: 0.75rem;
+      border-radius: 9999px;
+    }
+
+    &[data-ws-status='connecting'] .ball {
+      background-color: var(--color-yellow-400);
+      animation: ws-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+    }
+
+    &[data-ws-status='connected'] .ball {
+      background-color: var(--color-green-400);
+    }
+
+    &[data-ws-status='disconnected'] .ball {
+      background-color: var(--color-red-400);
+    }
+  }
+
+  @keyframes ws-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.5;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a small colored ball in the footer showing WebSocket connection state: yellow+pulsing (connecting), green (connected), red (disconnected)
- State is driven by `data-ws-status` attribute updated via a new client module listening to `htmx:wsConnecting`, `htmx:wsOpen`, and `htmx:wsClose` events
- Includes a tooltip on hover and ARIA `role="status"` + `aria-label` for accessibility

## Test Plan

- [ ] Visit the site and verify the footer shows a yellow pulsing ball initially
- [ ] After the WebSocket connects, the ball turns green with tooltip "Connected"
- [ ] Simulate a network disconnect (e.g. disable Wi-Fi) — ball turns red "Disconnected"
- [ ] Reconnect — ball returns to yellow "Connecting..." then green "Connected"
- [ ] Verify tooltip appears on hover and renders above the ball (not clipped by viewport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)