### PR TITLE
feat: add per-class ELO rating system

### DIFF
--- a/src/database/models/player.model.ts
+++ b/src/database/models/player.model.ts
@@ -45,6 +45,8 @@ export interface PlayerStats {
 
 export type PlayerSkill = Partial<Record<Tf2ClassName, number>>
 
+export type PlayerElo = Partial<Record<Tf2ClassName, number>>
+
 export interface PlayerModel {
   name: string
   steamId: SteamId64
@@ -74,4 +76,10 @@ export interface PlayerModel {
   verified?: boolean
   twitchTvProfile?: TwitchTvProfile
   stats: PlayerStats
+  elo?: PlayerElo
+  eloHistory?: {
+    at: Date
+    elo: PlayerElo
+    game: GameNumber
+  }[]
 }

--- a/src/games/calculate-elo-updates.test.ts
+++ b/src/games/calculate-elo-updates.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from 'vitest'
+import { calculateEloUpdates, defaultElo } from './calculate-elo-updates'
+import {
+  GameEndedReason,
+  GameEventType,
+  type GameCreated,
+  type GameEnded,
+  type GameStarted,
+  type PlayerReplaced,
+} from '../database/models/game-event.model'
+import { GameState, type GameModel, type GameNumber } from '../database/models/game.model'
+import { PlayerConnectionStatus, SlotStatus } from '../database/models/game-slot.model'
+import { Tf2Team } from '../shared/types/tf2-team'
+import { Tf2ClassName } from '../shared/types/tf2-class-name'
+import type { SteamId64 } from '../shared/types/steam-id-64'
+import type { GameSlotId } from '../shared/types/game-slot-id'
+
+// Fixed timestamps: 60-minute game
+const startedAt = new Date('2024-01-01T10:00:00Z')
+const endedAt = new Date('2024-01-01T11:00:00Z')
+const gameDurationMs = endedAt.getTime() - startedAt.getTime()
+
+const createdEvent: GameCreated = { event: GameEventType.gameCreated, at: new Date('2024-01-01T09:55:00Z') }
+const startedEvent: GameStarted = { event: GameEventType.gameStarted, at: startedAt }
+const endedEvent: GameEnded = { event: GameEventType.gameEnded, at: endedAt, reason: GameEndedReason.matchEnded }
+
+const red = '76561198000000001' as SteamId64
+const blu = '76561198000000002' as SteamId64
+const red2 = '76561198000000003' as SteamId64
+const blu2 = '76561198000000004' as SteamId64
+
+function makeSlot(
+  player: SteamId64,
+  team: Tf2Team,
+  gameClass: Tf2ClassName,
+  status = SlotStatus.active,
+) {
+  return {
+    id: `${team}-${gameClass}-1` as GameSlotId,
+    player,
+    team,
+    gameClass,
+    status,
+    connectionStatus: PlayerConnectionStatus.connected,
+  }
+}
+
+function makeGame(overrides: Omit<Partial<GameModel>, 'score'> & { score?: Record<Tf2Team, number> }): GameModel {
+  return {
+    number: 1 as GameNumber,
+    map: 'cp_process_final',
+    state: GameState.ended,
+    slots: [
+      makeSlot(red, Tf2Team.red, Tf2ClassName.scout),
+      makeSlot(blu, Tf2Team.blu, Tf2ClassName.scout),
+    ],
+    events: [createdEvent, startedEvent, endedEvent],
+    score: { red: 3, blu: 0 },
+    ...overrides,
+  }
+}
+
+// Getters that return defaultElo and 0 games for everyone
+const getDefaultElo = () => defaultElo
+const provisionalGames = () => 0
+const establishedGames = () => 10
+
+describe('calculateEloUpdates', () => {
+  describe('guard conditions', () => {
+    it('returns empty array when game state is not ended', () => {
+      const game = makeGame({ state: GameState.started })
+      expect(calculateEloUpdates(game, getDefaultElo, provisionalGames)).toEqual([])
+    })
+
+    it('returns empty array when game has no score', () => {
+      const { score: _s, ...game } = makeGame({})
+      expect(calculateEloUpdates(game as GameModel, getDefaultElo, provisionalGames)).toEqual([])
+    })
+
+    it('returns empty array when gameStarted event is missing', () => {
+      const game = makeGame({ events: [createdEvent, endedEvent] })
+      expect(calculateEloUpdates(game, getDefaultElo, provisionalGames)).toEqual([])
+    })
+
+    it('returns empty array when gameEnded event is missing', () => {
+      const game = makeGame({ events: [createdEvent, startedEvent] })
+      expect(calculateEloUpdates(game, getDefaultElo, provisionalGames)).toEqual([])
+    })
+  })
+
+  describe('ELO calculation', () => {
+    it('gives winner ELO gain and loser ELO loss when teams are equally matched', () => {
+      // E = 0.5 for both; K = 32 (provisional)
+      // winner: 1500 + 32 * (1 - 0.5) = 1516
+      // loser:  1500 + 32 * (0 - 0.5) = 1484
+      const game = makeGame({ score: { red: 3, blu: 0 } })
+      const updates = calculateEloUpdates(game, getDefaultElo, provisionalGames)
+
+      expect(updates.find(u => u.steamId === red)?.newElo).toBe(1516)
+      expect(updates.find(u => u.steamId === blu)?.newElo).toBe(1484)
+    })
+
+    it('results in no ELO change on a tie', () => {
+      // S = 0.5, E = 0.5 → delta = 0
+      const game = makeGame({ score: { red: 1, blu: 1 } })
+      const updates = calculateEloUpdates(game, getDefaultElo, provisionalGames)
+
+      expect(updates.find(u => u.steamId === red)?.newElo).toBe(defaultElo)
+      expect(updates.find(u => u.steamId === blu)?.newElo).toBe(defaultElo)
+    })
+
+    it('uses K=32 for provisional players (fewer than 10 games on class)', () => {
+      const game = makeGame({ score: { red: 3, blu: 0 } })
+      const updates = calculateEloUpdates(game, getDefaultElo, () => 9) // 9 games = still provisional
+      expect(updates.find(u => u.steamId === red)?.newElo).toBe(1516) // K=32
+    })
+
+    it('uses K=16 for established players (10 or more games on class)', () => {
+      // winner: 1500 + 16 * (1 - 0.5) = 1508
+      // loser:  1500 + 16 * (0 - 0.5) = 1492
+      const game = makeGame({ score: { red: 3, blu: 0 } })
+      const updates = calculateEloUpdates(game, getDefaultElo, establishedGames)
+
+      expect(updates.find(u => u.steamId === red)?.newElo).toBe(1508)
+      expect(updates.find(u => u.steamId === blu)?.newElo).toBe(1492)
+    })
+
+    it('gives a smaller gain to the higher-rated winner', () => {
+      // red at 1600, blu at 1400; red wins
+      // E_red ≈ 0.7597 → gain ≈ round(32 * 0.2403) = 8 → 1608
+      const customElo = (steamId: SteamId64) => (steamId === red ? 1600 : 1400)
+      const game = makeGame({ score: { red: 3, blu: 0 } })
+      const updates = calculateEloUpdates(game, customElo, provisionalGames)
+
+      expect(updates.find(u => u.steamId === red)?.newElo).toBe(1608)
+      expect(updates.find(u => u.steamId === blu)?.newElo).toBe(1392)
+    })
+
+    it('gives a larger gain to the lower-rated winner (upset)', () => {
+      // red at 1400, blu at 1600; red wins
+      // E_red ≈ 0.2403 → gain ≈ round(32 * 0.7597) = 24 → 1424
+      const customElo = (steamId: SteamId64) => (steamId === red ? 1400 : 1600)
+      const game = makeGame({ score: { red: 3, blu: 0 } })
+      const updates = calculateEloUpdates(game, customElo, provisionalGames)
+
+      expect(updates.find(u => u.steamId === red)?.newElo).toBe(1424)
+      expect(updates.find(u => u.steamId === blu)?.newElo).toBe(1576)
+    })
+
+    it('attaches the correct game number and timestamp to each update', () => {
+      const game = makeGame({ number: 42 as GameNumber })
+      const updates = calculateEloUpdates(game, getDefaultElo, provisionalGames)
+
+      for (const update of updates) {
+        expect(update.game).toBe(42)
+        expect(update.at).toEqual(endedAt)
+      }
+    })
+  })
+
+  describe('play time eligibility (80% threshold)', () => {
+    function atPercent(percent: number): Date {
+      return new Date(startedAt.getTime() + gameDurationMs * percent)
+    }
+
+    it('includes a player who played the full game', () => {
+      const game = makeGame({})
+      const updates = calculateEloUpdates(game, getDefaultElo, provisionalGames)
+      expect(updates.some(u => u.steamId === red)).toBe(true)
+    })
+
+    it('includes an original player replaced after the 80% mark', () => {
+      const replacedAt = atPercent(0.85) // 85% through
+      const sub = red2
+
+      const replacement: PlayerReplaced = {
+        event: GameEventType.playerReplaced,
+        at: replacedAt,
+        replacee: red,
+        replacement: sub,
+        gameClass: Tf2ClassName.scout,
+      }
+
+      const game = makeGame({
+        slots: [
+          makeSlot(red, Tf2Team.red, Tf2ClassName.scout, SlotStatus.waitingForSubstitute),
+          makeSlot(sub, Tf2Team.red, Tf2ClassName.scout),
+          makeSlot(blu, Tf2Team.blu, Tf2ClassName.scout),
+        ],
+        events: [createdEvent, startedEvent, replacement, endedEvent],
+      })
+
+      const updates = calculateEloUpdates(game, getDefaultElo, provisionalGames)
+      // red played 85% → included; sub played 15% → excluded
+      expect(updates.some(u => u.steamId === red)).toBe(true)
+      expect(updates.some(u => u.steamId === sub)).toBe(false)
+    })
+
+    it('excludes an original player replaced before the 80% mark', () => {
+      const replacedAt = atPercent(0.75) // 75% through
+      const sub = red2
+
+      const replacement: PlayerReplaced = {
+        event: GameEventType.playerReplaced,
+        at: replacedAt,
+        replacee: red,
+        replacement: sub,
+        gameClass: Tf2ClassName.scout,
+      }
+
+      const game = makeGame({
+        slots: [
+          makeSlot(red, Tf2Team.red, Tf2ClassName.scout, SlotStatus.waitingForSubstitute),
+          makeSlot(sub, Tf2Team.red, Tf2ClassName.scout),
+          makeSlot(blu, Tf2Team.blu, Tf2ClassName.scout),
+        ],
+        events: [createdEvent, startedEvent, replacement, endedEvent],
+      })
+
+      const updates = calculateEloUpdates(game, getDefaultElo, provisionalGames)
+      // red played 75% → excluded; sub played 25% → excluded
+      expect(updates.some(u => u.steamId === red)).toBe(false)
+      expect(updates.some(u => u.steamId === sub)).toBe(false)
+    })
+
+    it('includes a substitute who joined early enough to exceed the 80% threshold', () => {
+      const replacedAt = atPercent(0.1) // sub joins at 10% → plays 90%
+      const sub = red2
+
+      const replacement: PlayerReplaced = {
+        event: GameEventType.playerReplaced,
+        at: replacedAt,
+        replacee: red,
+        replacement: sub,
+        gameClass: Tf2ClassName.scout,
+      }
+
+      const game = makeGame({
+        slots: [
+          makeSlot(red, Tf2Team.red, Tf2ClassName.scout, SlotStatus.waitingForSubstitute),
+          makeSlot(sub, Tf2Team.red, Tf2ClassName.scout),
+          makeSlot(blu, Tf2Team.blu, Tf2ClassName.scout),
+        ],
+        events: [createdEvent, startedEvent, replacement, endedEvent],
+      })
+
+      const updates = calculateEloUpdates(game, getDefaultElo, provisionalGames)
+      // sub played 90% → included
+      expect(updates.some(u => u.steamId === sub)).toBe(true)
+    })
+
+    it('excludes a substitute who joined too late to reach the 80% threshold', () => {
+      const replacedAt = atPercent(0.25) // sub joins at 25% → plays only 75%
+      const sub = red2
+
+      const replacement: PlayerReplaced = {
+        event: GameEventType.playerReplaced,
+        at: replacedAt,
+        replacee: red,
+        replacement: sub,
+        gameClass: Tf2ClassName.scout,
+      }
+
+      const game = makeGame({
+        slots: [
+          makeSlot(red, Tf2Team.red, Tf2ClassName.scout, SlotStatus.waitingForSubstitute),
+          makeSlot(sub, Tf2Team.red, Tf2ClassName.scout),
+          makeSlot(blu, Tf2Team.blu, Tf2ClassName.scout),
+        ],
+        events: [createdEvent, startedEvent, replacement, endedEvent],
+      })
+
+      const updates = calculateEloUpdates(game, getDefaultElo, provisionalGames)
+      // sub played 75% → excluded
+      expect(updates.some(u => u.steamId === sub)).toBe(false)
+    })
+  })
+
+  describe('enemy ELO comparison', () => {
+    it('compares against the same-class enemy when one exists', () => {
+      // 1v1 scout mirror — both at 1500, red wins
+      const game = makeGame({ score: { red: 3, blu: 0 } })
+      const updates = calculateEloUpdates(game, getDefaultElo, provisionalGames)
+      expect(updates).toHaveLength(2)
+      expect(updates.find(u => u.steamId === red)?.newElo).toBe(1516)
+    })
+
+    it('falls back to all eligible enemies when no same-class enemy exists', () => {
+      // red plays scout, blu plays soldier (no mirror) — result should still be calculable
+      const game = makeGame({
+        slots: [
+          makeSlot(red, Tf2Team.red, Tf2ClassName.scout),
+          makeSlot(blu, Tf2Team.blu, Tf2ClassName.soldier),
+        ],
+        score: { red: 3, blu: 0 },
+      })
+
+      const updates = calculateEloUpdates(game, getDefaultElo, provisionalGames)
+      // Both players have updates because comparison falls back to the only eligible enemy
+      expect(updates.some(u => u.steamId === red)).toBe(true)
+      expect(updates.some(u => u.steamId === blu)).toBe(true)
+      // Equal ELO regardless of class → same result as a mirror match
+      expect(updates.find(u => u.steamId === red)?.newElo).toBe(1516)
+      expect(updates.find(u => u.steamId === blu)?.newElo).toBe(1484)
+    })
+
+    it('uses the average ELO across multiple same-class enemies', () => {
+      // 2v2 scouts: red (1500) vs blu (1400) + blu2 (1600) → avg enemy = 1500
+      // Equal averages → same result as a mirror 1v1 at 1500
+      const customElo = (steamId: SteamId64) => {
+        if (steamId === blu) return 1400
+        if (steamId === blu2) return 1600
+        return defaultElo
+      }
+
+      const game = makeGame({
+        slots: [
+          makeSlot(red, Tf2Team.red, Tf2ClassName.scout),
+          makeSlot(blu, Tf2Team.blu, Tf2ClassName.scout),
+          { ...makeSlot(blu2, Tf2Team.blu, Tf2ClassName.scout), id: 'blu-scout-2' as GameSlotId },
+        ],
+        score: { red: 3, blu: 0 },
+      })
+
+      const redUpdate = calculateEloUpdates(game, customElo, provisionalGames).find(
+        u => u.steamId === red,
+      )
+      // avg enemy ELO = (1400 + 1600) / 2 = 1500 → E = 0.5 → gain = 16
+      expect(redUpdate?.newElo).toBe(1516)
+    })
+  })
+})

--- a/src/games/calculate-elo-updates.test.ts
+++ b/src/games/calculate-elo-updates.test.ts
@@ -82,6 +82,7 @@ describe('calculateEloUpdates', () => {
     })
 
     it('returns empty array when game has no score', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { score: _s, ...game } = makeGame({})
       expect(calculateEloUpdates(game as GameModel, getDefaultElo, provisionalGames)).toEqual([])
     })

--- a/src/games/calculate-elo-updates.test.ts
+++ b/src/games/calculate-elo-updates.test.ts
@@ -20,9 +20,16 @@ const startedAt = new Date('2024-01-01T10:00:00Z')
 const endedAt = new Date('2024-01-01T11:00:00Z')
 const gameDurationMs = endedAt.getTime() - startedAt.getTime()
 
-const createdEvent: GameCreated = { event: GameEventType.gameCreated, at: new Date('2024-01-01T09:55:00Z') }
+const createdEvent: GameCreated = {
+  event: GameEventType.gameCreated,
+  at: new Date('2024-01-01T09:55:00Z'),
+}
 const startedEvent: GameStarted = { event: GameEventType.gameStarted, at: startedAt }
-const endedEvent: GameEnded = { event: GameEventType.gameEnded, at: endedAt, reason: GameEndedReason.matchEnded }
+const endedEvent: GameEnded = {
+  event: GameEventType.gameEnded,
+  at: endedAt,
+  reason: GameEndedReason.matchEnded,
+}
 
 const red = '76561198000000001' as SteamId64
 const blu = '76561198000000002' as SteamId64
@@ -45,7 +52,9 @@ function makeSlot(
   }
 }
 
-function makeGame(overrides: Omit<Partial<GameModel>, 'score'> & { score?: Record<Tf2Team, number> }): GameModel {
+function makeGame(
+  overrides: Omit<Partial<GameModel>, 'score'> & { score?: Record<Tf2Team, number> },
+): GameModel {
   return {
     number: 1 as GameNumber,
     map: 'cp_process_final',

--- a/src/games/calculate-elo-updates.ts
+++ b/src/games/calculate-elo-updates.ts
@@ -1,0 +1,108 @@
+import {
+  GameEventType,
+  type GameEnded,
+  type GameStarted,
+  type PlayerReplaced,
+} from '../database/models/game-event.model'
+import { GameState, type GameModel } from '../database/models/game.model'
+import { SlotStatus } from '../database/models/game-slot.model'
+import { Tf2Team } from '../shared/types/tf2-team'
+import type { SteamId64 } from '../shared/types/steam-id-64'
+import type { Tf2ClassName } from '../shared/types/tf2-class-name'
+import type { GameNumber } from '../database/models/game.model'
+
+export const defaultElo = 1500
+export const provisionalThreshold = 10
+const playTimeThreshold = 0.8
+
+export interface EloUpdate {
+  steamId: SteamId64
+  gameClass: Tf2ClassName
+  newElo: number
+  at: Date
+  game: GameNumber
+}
+
+function kFactor(gamesOnClass: number): number {
+  return gamesOnClass < provisionalThreshold ? 32 : 16
+}
+
+function expectedScore(playerElo: number, enemyAvgElo: number): number {
+  return 1 / (1 + Math.pow(10, (enemyAvgElo - playerElo) / 400))
+}
+
+function actualScore(playerTeam: Tf2Team, score: Record<Tf2Team, number>): number {
+  const { red, blu } = score
+  if (red === blu) return 0.5
+  return playerTeam === (red > blu ? Tf2Team.red : Tf2Team.blu) ? 1 : 0
+}
+
+export function calculateEloUpdates(
+  game: GameModel,
+  getElo: (steamId: SteamId64, gameClass: Tf2ClassName) => number,
+  getGamesPlayed: (steamId: SteamId64, gameClass: Tf2ClassName) => number,
+): EloUpdate[] {
+  if (game.state !== GameState.ended || !game.score) {
+    return []
+  }
+
+  const startedEvent = game.events.find(
+    (e): e is GameStarted => e.event === GameEventType.gameStarted,
+  )
+  const endedEvent = game.events.find(
+    (e): e is GameEnded => e.event === GameEventType.gameEnded,
+  )
+  if (!startedEvent || !endedEvent) {
+    return []
+  }
+
+  const gameStartedAt = startedEvent.at.getTime()
+  const gameEndedAt = endedEvent.at.getTime()
+  const gameDurationMs = gameEndedAt - gameStartedAt
+
+  const replacements = game.events.filter(
+    (e): e is PlayerReplaced => e.event === GameEventType.playerReplaced,
+  )
+
+  function timePlayedMs(steamId: SteamId64, status: SlotStatus): number {
+    const joinedAs = replacements.find(e => e.replacement === steamId)
+    if (joinedAs) {
+      return gameEndedAt - joinedAs.at.getTime()
+    }
+    if (status === SlotStatus.waitingForSubstitute) {
+      const wasReplaced = replacements.find(e => e.replacee === steamId)
+      return wasReplaced ? wasReplaced.at.getTime() - gameStartedAt : 0
+    }
+    return gameDurationMs
+  }
+
+  const eligibleSlots = game.slots.filter(
+    slot => timePlayedMs(slot.player, slot.status) / gameDurationMs > playTimeThreshold,
+  )
+
+  const score = game.score
+  const endedAt = new Date(gameEndedAt)
+  const updates: EloUpdate[] = []
+
+  for (const slot of eligibleSlots) {
+    const playerElo = getElo(slot.player, slot.gameClass)
+
+    const enemies = eligibleSlots.filter(s => s.team !== slot.team)
+    const sameClassEnemies = enemies.filter(s => s.gameClass === slot.gameClass)
+    const comparison = sameClassEnemies.length > 0 ? sameClassEnemies : enemies
+
+    if (comparison.length === 0) continue
+
+    const enemyAvgElo =
+      comparison.reduce((sum, s) => sum + getElo(s.player, s.gameClass), 0) / comparison.length
+
+    const E = expectedScore(playerElo, enemyAvgElo)
+    const S = actualScore(slot.team, score)
+    const K = kFactor(getGamesPlayed(slot.player, slot.gameClass))
+    const newElo = Math.round(playerElo + K * (S - E))
+
+    updates.push({ steamId: slot.player, gameClass: slot.gameClass, newElo, at: endedAt, game: game.number })
+  }
+
+  return updates
+}

--- a/src/games/calculate-elo-updates.ts
+++ b/src/games/calculate-elo-updates.ts
@@ -49,9 +49,7 @@ export function calculateEloUpdates(
   const startedEvent = game.events.find(
     (e): e is GameStarted => e.event === GameEventType.gameStarted,
   )
-  const endedEvent = game.events.find(
-    (e): e is GameEnded => e.event === GameEventType.gameEnded,
-  )
+  const endedEvent = game.events.find((e): e is GameEnded => e.event === GameEventType.gameEnded)
   if (!startedEvent || !endedEvent) {
     return []
   }
@@ -101,7 +99,13 @@ export function calculateEloUpdates(
     const K = kFactor(getGamesPlayed(slot.player, slot.gameClass))
     const newElo = Math.round(playerElo + K * (S - E))
 
-    updates.push({ steamId: slot.player, gameClass: slot.gameClass, newElo, at: endedAt, game: game.number })
+    updates.push({
+      steamId: slot.player,
+      gameClass: slot.gameClass,
+      newElo,
+      at: endedAt,
+      game: game.number,
+    })
   }
 
   return updates

--- a/src/games/plugins/update-player-elo.ts
+++ b/src/games/plugins/update-player-elo.ts
@@ -1,0 +1,51 @@
+import fp from 'fastify-plugin'
+import { events } from '../../events'
+import type { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import { type PlayerElo } from '../../database/models/player.model'
+import { collections } from '../../database/collections'
+import { players } from '../../players'
+import { safe } from '../../utils/safe'
+import { calculateEloUpdates, defaultElo as defaultEloValue } from '../calculate-elo-updates'
+
+export default fp(
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async () => {
+    events.on(
+      'game:ended',
+      safe(async ({ game }) => {
+        const eloMap = new Map<SteamId64, Partial<Record<Tf2ClassName, number>>>()
+        const gamesByClassMap = new Map<SteamId64, Partial<Record<Tf2ClassName, number>>>()
+
+        await Promise.all(
+          game.slots.map(async slot => {
+            const player = await collections.players.findOne(
+              { steamId: slot.player },
+              { projection: { elo: 1, 'stats.gamesByClass': 1 } },
+            )
+            eloMap.set(slot.player, player?.elo ?? {})
+            gamesByClassMap.set(slot.player, player?.stats.gamesByClass ?? {})
+          }),
+        )
+
+        const updates = calculateEloUpdates(
+          game,
+          (steamId, gameClass) => eloMap.get(steamId)?.[gameClass] ?? defaultEloValue,
+          (steamId, gameClass) => gamesByClassMap.get(steamId)?.[gameClass] ?? 0,
+        )
+
+        await Promise.all(
+          updates.map(async ({ steamId, gameClass, newElo, at, game: gameNumber }) => {
+            const eloUpdate: PlayerElo = { [gameClass]: newElo }
+            await players.update(steamId, before => ({
+              $set: { elo: { ...before.elo, ...eloUpdate } },
+              $push: {
+                eloHistory: { at, elo: eloUpdate, game: gameNumber },
+              },
+            }))
+          }),
+        )
+      }),
+    )
+  },
+)

--- a/src/migrations/021-backfill-player-elo.ts
+++ b/src/migrations/021-backfill-player-elo.ts
@@ -24,10 +24,7 @@ export async function up() {
   // In-memory state: updated as each game is processed in order
   const eloState = new Map<SteamId64, Partial<Record<Tf2ClassName, number>>>()
   const gamesPlayedState = new Map<SteamId64, Partial<Record<Tf2ClassName, number>>>()
-  const eloHistoryState = new Map<
-    SteamId64,
-    { at: Date; elo: PlayerElo; game: GameNumber }[]
-  >()
+  const eloHistoryState = new Map<SteamId64, { at: Date; elo: PlayerElo; game: GameNumber }[]>()
 
   for (const game of games) {
     const updates = calculateEloUpdates(

--- a/src/migrations/021-backfill-player-elo.ts
+++ b/src/migrations/021-backfill-player-elo.ts
@@ -1,0 +1,75 @@
+import { subMonths } from 'date-fns'
+import { collections } from '../database/collections'
+import { logger } from '../logger'
+import { GameState } from '../database/models/game.model'
+import { GameEventType } from '../database/models/game-event.model'
+import type { PlayerElo } from '../database/models/player.model'
+import type { SteamId64 } from '../shared/types/steam-id-64'
+import type { Tf2ClassName } from '../shared/types/tf2-class-name'
+import type { GameNumber } from '../database/models/game.model'
+import { calculateEloUpdates, defaultElo as defaultEloValue } from '../games/calculate-elo-updates'
+
+export async function up() {
+  const since = subMonths(new Date(), 6)
+
+  const games = await collections.games
+    .find(
+      { state: GameState.ended, 'events.0.at': { $gte: since } },
+      { sort: { 'events.0.at': 1 } },
+    )
+    .toArray()
+
+  logger.info(`backfilling ELO from ${games.length} games since ${since.toISOString()}`)
+
+  // In-memory state: updated as each game is processed in order
+  const eloState = new Map<SteamId64, Partial<Record<Tf2ClassName, number>>>()
+  const gamesPlayedState = new Map<SteamId64, Partial<Record<Tf2ClassName, number>>>()
+  const eloHistoryState = new Map<
+    SteamId64,
+    { at: Date; elo: PlayerElo; game: GameNumber }[]
+  >()
+
+  for (const game of games) {
+    const updates = calculateEloUpdates(
+      game,
+      (steamId, gameClass) => eloState.get(steamId)?.[gameClass] ?? defaultEloValue,
+      (steamId, gameClass) => gamesPlayedState.get(steamId)?.[gameClass] ?? 0,
+    )
+
+    for (const { steamId, gameClass, newElo, at } of updates) {
+      // Update ELO state
+      const currentElo = eloState.get(steamId) ?? {}
+      eloState.set(steamId, { ...currentElo, [gameClass]: newElo })
+
+      // Append to history
+      const history = eloHistoryState.get(steamId) ?? []
+      history.push({ at, elo: { [gameClass]: newElo }, game: game.number })
+      eloHistoryState.set(steamId, history)
+    }
+
+    // Increment games-played count for all eligible slots (drives K-factor in subsequent games)
+    const eligibleSteamIds = new Set(updates.map(u => u.steamId))
+    for (const slot of game.slots) {
+      if (!eligibleSteamIds.has(slot.player)) continue
+      const current = gamesPlayedState.get(slot.player) ?? {}
+      gamesPlayedState.set(slot.player, {
+        ...current,
+        [slot.gameClass]: (current[slot.gameClass] ?? 0) + 1,
+      })
+    }
+  }
+
+  // Write results to the database
+  let updated = 0
+  for (const [steamId, elo] of eloState) {
+    await collections.players.updateOne(
+      { steamId },
+      { $set: { elo }, $push: { eloHistory: { $each: eloHistoryState.get(steamId) ?? [] } } },
+    )
+    updated++
+  }
+
+  logger.info(
+    `backfilled ELO for ${updated} players from ${games.length} games (event: ${GameEventType.gameEnded})`,
+  )
+}

--- a/src/players/views/html/edit-player.page.tsx
+++ b/src/players/views/html/edit-player.page.tsx
@@ -16,12 +16,19 @@ import {
   IconAirTrafficControl,
   IconArrowBackUp,
   IconBan,
+  IconChartArrowsVertical,
   IconDeviceFloppy,
   IconMessageCircleOff,
   IconPlus,
   IconUserScan,
   IconX,
 } from '../../../html/components/icons'
+import { GameClassIcon } from '../../../html/components/game-class-icon'
+import { queue } from '../../../queue'
+import {
+  defaultElo,
+  provisionalThreshold,
+} from '../../../games/calculate-elo-updates'
 import type { Children } from '@kitajs/html'
 import {
   format,
@@ -45,6 +52,7 @@ const editPlayerPages = {
   '/bans': 'Bans',
   '/chat-mutes': 'Chat mutes',
   '/roles': 'Roles',
+  '/elo': 'ELO',
 } as const
 
 export async function EditPlayerProfilePage(props: { steamId: SteamId64 }) {
@@ -212,6 +220,54 @@ export async function EditPlayerRolesPage(props: { steamId: SteamId64 }) {
   )
 }
 
+export async function EditPlayerEloPage(props: { steamId: SteamId64 }) {
+  const player = await players.bySteamId(props.steamId, ['name', 'steamId', 'elo', 'stats'])
+  return (
+    <EditPlayer player={player} activePage="/elo">
+      <div class="admin-panel-content">
+        <table class="w-full text-sm text-white">
+          <thead>
+            <tr class="text-abru-light-75 border-abru-light-15 border-b text-left font-light">
+              <th class="pb-2 font-light">Class</th>
+              <th class="pb-2 font-light">ELO</th>
+              <th class="pb-2 font-light">Games</th>
+              <th class="pb-2 font-light">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {queue.config.classes.map(({ name: gameClass }) => {
+              const elo = player.elo?.[gameClass]
+              const games = player.stats.gamesByClass[gameClass] ?? 0
+              const provisional = games < provisionalThreshold
+              return (
+                <tr class="border-abru-light-10 border-b last:border-0">
+                  <td class="py-2">
+                    <div class="flex items-center gap-2">
+                      <GameClassIcon gameClass={gameClass} size={20} />
+                      <span class="capitalize">{gameClass}</span>
+                    </div>
+                  </td>
+                  <td class="py-2 font-bold">{elo ?? defaultElo}</td>
+                  <td class="text-abru-light-75 py-2">{games}</td>
+                  <td class="py-2">
+                    {games === 0 ? (
+                      <span class="text-abru-light-50">—</span>
+                    ) : provisional ? (
+                      <span class="text-yellow-400">Provisional</span>
+                    ) : (
+                      <span class="text-green-400">Established</span>
+                    )}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </EditPlayer>
+  )
+}
+
 function EditPlayer(props: {
   player: Pick<PlayerModel, 'name' | 'steamId'>
   children: Children
@@ -265,6 +321,13 @@ function EditPlayer(props: {
                 >
                   <IconAirTrafficControl />
                   Roles
+                </AdminPanelLink>
+                <AdminPanelLink
+                  href={`/players/${props.player.steamId}/edit/elo`}
+                  active={props.activePage === '/elo'}
+                >
+                  <IconChartArrowsVertical />
+                  ELO
                 </AdminPanelLink>
               </>
             )}

--- a/src/players/views/html/edit-player.page.tsx
+++ b/src/players/views/html/edit-player.page.tsx
@@ -25,10 +25,7 @@ import {
 } from '../../../html/components/icons'
 import { GameClassIcon } from '../../../html/components/game-class-icon'
 import { queue } from '../../../queue'
-import {
-  defaultElo,
-  provisionalThreshold,
-} from '../../../games/calculate-elo-updates'
+import { defaultElo, provisionalThreshold } from '../../../games/calculate-elo-updates'
 import type { Children } from '@kitajs/html'
 import {
   format,

--- a/src/players/views/html/player.page.tsx
+++ b/src/players/views/html/player.page.tsx
@@ -255,3 +255,4 @@ function PlayerPresentation(props: {
     </div>
   )
 }
+

--- a/src/players/views/html/player.page.tsx
+++ b/src/players/views/html/player.page.tsx
@@ -255,4 +255,3 @@ function PlayerPresentation(props: {
     </div>
   )
 }
-

--- a/src/routes/players/:steamId/edit/elo/index.ts
+++ b/src/routes/players/:steamId/edit/elo/index.ts
@@ -1,0 +1,26 @@
+import z from 'zod'
+import { PlayerRole } from '../../../../../database/models/player.model'
+import { steamId64 } from '../../../../../shared/schemas/steam-id-64'
+import { EditPlayerEloPage } from '../../../../../players/views/html/edit-player.page'
+import { routes } from '../../../../../utils/routes'
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export default routes(async app => {
+  app.get(
+    '/',
+    {
+      config: {
+        authorize: [PlayerRole.superUser],
+      },
+      schema: {
+        params: z.object({
+          steamId: steamId64,
+        }),
+      },
+    },
+    async (req, reply) => {
+      const { steamId } = req.params
+      reply.status(200).html(await EditPlayerEloPage({ steamId }))
+    },
+  )
+})


### PR DESCRIPTION
## Summary

- Adds automated per-class ELO rating calculated after each ended game using the standard ELO formula adapted for team play
- ELO is hidden from regular users and admins — visible only to super-users via a new section in the edit-player page (`/players/:steamId/edit/elo`)
- Includes a backfill migration (`021-backfill-player-elo.ts`) that processes the last 6 months of games in chronological order

## Design details

- **K-factor:** K=32 for provisional players (<10 games on class), K=16 for established (≥10)
- **Starting ELO:** 1500
- **Play time threshold:** player must have participated in >80% of the game to receive an ELO update (handles substitutes both ways)
- **Enemy comparison:** matched against same-class opponents; falls back to all eligible enemies if no mirror class exists
- **Observational only:** ELO has no effect on team balancing (existing `skill` system unchanged)

## Files

- `src/database/models/player.model.ts` — adds `PlayerElo` type, `elo` and `eloHistory` fields
- `src/games/calculate-elo-updates.ts` — pure ELO calculation function (no DB access, fully tested)
- `src/games/plugins/update-player-elo.ts` — Fastify plugin wired to `game:ended` event
- `src/migrations/021-backfill-player-elo.ts` — backfill migration for last 6 months
- `src/routes/players/:steamId/edit/elo/index.ts` — super-user-only route
- `src/players/views/html/edit-player.page.tsx` — ELO page with per-class table (ELO, games, provisional/established status)
- `src/games/calculate-elo-updates.test.ts` — unit tests covering guards, ELO math, play time eligibility, and enemy comparison

## Test plan

- [ ] Run `pnpm test` — all 226 tests pass
- [ ] Log in as a super-user and navigate to `/players/:steamId/edit/elo` — ELO table visible
- [ ] Log in as an admin (non-super-user) — ELO section absent from edit-player sidebar
- [ ] End a game and verify ELO updates appear on the edit-player ELO page
- [ ] Run migration and verify historical ELO is backfilled for recently active players

🤖 Generated with [Claude Code](https://claude.com/claude-code)