### PR TITLE
fix: remove avatar view-transition animation

### DIFF
--- a/src/games/views/html/game-slot.tsx
+++ b/src/games/views/html/game-slot.tsx
@@ -79,7 +79,6 @@ async function GameSlotContent(props: {
             width="38"
             height="38"
             alt={`${props.player.name}'s avatar`}
-            style={`view-transition-name: player-avatar-${props.player.steamId}`}
           />
           <a href={`/players/${props.player.steamId}`} class="player-link">
             <span class="player-name" safe>

--- a/src/hall-of-game/views/html/hall-of-fame.page.tsx
+++ b/src/hall-of-game/views/html/hall-of-fame.page.tsx
@@ -55,7 +55,6 @@ function Board(props: { title: string; entries: HallOfFameEntry[] }) {
             height="64"
             class="h-[38px] w-[38px]"
             alt="{name}'s avatar"
-            style={`view-transition-name: player-avatar-${record.player.steamId}`}
           />
           <span safe>{record.player.name}</span>
           <span class="justify-self-end">{record.count}</span>

--- a/src/players/views/html/player.page.tsx
+++ b/src/players/views/html/player.page.tsx
@@ -153,7 +153,6 @@ function PlayerPresentation(props: {
         height="184"
         class="player-avatar"
         alt={`${props.player.name}'s avatar`}
-        style={`view-transition-name: player-avatar-${props.player.steamId}`}
       />
 
       <div class="flex flex-row items-center gap-[10px]">

--- a/src/queue/views/html/queue-slot.tsx
+++ b/src/queue/views/html/queue-slot.tsx
@@ -124,7 +124,6 @@ async function PlayerInfo(props: { slot: QueueSlotModel; actor?: Actor }) {
         width="64"
         height="64"
         alt={`${props.slot.player.name}'s name`}
-        style={`view-transition-name: player-avatar-${props.slot.player.steamId}`}
       />
       <div class="player-name-area">
         <a


### PR DESCRIPTION
## Summary

- Removes `view-transition-name: player-avatar-*` style from avatar `<img>` elements in game-slot, hall-of-fame, player page, and queue-slot

## Test plan

- [ ] Navigate between pages and verify no avatar transition animation occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)