### PR TITLE
fix: redesign admin toolbox on player profile page

### DIFF
--- a/src/admin/player-restrictions/views/html/player-restrictions.page.tsx
+++ b/src/admin/player-restrictions/views/html/player-restrictions.page.tsx
@@ -14,6 +14,7 @@ export async function PlayerRestrictionsPage() {
           <MinimumTf2InGameHours />
           <RequirePlayerVerification />
           <PlayerSkillThreshold />
+          <SkillStep />
           <DefaultPlayerSkill />
 
           <p>
@@ -145,8 +146,35 @@ async function PlayerSkillThreshold() {
   )
 }
 
+async function SkillStep() {
+  const skillStep = await configuration.get('games.skill_step')
+  return (
+    <dl>
+      <dt>
+        <label for="skillStep">Skill step</label>
+      </dt>
+      <dd class="flex flex-col">
+        <div>
+          <input
+            type="number"
+            id="skillStep"
+            name="skillStep"
+            value={skillStep.toString()}
+            step="0.1"
+            min="0.1"
+          />
+        </div>
+        <p class="text-abru-light-75 text-sm">
+          Increment/decrement step when adjusting player skill in the admin panel.
+        </p>
+      </dd>
+    </dl>
+  )
+}
+
 async function DefaultPlayerSkill() {
   const defaultPlayerSkill = await configuration.get('games.default_player_skill')
+  const skillStep = await configuration.get('games.skill_step')
   const classes = queue.config.classes.map(({ name }) => name)
 
   return (
@@ -161,6 +189,7 @@ async function DefaultPlayerSkill() {
               gameClass={gameClass}
               name={`defaultPlayerSkill.${gameClass}`}
               value={defaultPlayerSkill[gameClass] ?? 1}
+              step={skillStep}
             />
           ))}
         </div>

--- a/src/database/models/configuration-entry.model.ts
+++ b/src/database/models/configuration-entry.model.ts
@@ -175,6 +175,12 @@ export const configurationSchema = z.discriminatedUnion('key', [
         'Number of active substitute requests that make the game be automatically force-ended',
       ),
   }),
+  z
+    .object({
+      key: z.literal('games.skill_step'),
+      value: z.number().positive().default(1.0),
+    })
+    .describe('Increment/decrement step when adjusting player skill in the admin panel'),
   z.object({
     key: z.literal('misc.discord_invite_link'),
     value: z.url().nullable().default(null),

--- a/src/html/@client/details-persist.ts
+++ b/src/html/@client/details-persist.ts
@@ -28,5 +28,7 @@ htmx.onLoad(element => {
     init(element)
   }
 
-  element.querySelectorAll<HTMLDetailsElement>('[data-details-persist]').forEach(el => init(el))
+  element.querySelectorAll<HTMLDetailsElement>('[data-details-persist]').forEach(el => {
+    init(el)
+  })
 })

--- a/src/html/@client/details-persist.ts
+++ b/src/html/@client/details-persist.ts
@@ -1,0 +1,34 @@
+import htmx from './htmx.js'
+
+function init(details: HTMLDetailsElement) {
+  const key = `details-persist-${details.getAttribute('data-details-persist')}`
+
+  details.addEventListener('toggle', () => {
+    try {
+      localStorage.setItem(key, details.open ? 'open' : 'closed')
+    } catch {
+      // ignore (e.g. private browsing, quota exceeded)
+    }
+  })
+
+  try {
+    const saved = localStorage.getItem(key)
+    if (saved !== null) {
+      details.open = saved === 'open'
+    }
+  } catch {
+    // ignore
+  }
+}
+
+htmx.onLoad(element => {
+  if (!(element instanceof HTMLElement)) return
+
+  if (element instanceof HTMLDetailsElement && element.hasAttribute('data-details-persist')) {
+    init(element)
+  }
+
+  element
+    .querySelectorAll<HTMLDetailsElement>('[data-details-persist]')
+    .forEach(el => init(el))
+})

--- a/src/html/@client/details-persist.ts
+++ b/src/html/@client/details-persist.ts
@@ -28,7 +28,5 @@ htmx.onLoad(element => {
     init(element)
   }
 
-  element
-    .querySelectorAll<HTMLDetailsElement>('[data-details-persist]')
-    .forEach(el => init(el))
+  element.querySelectorAll<HTMLDetailsElement>('[data-details-persist]').forEach(el => init(el))
 })

--- a/src/html/@client/main.ts
+++ b/src/html/@client/main.ts
@@ -21,6 +21,7 @@ import './flash-message'
 import './map-thumbnail'
 import './mention-completion'
 import './mention-notification'
+import './details-persist'
 import './tabs'
 
 export { goTo } from './navigation'

--- a/src/html/@client/main.ts
+++ b/src/html/@client/main.ts
@@ -22,6 +22,7 @@ import './map-thumbnail'
 import './mention-completion'
 import './mention-notification'
 import './details-persist'
+import './skill-input'
 import './tabs'
 
 export { goTo } from './navigation'

--- a/src/html/@client/skill-input.ts
+++ b/src/html/@client/skill-input.ts
@@ -1,0 +1,40 @@
+import htmx from './htmx.js'
+
+function initSkillSpinner(spinner: HTMLElement) {
+  const input = spinner.querySelector<HTMLInputElement>('input[type="number"]')
+  const display = spinner.querySelector<HTMLElement>('.skill-spinner-display')
+  if (!input || !display) return
+
+  const step = parseFloat(input.step) || 1
+
+  const nonNullDisplay = display
+  const nonNullInput = input
+
+  function updateDisplay() {
+    nonNullDisplay.textContent = String(parseFloat(nonNullInput.value) || 0)
+  }
+
+  spinner
+    .querySelector<HTMLButtonElement>('[data-action="decrement"]')
+    ?.addEventListener('click', () => {
+      input.value = String((parseFloat(input.value) || 0) - step)
+      updateDisplay()
+    })
+
+  spinner
+    .querySelector<HTMLButtonElement>('[data-action="increment"]')
+    ?.addEventListener('click', () => {
+      input.value = String((parseFloat(input.value) || 0) + step)
+      updateDisplay()
+    })
+}
+
+htmx.onLoad(element => {
+  if (!(element instanceof HTMLElement)) return
+
+  if (element.hasAttribute('data-skill-spinner')) {
+    initSkillSpinner(element)
+  }
+
+  element.querySelectorAll<HTMLElement>('[data-skill-spinner]').forEach(initSkillSpinner)
+})

--- a/src/html/components/game-class-skill-input.tsx
+++ b/src/html/components/game-class-skill-input.tsx
@@ -5,26 +5,38 @@ import { GameClassIcon } from './game-class-icon'
 export function GameClassSkillInput(props: {
   gameClass: Tf2ClassName
   value: number
+  step?: number
   name?: undefined | string
   id?: undefined | string
   style?: undefined | string
   children?: undefined | Children
 }) {
   const id = props.id ?? `playerSkill-${props.gameClass}`
+  const step = props.step ?? 1.0
   return (
-    <div class="game-class-skill-input" style={props.style}>
+    <div class="game-class-skill-input" style={props.style} data-skill-spinner>
       <GameClassIcon gameClass={props.gameClass} size={32} />
       <label class="sr-only" for={id}>
         Player's skill on {props.gameClass}
       </label>
+      <button type="button" class="skill-spinner-btn" data-action="decrement" aria-label="Decrease">
+        {'‹'}
+      </button>
+      <span class="skill-spinner-display" aria-live="polite">
+        {props.value.toString() as 'safe'}
+      </span>
       <input
         type="number"
         id={id}
         name={props.name}
         value={props.value.toString()}
         required
-        step=".5"
+        step={step.toString()}
+        class="sr-only"
       />
+      <button type="button" class="skill-spinner-btn" data-action="increment" aria-label="Increase">
+        {'›'}
+      </button>
       {props.children}
     </div>
   )

--- a/src/html/styles/game-class-skill-input.css
+++ b/src/html/styles/game-class-skill-input.css
@@ -11,11 +11,32 @@
       margin-left: 8px;
     }
 
-    input {
-      text-align: center;
-      width: 48px;
+    & .skill-spinner-btn {
       background: transparent;
       border: none;
+      cursor: pointer;
+      padding: 0 6px;
+      font-size: 18px;
+      color: var(--color-abru-light-35);
+      height: 100%;
+      display: flex;
+      align-items: center;
+
+      &:hover {
+        color: var(--color-abru-light-75);
+      }
+
+      &:active {
+        scale: 0.9;
+      }
+    }
+
+    & .skill-spinner-display {
+      min-width: 28px;
+      text-align: center;
+      font-size: 14px;
+      user-select: none;
+      color: var(--color-ash);
     }
   }
 }

--- a/src/players/views/html/admin-toolbox.tsx
+++ b/src/players/views/html/admin-toolbox.tsx
@@ -1,23 +1,39 @@
 import { configuration } from '../../../configuration'
-import type { PlayerModel } from '../../../database/models/player.model'
-import { IconClover, IconDeviceFloppy, IconEdit, IconInputX } from '../../../html/components/icons'
+import type { PlayerBan, PlayerModel } from '../../../database/models/player.model'
+import {
+  IconBan,
+  IconCheck,
+  IconChevronRight,
+  IconClover,
+  IconDeviceFloppy,
+  IconEdit,
+  IconInputX,
+} from '../../../html/components/icons'
 import { queue } from '../../../queue'
 import { WinLossChart } from './win-loss-chart'
 import { GameClassSkillInput } from '../../../html/components/game-class-skill-input'
 import { players } from '../..'
-import { formatDistanceToNow } from 'date-fns'
+import { format, formatDistanceToNow } from 'date-fns'
 import type { Tf2ClassName } from '../../../shared/types/tf2-class-name'
 import { pluckLastEdit } from '../../pluck-last-edit'
+import type { SteamId64 } from '../../../shared/types/steam-id-64'
 
 export async function AdminToolbox(props: {
-  player: Pick<PlayerModel, 'skill' | 'steamId' | 'skillHistory' | 'verified'>
+  player: Pick<PlayerModel, 'skill' | 'steamId' | 'skillHistory' | 'verified' | 'bans'>
 }) {
   const { player } = props
   const defaultSkill = await configuration.get('games.default_player_skill')
   const requireVerification = await configuration.get('queue.require_player_verification')
+  const compact = queue.config.classes.length > 4
 
   return (
-    <div id="player-admin-toolbox">
+    <details id="player-admin-toolbox" class="admin-toolbox-details" data-details-persist="admin-toolbox">
+      <summary class="admin-toolbox-summary">
+        <IconChevronRight size={14} class="admin-toolbox-chevron" />
+        <span>Admin toolbox</span>
+      </summary>
+      <script>{`try{if(localStorage.getItem('details-persist-admin-toolbox')==='open'){document.currentScript.closest('details').setAttribute('open','');}}catch(e){}` as 'safe'}</script>
+
       {requireVerification && (
         <div class="bg-abru-light-5 flex items-center gap-3 rounded-md px-3 py-2">
           <label for="playerVerified" class="cursor-pointer text-sm select-none">
@@ -38,76 +54,121 @@ export async function AdminToolbox(props: {
         </div>
       )}
 
-      <form
-        method="post"
-        action={`/players/${player.steamId}/edit/skill`}
-        class="player-admin-toolbox"
-      >
-        {player.skill === undefined && (
-          <div class="col-span-full flex items-center gap-2 rounded-md bg-green-800/30 px-3 py-2 text-sm text-green-400">
-            <IconClover size={16} />
-            <span>This player has no skill assigned</span>
-          </div>
-        )}
-
-        <h4 class="caption" style="grid-area: captionSkill">
-          Skill
-        </h4>
-        <h4 class="caption" style="grid-area: captionWinLoss">
-          Win-loss chart
-        </h4>
-
-        <div class={['skill-inputs', queue.config.classes.length > 4 && 'compact']}>
-          {queue.config.classes.map(gameClass => (
-            <GameClassSkillInput
-              gameClass={gameClass.name}
-              name={`skill.${gameClass.name}`}
-              value={player.skill?.[gameClass.name] ?? defaultSkill[gameClass.name] ?? 0}
-            >
-              <SkillLastUpdated className={gameClass.name} skillHistory={player.skillHistory} />
-            </GameClassSkillInput>
-          ))}
-
-          <div class={['skill-buttons', queue.config.classes.length > 4 && 'compact']}>
-            <button type="submit" class="button button--accent" title="Save">
-              <IconDeviceFloppy size={20} />
-              <span>Save</span>
-            </button>
-
-            <button
-              type="button"
-              class="button"
-              title="Reset"
-              hx-delete={`/players/${player.steamId}/edit/skill`}
-              hx-confirm="Are you sure you want to reset this player's skill?"
-              hx-trigger="click"
-              hx-disabled-elt="this"
-              hx-target="#player-admin-toolbox"
-              hx-swap="outerHTML"
-            >
-              <IconInputX size={20} />
-              <span>Reset</span>
-            </button>
-          </div>
+      <div class="player-admin-toolbox">
+        <div class="admin-toolbox-header">
+          <BanStatus bans={player.bans} steamId={player.steamId} />
+          <a
+            href={`/players/${player.steamId}/edit`}
+            class={['button button--accent shrink-0', compact && 'compact']}
+            title="Edit player"
+          >
+            <IconEdit />
+            <span>Edit player</span>
+          </a>
         </div>
 
-        <div class="mx-2" style="grid-area: winLoss">
-          <WinLossChart steamId={props.player.steamId} />
-        </div>
+        <div class="admin-toolbox-divider" />
 
+        <div class="admin-toolbox-body">
+          <div class="admin-toolbox-skill">
+            {player.skill === undefined && (
+              <div class="flex items-center gap-2 rounded-md bg-green-800/30 px-3 py-2 text-sm text-green-400">
+                <IconClover size={16} />
+                <span>This player has no skill assigned</span>
+              </div>
+            )}
+            <h4 class="caption">Skill</h4>
+            <form method="post" action={`/players/${player.steamId}/edit/skill`}>
+              <div class={['skill-inputs', compact && 'compact']}>
+                {queue.config.classes.map(gameClass => (
+                  <GameClassSkillInput
+                    gameClass={gameClass.name}
+                    name={`skill.${gameClass.name}`}
+                    value={player.skill?.[gameClass.name] ?? defaultSkill[gameClass.name] ?? 0}
+                  >
+                    <SkillLastUpdated
+                      className={gameClass.name}
+                      skillHistory={player.skillHistory}
+                    />
+                  </GameClassSkillInput>
+                ))}
+
+                <div class={['skill-buttons', compact && 'compact']}>
+                  <button type="submit" class="button button--accent" title="Save">
+                    <IconDeviceFloppy size={20} />
+                    <span>Save</span>
+                  </button>
+
+                  <button
+                    type="button"
+                    class="button"
+                    title="Reset"
+                    hx-delete={`/players/${player.steamId}/edit/skill`}
+                    hx-confirm="Are you sure you want to reset this player's skill?"
+                    hx-trigger="click"
+                    hx-disabled-elt="this"
+                    hx-target="#player-admin-toolbox"
+                    hx-swap="outerHTML"
+                  >
+                    <IconInputX size={20} />
+                    <span>Reset</span>
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
+
+          <div class="admin-toolbox-sep" />
+
+          <div class="admin-toolbox-winloss">
+            <h4 class="caption">Win-loss chart</h4>
+            <WinLossChart steamId={player.steamId} />
+          </div>
+        </div>
+      </div>
+    </details>
+  )
+}
+
+function BanStatus(props: { bans: PlayerBan[] | undefined; steamId: SteamId64 }) {
+  const now = new Date()
+  const activeBan = props.bans
+    ?.filter(ban => ban.end > now)
+    .sort((a, b) => b.end.getTime() - a.end.getTime())[0]
+
+  if (activeBan) {
+    return (
+      <div class="flex min-w-0 flex-1 items-center gap-3 rounded-md bg-red-900/30 px-3 py-2 text-sm text-red-300">
+        <IconBan size={16} class="shrink-0" />
+        <div class="flex min-w-0 flex-col">
+          <span>
+            Banned until{' '}
+            <strong safe>{format(activeBan.end, 'MMM dd, yyyy, HH:mm')}</strong>
+          </span>
+          <span class="truncate text-red-300/70" safe>
+            {activeBan.reason}
+          </span>
+        </div>
         <a
-          href={`/players/${player.steamId}/edit`}
-          class={[
-            'button button--accent self-center whitespace-nowrap',
-            queue.config.classes.length > 4 && 'compact',
-          ]}
-          style="grid-area: linkEdit"
-          title="Edit player"
+          href={`/players/${props.steamId}/edit/bans`}
+          class="ml-auto shrink-0 text-xs text-red-300 underline hover:text-red-200"
         >
-          <IconEdit />
-          <span>Edit player</span>
+          Manage bans
         </a>
-      </form>
+      </div>
+    )
+  }
+
+  return (
+    <div class="flex flex-1 items-center gap-3 rounded-md bg-abru-light-5 px-3 py-2 text-sm text-abru-light-50">
+      <IconCheck size={16} class="shrink-0" />
+      <span>No active ban</span>
+      <a
+        href={`/players/${props.steamId}/edit/bans`}
+        class="ml-auto text-xs text-abru-light-50 underline hover:text-abru-light-75"
+      >
+        Manage bans
+      </a>
     </div>
   )
 }
@@ -134,7 +195,7 @@ async function SkillLastUpdated(props: {
         {formatDistanceToNow(lastEdit.at, { addSuffix: true }) as 'safe'}
       </p>
       <p class="text-nowrap">
-        <strong>{previousValue}</strong> → <strong>{lastEdit.skill[props.className]}</strong>
+        <strong>{previousValue}</strong> → <strong safe>{lastEdit.skill[props.className]}</strong>
       </p>
     </div>
   )

--- a/src/players/views/html/admin-toolbox.tsx
+++ b/src/players/views/html/admin-toolbox.tsx
@@ -27,12 +27,20 @@ export async function AdminToolbox(props: {
   const compact = queue.config.classes.length > 4
 
   return (
-    <details id="player-admin-toolbox" class="admin-toolbox-details" data-details-persist="admin-toolbox">
+    <details
+      id="player-admin-toolbox"
+      class="admin-toolbox-details"
+      data-details-persist="admin-toolbox"
+    >
       <summary class="admin-toolbox-summary">
         <IconChevronRight size={14} class="admin-toolbox-chevron" />
         <span>Admin toolbox</span>
       </summary>
-      <script>{`try{if(localStorage.getItem('details-persist-admin-toolbox')==='open'){document.currentScript.closest('details').setAttribute('open','');}}catch(e){}` as 'safe'}</script>
+      <script>
+        {
+          `try{if(localStorage.getItem('details-persist-admin-toolbox')==='open'){document.currentScript.closest('details').setAttribute('open','');}}catch(e){}` as 'safe'
+        }
+      </script>
 
       {requireVerification && (
         <div class="bg-abru-light-5 flex items-center gap-3 rounded-md px-3 py-2">
@@ -142,8 +150,7 @@ function BanStatus(props: { bans: PlayerBan[] | undefined; steamId: SteamId64 })
         <IconBan size={16} class="shrink-0" />
         <div class="flex min-w-0 flex-col">
           <span>
-            Banned until{' '}
-            <strong safe>{format(activeBan.end, 'MMM dd, yyyy, HH:mm')}</strong>
+            Banned until <strong safe>{format(activeBan.end, 'MMM dd, yyyy, HH:mm')}</strong>
           </span>
           <span class="truncate text-red-300/70" safe>
             {activeBan.reason}
@@ -160,12 +167,12 @@ function BanStatus(props: { bans: PlayerBan[] | undefined; steamId: SteamId64 })
   }
 
   return (
-    <div class="flex flex-1 items-center gap-3 rounded-md bg-abru-light-5 px-3 py-2 text-sm text-abru-light-50">
+    <div class="bg-abru-light-5 text-abru-light-50 flex flex-1 items-center gap-3 rounded-md px-3 py-2 text-sm">
       <IconCheck size={16} class="shrink-0" />
       <span>No active ban</span>
       <a
         href={`/players/${props.steamId}/edit/bans`}
-        class="ml-auto text-xs text-abru-light-50 underline hover:text-abru-light-75"
+        class="text-abru-light-50 hover:text-abru-light-75 ml-auto text-xs underline"
       >
         Manage bans
       </a>
@@ -195,7 +202,7 @@ async function SkillLastUpdated(props: {
         {formatDistanceToNow(lastEdit.at, { addSuffix: true }) as 'safe'}
       </p>
       <p class="text-nowrap">
-        <strong>{previousValue}</strong> → <strong safe>{lastEdit.skill[props.className]}</strong>
+        <strong>{previousValue}</strong> → <strong>{lastEdit.skill[props.className]}</strong>
       </p>
     </div>
   )

--- a/src/players/views/html/admin-toolbox.tsx
+++ b/src/players/views/html/admin-toolbox.tsx
@@ -23,6 +23,7 @@ export async function AdminToolbox(props: {
 }) {
   const { player } = props
   const defaultSkill = await configuration.get('games.default_player_skill')
+  const skillStep = await configuration.get('games.skill_step')
   const requireVerification = await configuration.get('queue.require_player_verification')
   const compact = queue.config.classes.length > 4
 
@@ -93,6 +94,7 @@ export async function AdminToolbox(props: {
                     gameClass={gameClass.name}
                     name={`skill.${gameClass.name}`}
                     value={player.skill?.[gameClass.name] ?? defaultSkill[gameClass.name] ?? 0}
+                    step={skillStep}
                   >
                     <SkillLastUpdated
                       className={gameClass.name}

--- a/src/players/views/html/player.page.tsx
+++ b/src/players/views/html/player.page.tsx
@@ -43,6 +43,7 @@ export async function PlayerPage(props: { steamId: SteamId64; page: number }) {
     'skill',
     'skillHistory',
     'verified',
+    'bans',
   ])
   const user = requestContext.get('user')
 

--- a/src/players/views/html/style.css
+++ b/src/players/views/html/style.css
@@ -93,34 +93,107 @@
     }
   }
 
-  .player-admin-toolbox {
-    display: grid;
-    grid-template-areas:
-      'captionSkill     captionSkill'
-      'skill            skill'
-      'buttonSave       buttonReset'
-      'captionWinLoss   captionWinLoss'
-      'winLoss          winLoss'
-      'linkEdit         linkEdit';
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .admin-toolbox-details {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
 
+  .admin-toolbox-summary {
+    display: flex;
     align-items: center;
-    column-gap: 8px;
-    row-gap: 8px;
+    gap: 8px;
     border-radius: 8px;
     background: var(--color-abru-dark-29);
-    padding: 24px;
+    padding: 10px 16px;
+    cursor: pointer;
+    user-select: none;
+    color: var(--color-abru-light-50);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 
-    @media (width >= theme(--breakpoint-xl)) {
-      grid-template-areas:
-        'captionSkill  captionSkill captionSkill captionSkill captionSkill captionSkill . captionWinLoss  captionWinLoss  .       . linkEdit'
-        'skill         skill        skill        skill        skill        skill        . winLoss         winLoss         winLoss . linkEdit';
-      grid-template-columns: repeat(6, minmax(0, 2fr)) 4px repeat(3, 2fr) 4px 1fr;
-      align-items: flex-end;
+    &::marker,
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    .admin-toolbox-chevron {
+      transition: rotate 0.15s ease;
+      flex-shrink: 0;
+    }
+  }
+
+  details[open] .admin-toolbox-summary .admin-toolbox-chevron {
+    rotate: 90deg;
+  }
+
+  .player-admin-toolbox {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    border-radius: 8px;
+    background: var(--color-abru-dark-29);
+    padding: 20px 24px;
+
+    .admin-toolbox-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .admin-toolbox-divider {
+      height: 1px;
+      background: var(--color-abru-light-10);
+      margin-inline: -24px;
+    }
+
+    .admin-toolbox-body {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+
+      @media (width >= theme(--breakpoint-xl)) {
+        flex-direction: row;
+        align-items: flex-start;
+      }
+    }
+
+    .admin-toolbox-skill {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      flex: 1;
+      min-width: 0;
+
+      @media (width >= theme(--breakpoint-xl)) {
+        padding-right: 24px;
+      }
+    }
+
+    .admin-toolbox-sep {
+      display: none;
+
+      @media (width >= theme(--breakpoint-xl)) {
+        display: block;
+        width: 1px;
+        align-self: stretch;
+        background: var(--color-abru-light-10);
+      }
+    }
+
+    .admin-toolbox-winloss {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+
+      @media (width >= theme(--breakpoint-xl)) {
+        padding-left: 24px;
+      }
     }
 
     .skill-inputs {
-      grid-area: skill;
       display: flex;
       flex-wrap: wrap;
       gap: 4px;
@@ -181,7 +254,6 @@
       button {
         cursor: pointer;
         display: inline-block;
-
         padding: 4px 8px;
         border-radius: 4px;
         color: var(--color-ash);
@@ -198,7 +270,6 @@
       align-items: center;
       justify-content: center;
       gap: 4px;
-
       font-weight: 500;
 
       .wins {

--- a/src/routes/admin/player-restrictions/index.ts
+++ b/src/routes/admin/player-restrictions/index.ts
@@ -44,6 +44,7 @@ export default routes(async app => {
               etf2lAccountRequired: z.coerce.boolean().default(false),
               minimumInGameHours: z.coerce.number(),
               requirePlayerVerification: z.coerce.boolean().default(false),
+              skillStep: z.coerce.number().positive(),
               ...queue.config.classes
                 .map(({ name }) => name)
                 .reduce<
@@ -59,6 +60,7 @@ export default routes(async app => {
           minimumInGameHours,
           requirePlayerVerification,
           playerSkillThresholdEnabled,
+          skillStep,
         } = request.body
         const defaultPlayerSkill = Object.entries(request.body)
           .filter(([key]) => key.startsWith('defaultPlayerSkill.'))
@@ -76,6 +78,7 @@ export default routes(async app => {
             playerSkillThresholdEnabled ? request.body.playerSkillThreshold : null,
           ),
           configuration.set('games.default_player_skill', defaultPlayerSkill),
+          configuration.set('games.skill_step', skillStep),
         ])
         requestContext.set('messages', { success: ['Configuration saved'] })
         reply.status(200).html(await PlayerRestrictionsPage())

--- a/tests/pages/admin.page.ts
+++ b/tests/pages/admin.page.ts
@@ -49,6 +49,10 @@ export class AdminPage {
     skill: { scout: number; soldier: number; demoman: number; medic: number },
   ) {
     await this.page.goto(`/players/${steamId}`)
+    const toolbox = this.page.locator('#player-admin-toolbox')
+    if (!(await toolbox.evaluate((el: HTMLDetailsElement) => el.open))) {
+      await toolbox.locator('summary').click()
+    }
     await this.page.getByLabel("Player's skill on scout").fill(skill.scout.toString())
     await this.page.getByLabel("Player's skill on soldier").fill(skill.soldier.toString())
     await this.page.getByLabel("Player's skill on demoman").fill(skill.demoman.toString())

--- a/tests/pages/admin.page.ts
+++ b/tests/pages/admin.page.ts
@@ -5,9 +5,9 @@ export class AdminPage {
   constructor(public readonly page: Page) {}
 
   private async openToolbox() {
-    const toolbox = this.page.locator('#player-admin-toolbox')
-    if (!(await toolbox.evaluate((el: HTMLDetailsElement) => el.open))) {
-      await toolbox.locator('summary').click()
+    const content = this.page.locator('#player-admin-toolbox .player-admin-toolbox')
+    if (!(await content.isVisible())) {
+      await this.page.locator('#player-admin-toolbox summary').click()
     }
   }
 

--- a/tests/pages/admin.page.ts
+++ b/tests/pages/admin.page.ts
@@ -4,8 +4,16 @@ import { secondsToMilliseconds } from 'date-fns'
 export class AdminPage {
   constructor(public readonly page: Page) {}
 
+  private async openToolbox() {
+    const toolbox = this.page.locator('#player-admin-toolbox')
+    if (!(await toolbox.evaluate((el: HTMLDetailsElement) => el.open))) {
+      await toolbox.locator('summary').click()
+    }
+  }
+
   async banPlayer(steamId: string, { reason }: { reason: string }) {
     await this.page.goto(`/players/${steamId}`)
+    await this.openToolbox()
     await this.page.getByRole('link', { name: 'Edit player' }).click()
     await this.page.getByRole('link', { name: 'Bans' }).click()
     await this.page.getByRole('link', { name: 'Add ban' }).click()
@@ -15,6 +23,7 @@ export class AdminPage {
 
   async revokeAllBans(steamId: string) {
     await this.page.goto(`/players/${steamId}`)
+    await this.openToolbox()
     await this.page.getByRole('link', { name: 'Edit player' }).click()
     await this.page.getByRole('link', { name: 'Bans' }).click()
     await this.page.waitForURL(/\/players\/[^/]+\/edit\/bans$/)
@@ -26,6 +35,7 @@ export class AdminPage {
 
   async muteChatPlayer(steamId: string, { reason }: { reason: string }) {
     await this.page.goto(`/players/${steamId}`)
+    await this.openToolbox()
     await this.page.getByRole('link', { name: 'Edit player' }).click()
     await this.page.getByRole('link', { name: 'Chat mutes' }).click()
     await this.page.getByRole('link', { name: 'Add mute' }).click()
@@ -35,6 +45,7 @@ export class AdminPage {
 
   async revokeAllChatMutes(steamId: string) {
     await this.page.goto(`/players/${steamId}`)
+    await this.openToolbox()
     await this.page.getByRole('link', { name: 'Edit player' }).click()
     await this.page.getByRole('link', { name: 'Chat mutes' }).click()
     await this.page.waitForURL(/\/players\/[^/]+\/edit\/chat-mutes$/)
@@ -49,10 +60,7 @@ export class AdminPage {
     skill: { scout: number; soldier: number; demoman: number; medic: number },
   ) {
     await this.page.goto(`/players/${steamId}`)
-    const toolbox = this.page.locator('#player-admin-toolbox')
-    if (!(await toolbox.evaluate((el: HTMLDetailsElement) => el.open))) {
-      await toolbox.locator('summary').click()
-    }
+    await this.openToolbox()
     await this.page.getByLabel("Player's skill on scout").fill(skill.scout.toString())
     await this.page.getByLabel("Player's skill on soldier").fill(skill.soldier.toString())
     await this.page.getByLabel("Player's skill on demoman").fill(skill.demoman.toString())
@@ -63,6 +71,7 @@ export class AdminPage {
 
   async playerCooldown(steamId: string) {
     await this.page.goto(`/players/${steamId}`)
+    await this.openToolbox()
     await this.page.getByRole('link', { name: 'Edit player' }).click()
     return this.page.getByLabel('Cooldown level')
   }
@@ -109,6 +118,7 @@ export class AdminPage {
 
   async setPlayerVerified(steamId: string, verified: boolean) {
     await this.page.goto(`/players/${steamId}`)
+    await this.openToolbox()
     const checkbox = this.page.getByLabel('Player verified')
     if (!(await checkbox.isVisible())) {
       return


### PR DESCRIPTION
## Summary

- Replaces the old CSS named-grid layout with a cleaner flexbox structure
- Adds a **header bar** with ban status (active ban shows end date + reason + manage link; otherwise shows "No active ban") and the **Edit Player** button moved to the top-right
- Horizontal divider separates the header from the skill/win-loss body; on xl+ screens the two sections sit side by side with a vertical separator
- Wraps the entire toolbox in a native `<details>` element — collapsed by default, toggleable, with state **persisted in `localStorage`** via a new `details-persist.ts` client module
- Flicker-free: an inline synchronous `<script>` restores the open state before the browser paints the expanded content
- Fetches `bans` alongside other player fields so ban status is always current
- Replaces the browser-native `<input type="number">` spinner with a custom **‹ value ›** control — eliminates Firefox/Chrome rendering differences; buttons use muted color to create visual hierarchy over the value
- Adds `games.skill_step` configuration entry (default `1.0`) exposed in the **Player restrictions** admin page; the configured step is forwarded to all `GameClassSkillInput` spinners

## Test plan

- [ ] Visit a player profile as an admin — toolbox should be collapsed by default
- [ ] Expand the toolbox — state persists across page reloads
- [ ] Collapse and reload — stays collapsed
- [ ] View a banned player — header shows ban end date and reason in red
- [ ] View a non-banned player — header shows "No active ban" in muted style
- [ ] Save/reset skill and toggle verify — toolbox HTMX swap restores saved open/closed state
- [ ] Check compact mode (queues with >4 classes) — skill inputs and buttons hide labels correctly
- [ ] Skill spinner ‹/› buttons increment/decrement by the configured step
- [ ] Change skill step in Player restrictions admin panel — spinner step updates after save
- [ ] Verify spinner looks identical in Firefox and Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)