### PR TITLE
feat(players): add ELO history chart to player edit page

### DIFF
--- a/src/players/views/html/@client/elo-history-chart.ts
+++ b/src/players/views/html/@client/elo-history-chart.ts
@@ -1,0 +1,140 @@
+import { Chart, type ChartConfiguration } from 'chart.js/auto'
+
+export interface EloDataPoint {
+  gameNumber: number
+  date: string
+  elo: number
+}
+
+export type EloHistoryData = Record<string, EloDataPoint[]>
+export type XAxisMode = 'time' | 'game'
+
+const colors: Record<string, string> = {
+  scout: '#7ec8e3',
+  soldier: '#f0a500',
+  pyro: '#ff6b35',
+  demoman: '#9b59b6',
+  heavy: '#e74c3c',
+  engineer: '#f1c40f',
+  medic: '#2ecc71',
+  sniper: '#1abc9c',
+  spy: '#e91e63',
+}
+
+function buildChartConfig(
+  points: EloDataPoint[],
+  gameClass: string,
+  xMode: XAxisMode,
+): ChartConfiguration<'line'> {
+  const color = colors[gameClass] ?? '#F61059'
+  const labels =
+    xMode === 'time'
+      ? points.map(p => new Date(p.date).toLocaleDateString())
+      : points.map(p => `#${p.gameNumber}`)
+
+  return {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          data: points.map(p => p.elo),
+          fill: false,
+          borderWidth: 2,
+          borderColor: color,
+          pointBackgroundColor: color,
+          pointRadius: 3,
+          tension: 0.1,
+        },
+      ],
+    },
+    options: {
+      animation: false,
+      responsive: true,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            title: items => labels[items[0]!.dataIndex] ?? '',
+            label: item => `ELO: ${item.raw as number}`,
+          },
+        },
+      },
+      scales: {
+        x: {
+          border: { color: '#D9D9D9' },
+          grid: { color: 'rgba(217,217,217,0.15)' },
+          ticks: {
+            color: '#C7C4C7',
+            maxTicksLimit: 12,
+          },
+        },
+        y: {
+          border: { color: '#D9D9D9' },
+          grid: { color: 'rgba(217,217,217,0.15)' },
+          ticks: { color: '#C7C4C7' },
+        },
+      },
+    },
+  }
+}
+
+export function initEloHistoryChart(data: EloHistoryData) {
+  const canvas = document.getElementById('elo-history-canvas') as HTMLCanvasElement | null
+  if (!canvas) return
+
+  const classTabs = document.querySelectorAll<HTMLElement>('[data-elo-class]')
+  const xAxisBtns = document.querySelectorAll<HTMLElement>('[data-elo-xaxis]')
+  const emptyNotice = document.getElementById('elo-history-empty')
+
+  let activeClass = classTabs[0]?.dataset['eloClass'] ?? ''
+  let xMode: XAxisMode = 'time'
+  let chart: Chart | null = null
+
+  function refresh() {
+    const points = data[activeClass] ?? []
+
+    if (emptyNotice) {
+      emptyNotice.hidden = points.length > 0
+    }
+    canvas!.hidden = points.length === 0
+
+    if (points.length === 0) {
+      chart?.destroy()
+      chart = null
+      return
+    }
+
+    const config = buildChartConfig(points, activeClass, xMode)
+
+    if (chart) {
+      chart.data = config.data
+      chart.options = config.options!
+      chart.update()
+    } else {
+      chart = new Chart(canvas!, config)
+    }
+  }
+
+  classTabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      classTabs.forEach(t => {
+        t.dataset['active'] = t === tab ? 'true' : 'false'
+      })
+      activeClass = tab.dataset['eloClass'] ?? ''
+      refresh()
+    })
+  })
+
+  xAxisBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      xAxisBtns.forEach(b => {
+        b.dataset['active'] = b === btn ? 'true' : 'false'
+      })
+      xMode = (btn.dataset['eloXaxis'] ?? 'time') as XAxisMode
+      refresh()
+    })
+  })
+
+  refresh()
+}

--- a/src/players/views/html/edit-player.page.tsx
+++ b/src/players/views/html/edit-player.page.tsx
@@ -38,6 +38,7 @@ import {
 } from 'date-fns'
 import { isBot } from '../../../shared/types/bot'
 import { makeTitle } from '../../../html/make-title'
+import { EloHistoryChart } from './elo-history-chart'
 import { environment } from '../../../environment'
 import { configuration } from '../../../configuration'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
@@ -260,6 +261,7 @@ export async function EditPlayerEloPage(props: { steamId: SteamId64 }) {
             })}
           </tbody>
         </table>
+        <EloHistoryChart steamId={props.steamId} />
       </div>
     </EditPlayer>
   )

--- a/src/players/views/html/elo-history-chart.tsx
+++ b/src/players/views/html/elo-history-chart.tsx
@@ -87,6 +87,7 @@ export async function EloHistoryChart(props: { steamId: SteamId64 }) {
       const points: EloDataPoint[] = history
         .filter(entry => entry.elo[gameClass] !== undefined)
         .sort((a, b) => a.game - b.game)
+        .slice(-100)
         .map(entry => ({
           gameNumber: entry.game,
           date: entry.at instanceof Date ? entry.at.toISOString() : String(entry.at),

--- a/src/players/views/html/elo-history-chart.tsx
+++ b/src/players/views/html/elo-history-chart.tsx
@@ -1,0 +1,99 @@
+import { resolve } from 'node:path'
+import { bundle } from '../../../html/bundle'
+import { players } from '../../../players'
+import type { SteamId64 } from '../../../shared/types/steam-id-64'
+import { queue } from '../../../queue'
+import { GameClassIcon } from '../../../html/components/game-class-icon'
+import type { EloDataPoint, EloHistoryData } from './@client/elo-history-chart'
+
+export async function EloHistoryChart(props: { steamId: SteamId64 }) {
+  const player = await players.bySteamId(props.steamId, ['eloHistory'])
+  const mainJs = await bundle(resolve(import.meta.dirname, '@client', 'elo-history-chart.ts'))
+
+  const classes = queue.config.classes.map(c => c.name)
+  const data = buildChartData(player.eloHistory ?? [])
+
+  return (
+    <div class="mt-6">
+      <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div class="flex flex-wrap gap-1">
+          {classes.map((gameClass, i) => (
+            <button
+              class="elo-class-tab flex cursor-pointer items-center gap-1.5 rounded px-2.5 py-1 text-sm transition-colors"
+              data-elo-class={gameClass}
+              data-active={i === 0 ? 'true' : 'false'}
+            >
+              <GameClassIcon gameClass={gameClass} size={16} />
+              <span class="capitalize">{gameClass}</span>
+            </button>
+          ))}
+        </div>
+
+        <div class="flex gap-1">
+          <button
+            class="rounded px-2.5 py-1 text-sm transition-colors"
+            data-elo-xaxis="time"
+            data-active="true"
+          >
+            Over time
+          </button>
+          <button
+            class="rounded px-2.5 py-1 text-sm transition-colors"
+            data-elo-xaxis="game"
+            data-active="false"
+          >
+            By game #
+          </button>
+        </div>
+      </div>
+
+      <p id="elo-history-empty" class="text-abru-light-50 text-sm italic" hidden>
+        No ELO history for this class yet.
+      </p>
+      <canvas id="elo-history-canvas"></canvas>
+
+      <style>{`
+        .elo-class-tab[data-active="true"],
+        [data-elo-xaxis][data-active="true"] {
+          background-color: rgba(246, 16, 89, 0.2);
+          color: #f61059;
+        }
+        .elo-class-tab[data-active="false"],
+        [data-elo-xaxis][data-active="false"] {
+          background-color: rgba(255,255,255,0.05);
+          color: #C7C4C7;
+        }
+        .elo-class-tab[data-active="false"]:hover,
+        [data-elo-xaxis][data-active="false"]:hover {
+          background-color: rgba(255,255,255,0.1);
+        }
+      `}</style>
+
+      <script type="module">
+        {`
+        import { initEloHistoryChart } from '${mainJs}';
+        const data = ${JSON.stringify(data)};
+        initEloHistoryChart(data);
+        `}
+      </script>
+    </div>
+  )
+
+  function buildChartData(
+    history: { at: Date; elo: Record<string, number>; game: number }[],
+  ): EloHistoryData {
+    const result: EloHistoryData = {}
+    for (const gameClass of classes) {
+      const points: EloDataPoint[] = history
+        .filter(entry => entry.elo[gameClass] !== undefined)
+        .sort((a, b) => a.game - b.game)
+        .map(entry => ({
+          gameNumber: entry.game,
+          date: entry.at instanceof Date ? entry.at.toISOString() : String(entry.at),
+          elo: entry.elo[gameClass]!,
+        }))
+      result[gameClass] = points
+    }
+    return result
+  }
+}

--- a/src/routes/players/:steamId/edit/elo/index.ts
+++ b/src/routes/players/:steamId/edit/elo/index.ts
@@ -20,7 +20,7 @@ export default routes(async app => {
     },
     async (req, reply) => {
       const { steamId } = req.params
-      reply.status(200).html(await EditPlayerEloPage({ steamId }))
+      await reply.status(200).html(EditPlayerEloPage({ steamId }))
     },
   )
 })

--- a/src/routes/players/:steamId/edit/profile/index.ts
+++ b/src/routes/players/:steamId/edit/profile/index.ts
@@ -23,7 +23,7 @@ export default routes(async app => {
       },
       async (req, reply) => {
         const { steamId } = req.params
-        reply.status(200).html(await EditPlayerProfilePage({ steamId }))
+        await reply.status(200).html(EditPlayerProfilePage({ steamId }))
       },
     )
     .post(


### PR DESCRIPTION
## Summary

- Adds an interactive Chart.js line chart to the admin ELO page showing a player's ELO progression per game class
- Class tabs let you switch between classes (only configured queue classes shown); active class highlighted in accent color with per-class color coding
- X-axis toggle switches between **Over time** (date labels) and **By game #** (game number labels)
- Empty state shown when the selected class has no ELO history yet
- Chart updates in-place (no destroy/recreate) when switching class or X-axis mode

## Test plan

- [ ] Open `/players/:steamId/edit/elo` as a super-user
- [ ] Verify chart renders below the ELO summary table
- [ ] Click each class tab and confirm the chart updates to that class's history
- [ ] Toggle between "Over time" and "By game #" and confirm X-axis labels change
- [ ] For a class with no games, confirm the empty state message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)