### PR TITLE
fix(countdown): use server-rendered relative duration to avoid client clock skew

### DIFF
--- a/src/games/views/html/join-game-button.test.tsx
+++ b/src/games/views/html/join-game-button.test.tsx
@@ -111,7 +111,7 @@ describe('JoinGameButton', () => {
         const root = parse(html)
         const countdown = root.querySelector('[data-countdown]')
         expect(countdown).not.toBeNull()
-        expect(countdown!.getAttribute('data-countdown')).toBe(shouldJoinBy.getTime().toString())
+        expect(countdown!.getAttribute('data-countdown')).toBe('90000')
       })
 
       it('renders plain join game button (no countdown) when shouldJoinBy is in the past', async () => {

--- a/src/games/views/html/join-game-button.tsx
+++ b/src/games/views/html/join-game-button.tsx
@@ -69,7 +69,7 @@ async function JoinAsPlayer(props: { slot: GameSlotModel }) {
       <>
         <IconPlayerPlayFilled size={16} />
         join in{' '}
-        <span class="tabular-nums" data-countdown={props.slot.shouldJoinBy!.getTime()}>
+        <span class="tabular-nums" data-countdown={timeLeftMs}>
           {minutes}:{safeSeconds.length === 1 ? '0' : ''}
           {safeSeconds}
         </span>

--- a/src/html/@client/countdown.ts
+++ b/src/html/@client/countdown.ts
@@ -25,9 +25,10 @@ function maybeInit(element: Element) {
   const internalData = api.getInternalData(element)
   if (internalData.countdownInterval !== undefined) return
 
-  const deadline = Number(element.getAttribute(attrName))
+  const initialMs = Number(element.getAttribute(attrName))
+  const startedAt = Date.now()
   internalData.countdownInterval = setInterval(() => {
-    const ms = Math.max(deadline - Date.now(), 0)
+    const ms = Math.max(initialMs - (Date.now() - startedAt), 0)
     element.textContent = formatTimeout(ms)
     if (ms <= 0) {
       clearInterval(internalData.countdownInterval)

--- a/src/pre-ready/views/html/pre-ready-up-button.tsx
+++ b/src/pre-ready/views/html/pre-ready-up-button.tsx
@@ -31,7 +31,7 @@ export async function PreReadyUpButton(props: {
       <div class="flex-1">
         {timeLeft > 0 ? (
           <>
-            <span class="tabular-nums" data-countdown={preReadyUntil!.getTime()} safe>
+            <span class="tabular-nums" data-countdown={timeLeft} safe>
               {formatTimeout(timeLeft)}
             </span>
             <span class="sr-only">Pre-ready up</span>


### PR DESCRIPTION
## Summary

- Reverts the `data-countdown` attribute from absolute epoch timestamps (introduced in #577) back to server-rendered remaining milliseconds
- The client now computes `initialMs - (Date.now() - startedAt)` each tick instead of `deadline - Date.now()`, so elapsed time is measured locally and is unaffected by differences between server and client system clocks
- Players with a skewed system clock no longer see incorrect countdown values

## Test plan

- [ ] Verify the pre-ready countdown shows the correct remaining time
- [ ] Verify the join-game countdown shows the correct remaining time
- [ ] Verify no visible jump/flicker when either countdown element is swapped in via htmx
- [ ] Existing unit tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)