### PR TITLE
fix(players): show skill history per class, not per latest entry

### DIFF
--- a/src/players/pluck-last-edit.test.ts
+++ b/src/players/pluck-last-edit.test.ts
@@ -28,4 +28,32 @@ describe('pluckLastEdit()', () => {
       })
     })
   })
+
+  describe('when the last entry changed a different class', () => {
+    it('should return the last edit for the queried class, not the most recent entry', () => {
+      const scoutChange = { at: sub(new Date(), { hours: 1 }), skill: { scout: 2, soldier: 5 }, actor: mockActor }
+      const soldierChange = { at: new Date(), skill: { scout: 2, soldier: 6 }, actor: mockActor }
+      const history = [
+        { at: sub(new Date(), { hours: 2 }), skill: { scout: 1, soldier: 5 }, actor: mockActor },
+        scoutChange,
+        soldierChange,
+      ]
+      expect(pluckLastEdit(history, Tf2ClassName.scout)).toEqual({
+        lastEdit: scoutChange,
+        previousValue: 1,
+      })
+    })
+
+    it('should return unknown when the queried class was never changed', () => {
+      const soldierChange = { at: new Date(), skill: { scout: 1, soldier: 6 }, actor: mockActor }
+      const history = [
+        { at: sub(new Date(), { hours: 1 }), skill: { scout: 1, soldier: 5 }, actor: mockActor },
+        soldierChange,
+      ]
+      expect(pluckLastEdit(history, Tf2ClassName.scout)).toEqual({
+        lastEdit: soldierChange,
+        previousValue: 'unknown',
+      })
+    })
+  })
 })

--- a/src/players/pluck-last-edit.test.ts
+++ b/src/players/pluck-last-edit.test.ts
@@ -31,7 +31,11 @@ describe('pluckLastEdit()', () => {
 
   describe('when the last entry changed a different class', () => {
     it('should return the last edit for the queried class, not the most recent entry', () => {
-      const scoutChange = { at: sub(new Date(), { hours: 1 }), skill: { scout: 2, soldier: 5 }, actor: mockActor }
+      const scoutChange = {
+        at: sub(new Date(), { hours: 1 }),
+        skill: { scout: 2, soldier: 5 },
+        actor: mockActor,
+      }
       const soldierChange = { at: new Date(), skill: { scout: 2, soldier: 6 }, actor: mockActor }
       const history = [
         { at: sub(new Date(), { hours: 2 }), skill: { scout: 1, soldier: 5 }, actor: mockActor },

--- a/src/players/pluck-last-edit.ts
+++ b/src/players/pluck-last-edit.ts
@@ -8,11 +8,19 @@ export function pluckLastEdit(
   lastEdit: NonNullable<PlayerModel['skillHistory']>[number]
   previousValue: number | 'unknown'
 } {
-  const lastEdit = skillHistory.at(-1)!
-  const skillsForClass = skillHistory.map(s => s.skill[className]!)
-  const previousValue = skillsForClass.findLast(s => s !== lastEdit.skill[className])
+  for (let i = skillHistory.length - 1; i >= 1; i--) {
+    const current = skillHistory[i]!
+    const previous = skillHistory[i - 1]!
+    if (current.skill[className] !== previous.skill[className]) {
+      return {
+        lastEdit: current,
+        previousValue: previous.skill[className] ?? 'unknown',
+      }
+    }
+  }
+
   return {
-    lastEdit,
-    previousValue: previousValue ?? 'unknown',
+    lastEdit: skillHistory.at(-1)!,
+    previousValue: 'unknown',
   }
 }


### PR DESCRIPTION
## Summary

- `pluckLastEdit` previously always used the most recent history entry as `lastEdit`, regardless of which class changed
- If soldier was updated, the soldier-change entry would be used as `lastEdit` for scout too — causing a stale tooltip on scout with the wrong time and actor
- Now walks backwards through history to find the last entry where the queried class actually changed

## Test plan

- [x] Existing tests still pass
- [x] New test: when last entry changed a different class, returns the correct prior edit for the queried class
- [x] New test: when queried class was never changed, returns `'unknown'` (no tooltip shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)