### PR TITLE
feat(players): overlay skill history on ELO chart

### DIFF
--- a/src/players/views/html/@client/elo-history-chart.ts
+++ b/src/players/views/html/@client/elo-history-chart.ts
@@ -58,7 +58,7 @@ function buildChartConfig(
       borderWidth: 2,
       borderColor: 'rgba(255,255,255,0.65)',
       pointBackgroundColor: 'rgba(255,255,255,0.65)',
-      pointRadius: 3,
+      pointRadius: 1,
       tension: 0,
       stepped: true,
       borderDash: [5, 4],
@@ -110,6 +110,10 @@ function buildChartConfig(
                 grid: { drawOnChartArea: false },
                 ticks: { color: 'rgba(255,255,255,0.65)' },
                 position: 'right' as const,
+                afterDataLimits: (axis: { min: number; max: number }) => {
+                  axis.min -= 0.5
+                  axis.max += 0.5
+                },
               },
             }
           : {}),

--- a/src/players/views/html/@client/elo-history-chart.ts
+++ b/src/players/views/html/@client/elo-history-chart.ts
@@ -34,7 +34,7 @@ function buildChartConfig(
       ? points.map(p => new Date(p.date).toLocaleDateString())
       : points.map(p => `#${p.gameNumber}`)
 
-  const hasSkill = skillPoints != null && skillPoints.some(v => v !== null)
+  const hasSkill = skillPoints?.some(v => v !== null)
 
   const datasets: ChartConfiguration<'line'>['data']['datasets'] = [
     {

--- a/src/players/views/html/@client/elo-history-chart.ts
+++ b/src/players/views/html/@client/elo-history-chart.ts
@@ -7,6 +7,7 @@ export interface EloDataPoint {
 }
 
 export type EloHistoryData = Record<string, EloDataPoint[]>
+export type SkillData = Record<string, (number | null)[]>
 export type XAxisMode = 'time' | 'game'
 
 const colors: Record<string, string> = {
@@ -25,6 +26,7 @@ function buildChartConfig(
   points: EloDataPoint[],
   gameClass: string,
   xMode: XAxisMode,
+  skillPoints?: (number | null)[],
 ): ChartConfiguration<'line'> {
   const color = colors[gameClass] ?? '#F61059'
   const labels =
@@ -32,31 +34,57 @@ function buildChartConfig(
       ? points.map(p => new Date(p.date).toLocaleDateString())
       : points.map(p => `#${p.gameNumber}`)
 
+  const hasSkill = skillPoints != null && skillPoints.some(v => v !== null)
+
+  const datasets: ChartConfiguration<'line'>['data']['datasets'] = [
+    {
+      label: 'ELO',
+      data: points.map(p => p.elo),
+      fill: false,
+      borderWidth: 2,
+      borderColor: color,
+      pointBackgroundColor: color,
+      pointRadius: 3,
+      tension: 0.1,
+      yAxisID: 'y',
+    },
+  ]
+
+  if (hasSkill) {
+    datasets.push({
+      label: 'Skill',
+      data: skillPoints as number[],
+      fill: false,
+      borderWidth: 2,
+      borderColor: 'rgba(255,255,255,0.65)',
+      pointBackgroundColor: 'rgba(255,255,255,0.65)',
+      pointRadius: 3,
+      tension: 0,
+      stepped: true,
+      borderDash: [5, 4],
+      yAxisID: 'y1',
+      spanGaps: false,
+    })
+  }
+
   return {
     type: 'line',
-    data: {
-      labels,
-      datasets: [
-        {
-          data: points.map(p => p.elo),
-          fill: false,
-          borderWidth: 2,
-          borderColor: color,
-          pointBackgroundColor: color,
-          pointRadius: 3,
-          tension: 0.1,
-        },
-      ],
-    },
+    data: { labels, datasets },
     options: {
       animation: false,
       responsive: true,
       plugins: {
-        legend: { display: false },
+        legend: {
+          display: hasSkill,
+          labels: { color: '#C7C4C7' },
+        },
         tooltip: {
           callbacks: {
             title: items => labels[items[0]!.dataIndex] ?? '',
-            label: item => `ELO: ${item.raw as number}`,
+            label: item =>
+              item.dataset.label === 'Skill'
+                ? `Skill: ${item.raw as number}`
+                : `ELO: ${item.raw as number}`,
           },
         },
       },
@@ -73,13 +101,24 @@ function buildChartConfig(
           border: { color: '#D9D9D9' },
           grid: { color: 'rgba(217,217,217,0.15)' },
           ticks: { color: '#C7C4C7' },
+          position: 'left',
         },
+        ...(hasSkill
+          ? {
+              y1: {
+                border: { color: 'rgba(255,255,255,0.3)' },
+                grid: { drawOnChartArea: false },
+                ticks: { color: 'rgba(255,255,255,0.65)' },
+                position: 'right' as const,
+              },
+            }
+          : {}),
       },
     },
   }
 }
 
-export function initEloHistoryChart(data: EloHistoryData) {
+export function initEloHistoryChart(data: EloHistoryData, skillData?: SkillData) {
   const canvas = document.getElementById('elo-history-canvas') as HTMLCanvasElement | null
   if (!canvas) return
 
@@ -105,7 +144,7 @@ export function initEloHistoryChart(data: EloHistoryData) {
       return
     }
 
-    const config = buildChartConfig(points, activeClass, xMode)
+    const config = buildChartConfig(points, activeClass, xMode, skillData?.[activeClass])
 
     if (chart) {
       chart.data = config.data

--- a/src/players/views/html/elo-history-chart.tsx
+++ b/src/players/views/html/elo-history-chart.tsx
@@ -4,14 +4,15 @@ import { players } from '../../../players'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
 import { queue } from '../../../queue'
 import { GameClassIcon } from '../../../html/components/game-class-icon'
-import type { EloDataPoint, EloHistoryData } from './@client/elo-history-chart'
+import type { EloDataPoint, EloHistoryData, SkillData } from './@client/elo-history-chart'
 
 export async function EloHistoryChart(props: { steamId: SteamId64 }) {
-  const player = await players.bySteamId(props.steamId, ['eloHistory'])
+  const player = await players.bySteamId(props.steamId, ['eloHistory', 'skillHistory'])
   const mainJs = await bundle(resolve(import.meta.dirname, '@client', 'elo-history-chart.ts'))
 
   const classes = queue.config.classes.map(c => c.name)
   const data = buildChartData(player.eloHistory ?? [])
+  const skillData = buildSkillData(data, player.skillHistory ?? [])
 
   return (
     <div class="mt-6">
@@ -73,7 +74,8 @@ export async function EloHistoryChart(props: { steamId: SteamId64 }) {
         {`
         import { initEloHistoryChart } from '${mainJs}';
         const data = ${JSON.stringify(data)};
-        initEloHistoryChart(data);
+        const skillData = ${JSON.stringify(skillData)};
+        initEloHistoryChart(data, skillData);
         `}
       </script>
     </div>
@@ -94,6 +96,22 @@ export async function EloHistoryChart(props: { steamId: SteamId64 }) {
           elo: entry.elo[gameClass]!,
         }))
       result[gameClass] = points
+    }
+    return result
+  }
+
+  function buildSkillData(
+    eloData: EloHistoryData,
+    skillHistory: { at: Date; skill: Record<string, number> }[],
+  ): SkillData {
+    const result: SkillData = {}
+    const sorted = [...skillHistory].sort((a, b) => a.at.getTime() - b.at.getTime())
+    for (const gameClass of classes) {
+      result[gameClass] = (eloData[gameClass] ?? []).map(point => {
+        const pointDate = new Date(point.date)
+        const entry = sorted.filter(s => s.at <= pointDate).at(-1)
+        return entry?.skill[gameClass] ?? null
+      })
     }
     return result
   }


### PR DESCRIPTION
## Summary

- Adds a skill layer on top of the ELO history chart so admins can correlate ELO changes with manual skill adjustments
- Skill is rendered as a dashed white stepped line on a right-side Y-axis, aligned to existing ELO data points
- The overlay only appears when the selected class has admin-set skill history; charts for players without skill data are unchanged

## How it works

For each ELO data point, `buildSkillData` finds the most recent `skillHistory` entry whose `at` date is ≤ the game date, producing a parallel array of `number | null`. This gives a step-function that stays flat between admin changes and jumps when skill is updated.

## Test plan

- [ ] Open a player profile with skill history set — verify the dashed skill line appears on the ELO chart with a right-side axis
- [ ] Switch between class tabs — verify skill line updates correctly per class
- [ ] Switch between "Over time" / "By game #" modes — verify both axes render correctly
- [ ] Open a player profile with no skill history — verify chart looks identical to before (no second axis, no legend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)