### PR TITLE
chore: add pnpm-workspace.yaml for pnpm v11 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24.15.0-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@10.0.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 COPY . /app
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -130,10 +130,5 @@
     "typescript": "6.0.3",
     "typescript-eslint": "8.58.2",
     "vitest": "4.1.6"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - esbuild
+  - protobufjs


### PR DESCRIPTION
## Summary

- Creates `pnpm-workspace.yaml` with `onlyBuiltDependencies: [esbuild, protobufjs]`
- Removes the now-ignored `pnpm.onlyBuiltDependencies` from `package.json`

## Background

pnpm v11 (introduced in #594) enables `strictDepBuilds: true` by default, which blocks all dependency build scripts not explicitly allowed. In v11, the approved list must live in `pnpm-workspace.yaml` — the old `package.json` `pnpm.onlyBuiltDependencies` field is no longer respected, causing CI to fail with `ERR_PNPM_IGNORED_BUILDS` for both `esbuild` and `protobufjs`.

## Test plan

- [ ] Merge this PR first
- [ ] Renovate will rebase #594 automatically (or trigger manually), after which CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)