### PR TITLE
fix: use allowBuilds in pnpm-workspace.yaml for pnpm v11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-onlyBuiltDependencies:
-  - esbuild
-  - protobufjs
+allowBuilds:
+  esbuild: true
+  protobufjs: true


### PR DESCRIPTION
## Summary

- Replaces `onlyBuiltDependencies` with `allowBuilds` in `pnpm-workspace.yaml`

## Background

pnpm v11.0 replaced `onlyBuiltDependencies` with a new `allowBuilds` map (see [v11.0 release notes](https://pnpm.io/blog/releases/11.0)). The old key is silently ignored in v11, so even though `pnpm-workspace.yaml` existed (added in #595), `esbuild` and `protobufjs` build scripts were still blocked with `ERR_PNPM_IGNORED_BUILDS`.

## Test plan

- [ ] Merge this PR
- [ ] Renovate will rebase #594, after which CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)