### PR TITLE
fix: batch actor lookup in sync-clients

### DIFF
--- a/src/queue/plugins/sync-clients.test.ts
+++ b/src/queue/plugins/sync-clients.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import type { FastifyInstance } from 'fastify'
+
+const {
+  mockPlayersFind,
+  mockPlayersCollectionFindOne,
+  mockQueueSlotsFind,
+  mockQueueSlotsFindOne,
+  mockNotFound,
+} = vi.hoisted(() => ({
+  mockPlayersFind: vi.fn(),
+  mockPlayersCollectionFindOne: vi.fn(),
+  mockQueueSlotsFind: vi.fn(),
+  mockQueueSlotsFindOne: vi.fn(),
+  mockNotFound: vi.fn((msg: string) => new Error(msg)),
+}))
+
+vi.mock('fastify-plugin', () => ({ default: <T>(fn: T): T => fn }))
+vi.mock('../../events', () => ({ events: { on: vi.fn() } }))
+vi.mock('../../utils/safe', () => ({ safe: <T>(fn: T): T => fn }))
+vi.mock('../../players', () => ({ players: { bySteamId: vi.fn() } }))
+vi.mock('../../errors', () => ({ errors: { notFound: mockNotFound } }))
+vi.mock('../../database/collections', () => ({
+  collections: {
+    players: { find: mockPlayersFind, findOne: mockPlayersCollectionFindOne },
+    queueSlots: { find: mockQueueSlotsFind, findOne: mockQueueSlotsFindOne },
+  },
+}))
+
+vi.mock('../views/html/queue-slot', () => ({ QueueSlot: vi.fn().mockResolvedValue('') }))
+vi.mock('../views/html/online-player-list', () => ({
+  OnlinePlayerList: vi.fn().mockResolvedValue(''),
+}))
+vi.mock('../views/html/ready-up-dialog', () => ({
+  ReadyUpDialog: {
+    close: vi.fn().mockResolvedValue(''),
+    show: vi.fn().mockReturnValue(''),
+  },
+}))
+vi.mock('../views/html/map-vote', () => ({
+  MapResult: vi.fn().mockResolvedValue(''),
+  MapVote: vi.fn().mockReturnValue(''),
+}))
+vi.mock('../views/html/set-title', () => ({ SetTitle: vi.fn().mockResolvedValue('') }))
+vi.mock('../views/html/substitution-requests', () => ({
+  SubstitutionRequests: Object.assign(vi.fn().mockResolvedValue(''), {
+    notify: vi.fn().mockReturnValue(''),
+  }),
+}))
+vi.mock('../views/html/running-game-snackbar', () => ({
+  RunningGameSnackbar: vi.fn().mockResolvedValue(''),
+}))
+vi.mock('../views/html/stream-list', () => ({ StreamList: vi.fn().mockResolvedValue('') }))
+vi.mock('../views/html/ban-alerts', () => ({ BanAlerts: vi.fn().mockResolvedValue('') }))
+vi.mock('../views/html/current-player-count', () => ({
+  CurrentPlayerCount: vi.fn().mockResolvedValue(''),
+}))
+vi.mock('../../pre-ready/views/html/pre-ready-up-button', () => ({
+  PreReadyUpButton: vi.fn().mockReturnValue(''),
+}))
+vi.mock('../views/html/online-player-count', () => ({
+  OnlinePlayerCount: vi.fn().mockResolvedValue(''),
+}))
+vi.mock('../views/html/chat', () => ({
+  ChatMessages: Object.assign(vi.fn().mockResolvedValue(''), {
+    append: vi.fn().mockReturnValue(''),
+    remove: vi.fn().mockReturnValue(''),
+  }),
+}))
+vi.mock('../views/html/is-in-queue', () => ({ IsInQueue: vi.fn().mockResolvedValue('') }))
+
+import { events } from '../../events'
+import { players } from '../../players'
+import plugin from './sync-clients'
+
+const steamId1 = '76561198000000001' as SteamId64
+const steamId2 = '76561198000000002' as SteamId64
+
+function makeApp() {
+  const mockSend = vi.fn()
+  const mockTo = vi.fn()
+  mockTo.mockReturnValue({ to: mockTo, send: mockSend })
+  return {
+    gateway: {
+      to: mockTo,
+      broadcast: vi.fn(),
+      on: vi.fn(),
+    },
+    websocketServer: {
+      clients: new Set(),
+    },
+  } as unknown as FastifyInstance
+}
+
+type Handler<T> = (params: T) => Promise<void>
+
+function getHandler<T>(event: string): Handler<T> {
+  const call = vi.mocked(events.on).mock.calls.find(([e]) => e === event)
+  if (!call) throw new Error(`No handler registered for event: ${event}`)
+  return call[1] as Handler<T>
+}
+
+describe('sync-clients', () => {
+  let app: FastifyInstance
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    app = makeApp()
+    mockQueueSlotsFind.mockReturnValue({ toArray: vi.fn().mockResolvedValue([]) })
+    mockQueueSlotsFindOne.mockResolvedValue(null)
+    mockPlayersCollectionFindOne.mockResolvedValue(null)
+    mockPlayersFind.mockReturnValue({ toArray: vi.fn().mockResolvedValue([]) })
+    await (plugin as unknown as (app: FastifyInstance) => Promise<void>)(app)
+  })
+
+  describe('syncAllSlots', () => {
+    it('issues a single batch DB query instead of per-player bySteamId calls', async () => {
+      mockPlayersFind.mockReturnValue({
+        toArray: vi.fn().mockResolvedValue([{ steamId: steamId1 }]),
+      })
+      const handler = getHandler<{ steamId: SteamId64; activeGame: number }>(
+        'player/activeGame:updated',
+      )
+
+      await handler({ steamId: steamId1, activeGame: 1 })
+
+      expect(mockPlayersFind).toHaveBeenCalledOnce()
+      expect(mockPlayersFind).toHaveBeenCalledWith(
+        { steamId: { $in: [steamId1] } },
+        expect.objectContaining({ projection: expect.any(Object) }),
+      )
+      expect(vi.mocked(players.bySteamId)).not.toHaveBeenCalled()
+    })
+
+    it('throws when the player is not in the batch result', async () => {
+      mockPlayersFind.mockReturnValue({ toArray: vi.fn().mockResolvedValue([]) })
+      const handler = getHandler<{ steamId: SteamId64; activeGame: number }>(
+        'player/activeGame:updated',
+      )
+
+      await expect(handler({ steamId: steamId1, activeGame: 1 })).rejects.toThrow()
+      expect(mockNotFound).toHaveBeenCalledWith(expect.stringContaining(steamId1))
+    })
+  })
+
+  describe('fetchActorMap', () => {
+    it('issues a single batch DB query for multiple recipients', async () => {
+      const recipientSlots = [
+        { player: { steamId: steamId1 }, canMakeFriendsWith: [steamId2] },
+        { player: { steamId: steamId2 }, canMakeFriendsWith: [steamId1] },
+      ]
+      mockQueueSlotsFindOne.mockResolvedValueOnce({ player: { steamId: steamId1 } })
+      mockQueueSlotsFind.mockReturnValueOnce({
+        toArray: vi.fn().mockResolvedValue(recipientSlots),
+      })
+      mockPlayersFind.mockReturnValue({
+        toArray: vi.fn().mockResolvedValue([{ steamId: steamId1 }, { steamId: steamId2 }]),
+      })
+      const handler = getHandler<{ target: SteamId64 }>('queue/friendship:created')
+
+      await handler({ target: steamId1 })
+
+      expect(mockPlayersFind).toHaveBeenCalledOnce()
+      expect(mockPlayersFind).toHaveBeenCalledWith(
+        { steamId: { $in: [steamId1, steamId2] } },
+        expect.objectContaining({ projection: expect.any(Object) }),
+      )
+    })
+  })
+
+  describe('queue/slots:updated handler', () => {
+    it('pre-fetches all connected players in a single batch query', async () => {
+      ;(app.websocketServer.clients as Set<unknown>).add({ player: { steamId: steamId1 } })
+      ;(app.websocketServer.clients as Set<unknown>).add({ player: { steamId: steamId2 } })
+      ;(app.websocketServer.clients as Set<unknown>).add({ player: undefined })
+      mockPlayersFind.mockReturnValue({
+        toArray: vi.fn().mockResolvedValue([{ steamId: steamId1 }, { steamId: steamId2 }]),
+      })
+      const handler = getHandler<{ slots: unknown[] }>('queue/slots:updated')
+
+      await handler({ slots: [] })
+
+      expect(mockPlayersFind).toHaveBeenCalledOnce()
+      expect(mockPlayersFind).toHaveBeenCalledWith(
+        { steamId: { $in: [steamId1, steamId2] } },
+        expect.objectContaining({ projection: expect.any(Object) }),
+      )
+      expect(vi.mocked(players.bySteamId)).not.toHaveBeenCalled()
+    })
+
+    it('does not include unauthenticated clients in the batch query', async () => {
+      ;(app.websocketServer.clients as Set<unknown>).add({ player: undefined })
+      const handler = getHandler<{ slots: unknown[] }>('queue/slots:updated')
+
+      await handler({ slots: [] })
+
+      expect(mockPlayersFind).toHaveBeenCalledWith(
+        { steamId: { $in: [] } },
+        expect.objectContaining({ projection: expect.any(Object) }),
+      )
+    })
+  })
+})

--- a/src/queue/plugins/sync-clients.ts
+++ b/src/queue/plugins/sync-clients.ts
@@ -21,22 +21,23 @@ import { IsInQueue } from '../views/html/is-in-queue'
 import type { PlayerModel } from '../../database/models/player.model'
 import type { AppWebSocket } from '../../websocket/types'
 import { players } from '../../players'
+import { errors } from '../../errors'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
   async app => {
     async function syncAllSlots(...clients: SteamId64[]) {
-      const slots = await collections.queueSlots.find().toArray()
+      const [slots, actorMap] = await Promise.all([
+        collections.queueSlots.find().toArray(),
+        fetchActorMap(clients),
+      ])
       await Promise.all(
         clients.map(async client => {
-          const actor = await players.bySteamId(client, [
-            'steamId',
-            'bans',
-            'activeGame',
-            'skill',
-            'verified',
-            'roles',
-          ])
+          const actor = actorMap.get(client)
+          if (!actor) {
+            throw errors.notFound(`Player with steamId ${client} does not exist`)
+          }
+
           app.gateway
             .to({ players: [actor.steamId] })
             .to({ url: '/' })

--- a/src/queue/plugins/sync-clients.ts
+++ b/src/queue/plugins/sync-clients.ts
@@ -186,23 +186,24 @@ export default fp(
     )
 
     async function fetchActorMap(recipientIds: SteamId64[]) {
-      const entries = await Promise.all(
-        recipientIds.map(
-          async id =>
-            [
-              id,
-              await players.bySteamId(id, [
-                'steamId',
-                'bans',
-                'activeGame',
-                'skill',
-                'verified',
-                'roles',
-              ]),
-            ] as const,
-        ),
-      )
-      return new Map(entries)
+      const actors = await collections.players
+        .find<
+          Pick<PlayerModel, 'steamId' | 'bans' | 'activeGame' | 'skill' | 'verified' | 'roles'>
+        >(
+          { steamId: { $in: recipientIds } },
+          {
+            projection: {
+              steamId: 1,
+              bans: 1,
+              activeGame: 1,
+              skill: 1,
+              verified: 1,
+              roles: 1,
+            },
+          },
+        )
+        .toArray()
+      return new Map(actors.map(actor => [actor.steamId, actor] as const))
     }
 
     events.on(

--- a/src/queue/plugins/sync-clients.ts
+++ b/src/queue/plugins/sync-clients.ts
@@ -31,21 +31,19 @@ export default fp(
         collections.queueSlots.find().toArray(),
         fetchActorMap(clients),
       ])
-      await Promise.all(
-        clients.map(async client => {
-          const actor = actorMap.get(client)
-          if (!actor) {
-            throw errors.notFound(`Player with steamId ${client} does not exist`)
-          }
+      for (const client of clients) {
+        const actor = actorMap.get(client)
+        if (!actor) {
+          throw errors.notFound(`Player with steamId ${client} does not exist`)
+        }
 
-          app.gateway
-            .to({ players: [actor.steamId] })
-            .to({ url: '/' })
-            .send(() =>
-              Promise.all(slots.map(slot => QueueSlot({ slot, actor }))).then(arr => arr.join()),
-            )
-        }),
-      )
+        app.gateway
+          .to({ players: [actor.steamId] })
+          .to({ url: '/' })
+          .send(() =>
+            Promise.all(slots.map(slot => QueueSlot({ slot, actor }))).then(arr => arr.join()),
+          )
+      }
     }
 
     async function syncQueuePage(socket: AppWebSocket) {

--- a/src/queue/plugins/sync-clients.ts
+++ b/src/queue/plugins/sync-clients.ts
@@ -135,22 +135,21 @@ export default fp(
     events.on(
       'queue/slots:updated',
       safe(async ({ slots }) => {
-        const playerCount = await CurrentPlayerCount()
-        app.gateway.broadcast(async player => {
-          const actor = player
-            ? await players.bySteamId(player, [
-                'steamId',
-                'bans',
-                'activeGame',
-                'skill',
-                'verified',
-                'roles',
-              ])
-            : undefined
-          return [
-            ...(await Promise.all(slots.map(slot => QueueSlot({ slot, actor })))),
+        const connectedPlayers = [...(app.websocketServer.clients as Set<AppWebSocket>)]
+          .map(c => c.player?.steamId)
+          .filter((id): id is SteamId64 => id !== undefined)
+
+        const [playerCount, actorMap] = await Promise.all([
+          CurrentPlayerCount(),
+          fetchActorMap(connectedPlayers),
+        ])
+
+        app.gateway.broadcast(player => {
+          const actor = player ? actorMap.get(player) : undefined
+          return Promise.all(slots.map(slot => QueueSlot({ slot, actor }))).then(items => [
+            ...items,
             playerCount,
-          ]
+          ])
         })
 
         app.gateway.broadcast(() => SetTitle())


### PR DESCRIPTION
## Summary
- Replace per-recipient `players.bySteamId` calls with a single `collections.players.find({ steamId: { $in } })` query.
- Build the actor lookup table from the returned cursor with a `Map` keyed by `steamId`.
- Keep the existing projected fields for queue actor rendering.