### PR TITLE
fix: add OTEL metrics for queue hot path latency

### DIFF
--- a/src/queue/cleanup-friendships.ts
+++ b/src/queue/cleanup-friendships.ts
@@ -3,7 +3,7 @@ import { events } from '../events'
 import { withQueueLock } from './with-queue-lock'
 
 export async function cleanupFriendships() {
-  await withQueueLock('cleanupfriendships', async () => {
+  await withQueueLock('cleanup-friendships', async () => {
     const medics = (
       await collections.queueSlots
         .find({ 'canMakeFriendsWith.0': { $exists: true }, player: { $ne: null } })

--- a/src/queue/cleanup-friendships.ts
+++ b/src/queue/cleanup-friendships.ts
@@ -1,6 +1,6 @@
 import { collections } from '../database/collections'
 import { events } from '../events'
-import { withQueueLock } from './mutex'
+import { withQueueLock } from './with-queue-lock'
 
 export async function cleanupFriendships() {
   await withQueueLock('cleanupfriendships', async () => {

--- a/src/queue/cleanup-friendships.ts
+++ b/src/queue/cleanup-friendships.ts
@@ -1,9 +1,9 @@
 import { collections } from '../database/collections'
 import { events } from '../events'
-import { mutex } from './mutex'
+import { withQueueLock } from './mutex'
 
 export async function cleanupFriendships() {
-  await mutex.runExclusive(async () => {
+  await withQueueLock('cleanupfriendships', async () => {
     const medics = (
       await collections.queueSlots
         .find({ 'canMakeFriendsWith.0': { $exists: true }, player: { $ne: null } })

--- a/src/queue/join.ts
+++ b/src/queue/join.ts
@@ -10,7 +10,7 @@ import { preReady } from '../pre-ready'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getState } from './get-state'
 import { meetsSkillThreshold } from './meets-skill-threshold'
-import { withQueueLock } from './mutex'
+import { withQueueLock } from './with-queue-lock'
 import type { QueueSlotId } from './types/queue-slot-id'
 
 export async function join(slotId: QueueSlotId, steamId: SteamId64): Promise<QueueSlotModel[]> {

--- a/src/queue/join.ts
+++ b/src/queue/join.ts
@@ -12,9 +12,13 @@ import { getState } from './get-state'
 import { meetsSkillThreshold } from './meets-skill-threshold'
 import { mutex } from './mutex'
 import type { QueueSlotId } from './types/queue-slot-id'
+import { queueMutexWaitDuration } from './metrics'
+import { performance } from 'perf_hooks'
 
 export async function join(slotId: QueueSlotId, steamId: SteamId64): Promise<QueueSlotModel[]> {
+  const waitStart = performance.now()
   return await mutex.runExclusive(async () => {
+    queueMutexWaitDuration.record((performance.now() - waitStart) / 1000, { operation: 'join' })
     logger.trace({ steamId, slotId }, `queue.join()`)
     const player = await players.bySteamId(steamId, [
       'hasAcceptedRules',

--- a/src/queue/join.ts
+++ b/src/queue/join.ts
@@ -10,15 +10,11 @@ import { preReady } from '../pre-ready'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getState } from './get-state'
 import { meetsSkillThreshold } from './meets-skill-threshold'
-import { mutex } from './mutex'
+import { withQueueLock } from './mutex'
 import type { QueueSlotId } from './types/queue-slot-id'
-import { queueMutexWaitDuration } from './metrics'
-import { performance } from 'perf_hooks'
 
 export async function join(slotId: QueueSlotId, steamId: SteamId64): Promise<QueueSlotModel[]> {
-  const waitStart = performance.now()
-  return await mutex.runExclusive(async () => {
-    queueMutexWaitDuration.record((performance.now() - waitStart) / 1000, { operation: 'join' })
+  return await withQueueLock('join', async () => {
     logger.trace({ steamId, slotId }, `queue.join()`)
     const player = await players.bySteamId(steamId, [
       'hasAcceptedRules',

--- a/src/queue/kick.ts
+++ b/src/queue/kick.ts
@@ -6,7 +6,7 @@ import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getMapVoteResults } from './get-map-vote-results'
 import { getState } from './get-state'
-import { withQueueLock } from './mutex'
+import { withQueueLock } from './with-queue-lock'
 import { preReady } from '../pre-ready'
 import { errors } from '../errors'
 

--- a/src/queue/kick.ts
+++ b/src/queue/kick.ts
@@ -6,12 +6,12 @@ import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getMapVoteResults } from './get-map-vote-results'
 import { getState } from './get-state'
-import { mutex } from './mutex'
+import { withQueueLock } from './mutex'
 import { preReady } from '../pre-ready'
 import { errors } from '../errors'
 
 export async function kick(...steamIds: SteamId64[]): Promise<QueueSlotModel[]> {
-  return await mutex.runExclusive(async () => {
+  return await withQueueLock('kick', async () => {
     logger.trace({ steamIds }, 'queue.kick()')
     const state = await getState()
     if (state === QueueState.launching) {

--- a/src/queue/leave.ts
+++ b/src/queue/leave.ts
@@ -9,9 +9,13 @@ import { getState } from './get-state'
 import { mutex } from './mutex'
 import { preReady } from '../pre-ready'
 import { errors } from '../errors'
+import { queueMutexWaitDuration } from './metrics'
+import { performance } from 'perf_hooks'
 
 export async function leave(steamId: SteamId64): Promise<QueueSlotModel> {
+  const waitStart = performance.now()
   return await mutex.runExclusive(async () => {
+    queueMutexWaitDuration.record((performance.now() - waitStart) / 1000, { operation: 'leave' })
     logger.trace({ steamId }, 'queue.leave()')
     const state = await getState()
     if (state === QueueState.launching) {

--- a/src/queue/leave.ts
+++ b/src/queue/leave.ts
@@ -6,7 +6,7 @@ import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getMapVoteResults } from './get-map-vote-results'
 import { getState } from './get-state'
-import { withQueueLock } from './mutex'
+import { withQueueLock } from './with-queue-lock'
 import { preReady } from '../pre-ready'
 import { errors } from '../errors'
 

--- a/src/queue/leave.ts
+++ b/src/queue/leave.ts
@@ -6,16 +6,12 @@ import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getMapVoteResults } from './get-map-vote-results'
 import { getState } from './get-state'
-import { mutex } from './mutex'
+import { withQueueLock } from './mutex'
 import { preReady } from '../pre-ready'
 import { errors } from '../errors'
-import { queueMutexWaitDuration } from './metrics'
-import { performance } from 'perf_hooks'
 
 export async function leave(steamId: SteamId64): Promise<QueueSlotModel> {
-  const waitStart = performance.now()
-  return await mutex.runExclusive(async () => {
-    queueMutexWaitDuration.record((performance.now() - waitStart) / 1000, { operation: 'leave' })
+  return await withQueueLock('leave', async () => {
     logger.trace({ steamId }, 'queue.leave()')
     const state = await getState()
     if (state === QueueState.launching) {

--- a/src/queue/mark-as-friend.ts
+++ b/src/queue/mark-as-friend.ts
@@ -6,19 +6,13 @@ import { events } from '../events'
 import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getState } from './get-state'
-import { mutex } from './mutex'
-import { queueMutexWaitDuration } from './metrics'
-import { performance } from 'perf_hooks'
+import { withQueueLock } from './mutex'
 
 export async function markAsFriend(
   source: SteamId64,
   target: SteamId64 | null,
 ): Promise<QueueSlotModel | null> {
-  const waitStart = performance.now()
-  return await mutex.runExclusive(async () => {
-    queueMutexWaitDuration.record((performance.now() - waitStart) / 1000, {
-      operation: 'markasfriend',
-    })
+  return await withQueueLock('markasfriend', async () => {
     logger.trace({ source, target }, `queue.markAsFriend()`)
 
     const queueState = await getState()

--- a/src/queue/mark-as-friend.ts
+++ b/src/queue/mark-as-friend.ts
@@ -12,7 +12,7 @@ export async function markAsFriend(
   source: SteamId64,
   target: SteamId64 | null,
 ): Promise<QueueSlotModel | null> {
-  return await withQueueLock('markasfriend', async () => {
+  return await withQueueLock('mark-as-friend', async () => {
     logger.trace({ source, target }, `queue.markAsFriend()`)
 
     const queueState = await getState()

--- a/src/queue/mark-as-friend.ts
+++ b/src/queue/mark-as-friend.ts
@@ -7,12 +7,18 @@ import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getState } from './get-state'
 import { mutex } from './mutex'
+import { queueMutexWaitDuration } from './metrics'
+import { performance } from 'perf_hooks'
 
 export async function markAsFriend(
   source: SteamId64,
   target: SteamId64 | null,
 ): Promise<QueueSlotModel | null> {
+  const waitStart = performance.now()
   return await mutex.runExclusive(async () => {
+    queueMutexWaitDuration.record((performance.now() - waitStart) / 1000, {
+      operation: 'markasfriend',
+    })
     logger.trace({ source, target }, `queue.markAsFriend()`)
 
     const queueState = await getState()

--- a/src/queue/mark-as-friend.ts
+++ b/src/queue/mark-as-friend.ts
@@ -6,7 +6,7 @@ import { events } from '../events'
 import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getState } from './get-state'
-import { withQueueLock } from './mutex'
+import { withQueueLock } from './with-queue-lock'
 
 export async function markAsFriend(
   source: SteamId64,

--- a/src/queue/measure-time.ts
+++ b/src/queue/measure-time.ts
@@ -1,0 +1,22 @@
+import { performance } from 'node:perf_hooks'
+
+interface MeasureTimeRecordProps {
+  ms: number
+  result: 'success' | 'error'
+}
+
+export async function measureTime<T>(
+  fn: () => Promise<T>,
+  record: (props: MeasureTimeRecordProps) => void,
+): Promise<T> {
+  const start = performance.now()
+  return fn()
+    .then(ret => {
+      record({ ms: performance.now() - start, result: 'success' })
+      return ret
+    })
+    .catch((error: unknown) => {
+      record({ ms: performance.now() - start, result: 'error' })
+      throw error
+    })
+}

--- a/src/queue/metrics.ts
+++ b/src/queue/metrics.ts
@@ -1,17 +1,11 @@
 import { meter } from '../otel'
 
-export const queueOperationDuration = meter.createHistogram(
-  'tf2pickup.queue.operation.duration',
-  {
-    description: 'Time from WS message received to domain event emitted',
-    unit: 's',
-  },
-)
+export const queueWsCallDuration = meter.createHistogram('tf2pickup.queue.ws_call.duration', {
+  description: 'Time from WS message received to domain event emitted',
+  unit: 'ms',
+})
 
-export const queueMutexWaitDuration = meter.createHistogram(
-  'tf2pickup.queue.mutex.wait.duration',
-  {
-    description: 'Time waiting to acquire the queue mutex',
-    unit: 's',
-  },
-)
+export const queueMutexWaitDuration = meter.createHistogram('tf2pickup.queue.mutex_wait.duration', {
+  description: 'Time waiting to acquire the queue mutex',
+  unit: 'ms',
+})

--- a/src/queue/metrics.ts
+++ b/src/queue/metrics.ts
@@ -1,0 +1,17 @@
+import { meter } from '../otel'
+
+export const queueOperationDuration = meter.createHistogram(
+  'tf2pickup.queue.operation.duration',
+  {
+    description: 'Time from WS message received to domain event emitted',
+    unit: 's',
+  },
+)
+
+export const queueMutexWaitDuration = meter.createHistogram(
+  'tf2pickup.queue.mutex.wait.duration',
+  {
+    description: 'Time waiting to acquire the queue mutex',
+    unit: 's',
+  },
+)

--- a/src/queue/mutex.ts
+++ b/src/queue/mutex.ts
@@ -1,3 +1,13 @@
 import { Mutex } from 'async-mutex'
+import { performance } from 'perf_hooks'
+import { queueMutexWaitDuration } from './metrics'
 
-export const mutex = new Mutex()
+const mutex = new Mutex()
+
+export async function withQueueLock<T>(operation: string, fn: () => Promise<T>): Promise<T> {
+  const waitStart = performance.now()
+  return mutex.runExclusive(async () => {
+    queueMutexWaitDuration.record((performance.now() - waitStart) / 1000, { operation })
+    return fn()
+  })
+}

--- a/src/queue/plugins/gateway-listeners.ts
+++ b/src/queue/plugins/gateway-listeners.ts
@@ -18,6 +18,8 @@ import { MapVoteSelection } from '../views/html/map-vote-selection'
 import { FlashMessage } from '../../html/components/flash-message'
 import type { AppWebSocket } from '../../websocket/types'
 import { players } from '../../players'
+import { queueOperationDuration } from '../metrics'
+import { performance } from 'perf_hooks'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -38,25 +40,38 @@ export default fp(
     }
 
     function wsSafe<Args extends unknown[]>(
+      operation: string,
       fn: (socket: AppWebSocket, ...args: Args) => Promise<void>,
     ) {
       return (socket: AppWebSocket, ...args: Args) => {
-        fn(socket, ...args).catch(async (error: unknown) => {
-          logger.error(error)
-          if (error instanceof Error) {
-            const msg = await FlashMessage({
-              message: `Error: ${error.message}`,
-              type: 'error',
+        const start = performance.now()
+        fn(socket, ...args)
+          .then(() => {
+            queueOperationDuration.record((performance.now() - start) / 1000, {
+              operation,
+              result: 'success',
             })
-            socket.send(msg)
-          }
-        })
+          })
+          .catch(async (error: unknown) => {
+            queueOperationDuration.record((performance.now() - start) / 1000, {
+              operation,
+              result: 'error',
+            })
+            logger.error(error)
+            if (error instanceof Error) {
+              const msg = await FlashMessage({
+                message: `Error: ${error.message}`,
+                type: 'error',
+              })
+              socket.send(msg)
+            }
+          })
       }
     }
 
     app.gateway.on(
       'queue:join',
-      wsSafe(async (socket, slotId) => {
+      wsSafe('join', async (socket, slotId) => {
         if (!socket.player) {
           throw errors.unauthorized('unauthorized')
         }
@@ -74,7 +89,7 @@ export default fp(
 
     app.gateway.on(
       'queue:leave',
-      wsSafe(async socket => {
+      wsSafe('leave', async socket => {
         if (!socket.player) {
           throw errors.unauthorized('unauthorized')
         }
@@ -101,7 +116,7 @@ export default fp(
 
     app.gateway.on(
       'queue:readyup',
-      wsSafe(async socket => {
+      wsSafe('readyup', async socket => {
         if (!socket.player) {
           throw errors.unauthorized('unauthorized')
         }
@@ -113,7 +128,7 @@ export default fp(
 
     app.gateway.on(
       'queue:votemap',
-      wsSafe(async (socket, map) => {
+      wsSafe('votemap', async (socket, map) => {
         if (!socket.player) {
           throw errors.unauthorized('unauthorized')
         }
@@ -127,7 +142,7 @@ export default fp(
 
     app.gateway.on(
       'queue:markasfriend',
-      wsSafe(async (socket, steamId) => {
+      wsSafe('markasfriend', async (socket, steamId) => {
         if (!socket.player) {
           throw errors.unauthorized('unauthorized')
         }
@@ -138,7 +153,7 @@ export default fp(
 
     app.gateway.on(
       'queue:togglepreready',
-      wsSafe(async socket => {
+      wsSafe('togglepreready', async socket => {
         if (!socket.player) {
           throw errors.unauthorized('unauthorized')
         }

--- a/src/queue/plugins/gateway-listeners.ts
+++ b/src/queue/plugins/gateway-listeners.ts
@@ -18,8 +18,8 @@ import { MapVoteSelection } from '../views/html/map-vote-selection'
 import { FlashMessage } from '../../html/components/flash-message'
 import type { AppWebSocket } from '../../websocket/types'
 import { players } from '../../players'
-import { queueOperationDuration } from '../metrics'
-import { performance } from 'perf_hooks'
+import { queueWsCallDuration } from '../metrics'
+import { measureTime } from '../measure-time'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -44,28 +44,26 @@ export default fp(
       fn: (socket: AppWebSocket, ...args: Args) => Promise<void>,
     ) {
       return (socket: AppWebSocket, ...args: Args) => {
-        const start = performance.now()
-        fn(socket, ...args)
-          .then(() => {
-            queueOperationDuration.record((performance.now() - start) / 1000, {
+        measureTime(
+          async () => {
+            await fn(socket, ...args)
+          },
+          ({ ms, result }) => {
+            queueWsCallDuration.record(ms, {
               operation,
-              result: 'success',
+              result,
             })
-          })
-          .catch(async (error: unknown) => {
-            queueOperationDuration.record((performance.now() - start) / 1000, {
-              operation,
-              result: 'error',
+          },
+        ).catch(async (error: unknown) => {
+          logger.error(error)
+          if (error instanceof Error) {
+            const msg = await FlashMessage({
+              message: `Error: ${error.message}`,
+              type: 'error',
             })
-            logger.error(error)
-            if (error instanceof Error) {
-              const msg = await FlashMessage({
-                message: `Error: ${error.message}`,
-                type: 'error',
-              })
-              socket.send(msg)
-            }
-          })
+            socket.send(msg)
+          }
+        })
       }
     }
 

--- a/src/queue/plugins/gateway-listeners.ts
+++ b/src/queue/plugins/gateway-listeners.ts
@@ -19,7 +19,7 @@ import { FlashMessage } from '../../html/components/flash-message'
 import type { AppWebSocket } from '../../websocket/types'
 import { players } from '../../players'
 import { queueWsCallDuration } from '../metrics'
-import { measureTime } from '../measure-time'
+import { measureTime } from '../../utils/measure-time'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await

--- a/src/queue/ready-up.ts
+++ b/src/queue/ready-up.ts
@@ -10,7 +10,7 @@ import { preReady } from '../pre-ready'
 import { errors } from '../errors'
 
 export async function readyUp(steamId: SteamId64): Promise<QueueSlotModel> {
-  return await withQueueLock('readyup', async () => {
+  return await withQueueLock('ready-up', async () => {
     logger.trace({ steamId }, 'queue.readyUp()')
     const state = await getState()
     if (state !== QueueState.ready) {

--- a/src/queue/ready-up.ts
+++ b/src/queue/ready-up.ts
@@ -5,7 +5,7 @@ import { events } from '../events'
 import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getState } from './get-state'
-import { withQueueLock } from './mutex'
+import { withQueueLock } from './with-queue-lock'
 import { preReady } from '../pre-ready'
 import { errors } from '../errors'
 

--- a/src/queue/ready-up.ts
+++ b/src/queue/ready-up.ts
@@ -8,9 +8,13 @@ import { getState } from './get-state'
 import { mutex } from './mutex'
 import { preReady } from '../pre-ready'
 import { errors } from '../errors'
+import { queueMutexWaitDuration } from './metrics'
+import { performance } from 'perf_hooks'
 
 export async function readyUp(steamId: SteamId64): Promise<QueueSlotModel> {
+  const waitStart = performance.now()
   return await mutex.runExclusive(async () => {
+    queueMutexWaitDuration.record((performance.now() - waitStart) / 1000, { operation: 'readyup' })
     logger.trace({ steamId }, 'queue.readyUp()')
     const state = await getState()
     if (state !== QueueState.ready) {

--- a/src/queue/ready-up.ts
+++ b/src/queue/ready-up.ts
@@ -5,16 +5,12 @@ import { events } from '../events'
 import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getState } from './get-state'
-import { mutex } from './mutex'
+import { withQueueLock } from './mutex'
 import { preReady } from '../pre-ready'
 import { errors } from '../errors'
-import { queueMutexWaitDuration } from './metrics'
-import { performance } from 'perf_hooks'
 
 export async function readyUp(steamId: SteamId64): Promise<QueueSlotModel> {
-  const waitStart = performance.now()
-  return await mutex.runExclusive(async () => {
-    queueMutexWaitDuration.record((performance.now() - waitStart) / 1000, { operation: 'readyup' })
+  return await withQueueLock('readyup', async () => {
     logger.trace({ steamId }, 'queue.readyUp()')
     const state = await getState()
     if (state !== QueueState.ready) {

--- a/src/queue/set-state.ts
+++ b/src/queue/set-state.ts
@@ -7,7 +7,7 @@ import { preReady } from '../pre-ready'
 import { withQueueLock } from './with-queue-lock'
 
 export async function setState(state: QueueState) {
-  await withQueueLock('setstate', async () => {
+  await withQueueLock('set-state', async () => {
     logger.trace({ state }, 'queue.setState()')
     await collections.queueState.updateOne({}, { $set: { state } })
 

--- a/src/queue/set-state.ts
+++ b/src/queue/set-state.ts
@@ -4,10 +4,10 @@ import { errors } from '../errors'
 import { events } from '../events'
 import { logger } from '../logger'
 import { preReady } from '../pre-ready'
-import { mutex } from './mutex'
+import { withQueueLock } from './mutex'
 
 export async function setState(state: QueueState) {
-  await mutex.runExclusive(async () => {
+  await withQueueLock('setstate', async () => {
     logger.trace({ state }, 'queue.setState()')
     await collections.queueState.updateOne({}, { $set: { state } })
 

--- a/src/queue/set-state.ts
+++ b/src/queue/set-state.ts
@@ -4,7 +4,7 @@ import { errors } from '../errors'
 import { events } from '../events'
 import { logger } from '../logger'
 import { preReady } from '../pre-ready'
-import { withQueueLock } from './mutex'
+import { withQueueLock } from './with-queue-lock'
 
 export async function setState(state: QueueState) {
   await withQueueLock('setstate', async () => {

--- a/src/queue/unready.ts
+++ b/src/queue/unready.ts
@@ -3,7 +3,7 @@ import type { QueueSlotModel } from '../database/models/queue-slot.model'
 import { events } from '../events'
 import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
-import { withQueueLock } from './mutex'
+import { withQueueLock } from './with-queue-lock'
 
 export async function unready(...steamIds: SteamId64[]): Promise<QueueSlotModel[]> {
   return await withQueueLock('unready', async () => {

--- a/src/queue/unready.ts
+++ b/src/queue/unready.ts
@@ -3,10 +3,10 @@ import type { QueueSlotModel } from '../database/models/queue-slot.model'
 import { events } from '../events'
 import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
-import { mutex } from './mutex'
+import { withQueueLock } from './mutex'
 
 export async function unready(...steamIds: SteamId64[]): Promise<QueueSlotModel[]> {
-  return await mutex.runExclusive(async () => {
+  return await withQueueLock('unready', async () => {
     logger.trace({ steamIds }, 'queue.unready()')
     const slots: QueueSlotModel[] = []
     for (const steamId of steamIds) {

--- a/src/queue/vote-map.ts
+++ b/src/queue/vote-map.ts
@@ -7,7 +7,7 @@ import { getMapVoteResults } from './get-map-vote-results'
 import { withQueueLock } from './with-queue-lock'
 
 export async function voteMap(steamId: SteamId64, map: string): Promise<Record<string, number>> {
-  return await withQueueLock('votemap', async () => {
+  return await withQueueLock('vote-map', async () => {
     logger.trace({ steamId, map }, 'queue.voteMap()')
     const mapCount = await collections.queueMapOptions.countDocuments({ name: map })
     if (mapCount === 0) {

--- a/src/queue/vote-map.ts
+++ b/src/queue/vote-map.ts
@@ -4,14 +4,10 @@ import { events } from '../events'
 import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getMapVoteResults } from './get-map-vote-results'
-import { mutex } from './mutex'
-import { queueMutexWaitDuration } from './metrics'
-import { performance } from 'perf_hooks'
+import { withQueueLock } from './mutex'
 
 export async function voteMap(steamId: SteamId64, map: string): Promise<Record<string, number>> {
-  const waitStart = performance.now()
-  return await mutex.runExclusive(async () => {
-    queueMutexWaitDuration.record((performance.now() - waitStart) / 1000, { operation: 'votemap' })
+  return await withQueueLock('votemap', async () => {
     logger.trace({ steamId, map }, 'queue.voteMap()')
     const mapCount = await collections.queueMapOptions.countDocuments({ name: map })
     if (mapCount === 0) {

--- a/src/queue/vote-map.ts
+++ b/src/queue/vote-map.ts
@@ -4,7 +4,7 @@ import { events } from '../events'
 import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getMapVoteResults } from './get-map-vote-results'
-import { withQueueLock } from './mutex'
+import { withQueueLock } from './with-queue-lock'
 
 export async function voteMap(steamId: SteamId64, map: string): Promise<Record<string, number>> {
   return await withQueueLock('votemap', async () => {

--- a/src/queue/vote-map.ts
+++ b/src/queue/vote-map.ts
@@ -5,9 +5,13 @@ import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getMapVoteResults } from './get-map-vote-results'
 import { mutex } from './mutex'
+import { queueMutexWaitDuration } from './metrics'
+import { performance } from 'perf_hooks'
 
 export async function voteMap(steamId: SteamId64, map: string): Promise<Record<string, number>> {
+  const waitStart = performance.now()
   return await mutex.runExclusive(async () => {
+    queueMutexWaitDuration.record((performance.now() - waitStart) / 1000, { operation: 'votemap' })
     logger.trace({ steamId, map }, 'queue.voteMap()')
     const mapCount = await collections.queueMapOptions.countDocuments({ name: map })
     if (mapCount === 0) {

--- a/src/queue/with-queue-lock.ts
+++ b/src/queue/with-queue-lock.ts
@@ -1,5 +1,5 @@
 import { Mutex } from 'async-mutex'
-import { performance } from 'perf_hooks'
+import { performance } from 'node:perf_hooks'
 import { queueMutexWaitDuration } from './metrics'
 
 const mutex = new Mutex()

--- a/src/queue/with-queue-lock.ts
+++ b/src/queue/with-queue-lock.ts
@@ -7,7 +7,7 @@ const mutex = new Mutex()
 export async function withQueueLock<T>(operation: string, fn: () => Promise<T>): Promise<T> {
   const waitStart = performance.now()
   return mutex.runExclusive(async () => {
-    queueMutexWaitDuration.record((performance.now() - waitStart) / 1000, { operation })
+    queueMutexWaitDuration.record(performance.now() - waitStart, { operation })
     return fn()
   })
 }

--- a/src/utils/measure-time.ts
+++ b/src/utils/measure-time.ts
@@ -10,13 +10,12 @@ export async function measureTime<T>(
   record: (props: MeasureTimeRecordProps) => void,
 ): Promise<T> {
   const start = performance.now()
-  return fn()
-    .then(ret => {
-      record({ ms: performance.now() - start, result: 'success' })
-      return ret
-    })
-    .catch((error: unknown) => {
-      record({ ms: performance.now() - start, result: 'error' })
-      throw error
-    })
+  try {
+    const ret = await fn()
+    record({ ms: performance.now() - start, result: 'success' })
+    return ret
+  } catch (error: unknown) {
+    record({ ms: performance.now() - start, result: 'error' })
+    throw error
+  }
 }

--- a/src/websocket/gateway.ts
+++ b/src/websocket/gateway.ts
@@ -7,6 +7,7 @@ import { assertIsError } from '../utils/assert-is-error'
 import { logger } from '../logger'
 import type { QueueSlotId } from '../queue/types/queue-slot-id'
 import { meter } from '../otel'
+import { ValueType } from '@opentelemetry/api'
 import type { AppWebSocket } from './types'
 
 export interface ClientToServerEvents {
@@ -87,6 +88,12 @@ interface Broadcaster {
 const outgoingWsMessages = meter.createCounter('tf2pickup.websocket.outgoing_message.count', {
   description: 'Messages sent via websockets',
   unit: '1',
+})
+
+const broadcastRecipients = meter.createHistogram('tf2pickup.websocket.broadcast.recipients', {
+  description: 'Number of clients receiving each broadcast call',
+  unit: '{clients}',
+  valueType: ValueType.INT,
 })
 
 async function sendSafe(client: AppWebSocket, msg: string) {
@@ -183,6 +190,7 @@ class BroadcastOperator {
   }
 
   send(message: MessageFn) {
+    let recipients = 0
     this.app.websocketServer.clients.forEach(async client => {
       const socket = client as AppWebSocket
       if ('authenticated' in this.filters) {
@@ -202,8 +210,10 @@ class BroadcastOperator {
           return
         }
       }
+      recipients++
       await send(socket, message)
     })
+    broadcastRecipients.record(recipients)
   }
 }
 
@@ -221,9 +231,12 @@ export class Gateway extends EventEmitter implements Broadcaster {
   }
 
   broadcast(message: MessageFn) {
+    let recipients = 0
     this.app.websocketServer.clients.forEach(async client => {
+      recipients++
       await send(client as AppWebSocket, message)
     })
+    broadcastRecipients.record(recipients)
   }
 
   to(filter: UserFilters): BroadcastOperator {


### PR DESCRIPTION
Adds three histograms to pinpoint bottlenecks in the queue WebSocket flow:
- `tf2pickup.queue.ws_call.duration`: full time per WS operation (join/leave/etc)
- `tf2pickup.queue.mutex_wait.duration`: time spent waiting for the queue mutex
- `tf2pickup.websocket.broadcast.recipients`: fan-out size per broadcast call