### PR TITLE
fix: export logs via OTLP

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@kitajs/ts-html-plugin": "4.1.4",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.76.0",
+    "@opentelemetry/exporter-logs-otlp-http": "0.218.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.218.0",
     "@opentelemetry/instrumentation": "0.218.0",
     "@opentelemetry/instrumentation-pino": "0.64.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@opentelemetry/auto-instrumentations-node':
         specifier: 0.76.0
         version: 0.76.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))
+      '@opentelemetry/exporter-logs-otlp-http':
+        specifier: 0.218.0
+        version: 0.218.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: 0.218.0
         version: 0.218.0(@opentelemetry/api@1.9.1)

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -11,6 +11,8 @@ import { RuntimeNodeInstrumentation } from '@opentelemetry/instrumentation-runti
 import { metrics } from '@opentelemetry/api'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto'
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
+import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs'
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici'
 
@@ -23,6 +25,7 @@ const sdk = new NodeSDK({
   metricReader: new PeriodicExportingMetricReader({
     exporter: new OTLPMetricExporter(),
   }),
+  logRecordProcessor: new BatchLogRecordProcessor(new OTLPLogExporter()),
   instrumentations: [
     new RuntimeNodeInstrumentation(),
     new HttpInstrumentation(),


### PR DESCRIPTION
## Summary

- Adds `@opentelemetry/exporter-logs-otlp-http` dependency
- Configures `OTLPLogExporter` with `BatchLogRecordProcessor` in the NodeSDK
- Pino logs are now exported via OTLP alongside traces and metrics

## Motivation

Previously, logs were only written to stdout and collected by a local filelog receiver on the SigNoz host. This meant remote deployments (e.g. tf2pickup.fi) had no logs in SigNoz at all.

With OTLP log export, any deployment that sets `OTEL_EXPORTER_OTLP_ENDPOINT` will automatically ship logs — no per-host collector setup required.

## Follow-up (server-side)

The `filelog` receiver in `otel-collector-config-2.yaml` on the SigNoz host that reads tf2pickup Docker container logs should be removed to avoid duplicate log entries for tf2pickup.pl.

## Test plan

- [ ] Deploy to tf2pickup.fi and verify `tf2pickup-fi` appears in the SigNoz logs service name filter
- [ ] Verify tf2pickup.pl logs are not duplicated after removing the filelog receiver rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)