### PR TITLE
fix: play mention notification sound in background tabs

### DIFF
--- a/src/html/@client/mention-notification.ts
+++ b/src/html/@client/mention-notification.ts
@@ -36,7 +36,7 @@ function setMention(event: CustomEvent<{ volume: number }>) {
 
   hasMention = true
 
-  currentSound = new Howl({ src: ['/sounds/mention.webm'], volume: event.detail.volume })
+  currentSound = new Howl({ src: ['/sounds/mention.webm'], volume: event.detail.volume, html5: true })
   currentSound.play()
 
   chatTabButton()?.classList.add('has-mention')

--- a/src/html/@client/mention-notification.ts
+++ b/src/html/@client/mention-notification.ts
@@ -36,7 +36,11 @@ function setMention(event: CustomEvent<{ volume: number }>) {
 
   hasMention = true
 
-  currentSound = new Howl({ src: ['/sounds/mention.webm'], volume: event.detail.volume, html5: true })
+  currentSound = new Howl({
+    src: ['/sounds/mention.webm'],
+    volume: event.detail.volume,
+    html5: true,
+  })
   currentSound.play()
 
   chatTabButton()?.classList.add('has-mention')


### PR DESCRIPTION
## Summary

- Use `html5: true` when constructing the `Howl` for the chat mention sound
- Chrome suspends the Web Audio `AudioContext` when a tab is backgrounded, queuing any sounds until the tab regains focus
- HTML5 audio (`<audio>` element) is not subject to this restriction and plays immediately regardless of tab visibility
- The ready-up sound works in background tabs because `new Notification()` grants the site Chrome's autoplay permission; the mention sound has no such notification, so it relied solely on the AudioContext

## Test plan

- [ ] Open the site in a background tab, have another user mention you in chat — the sound should play immediately without switching to the tab