### PR TITLE
fix: exclude tsx@4.22.2 from minimumReleaseAge policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,9 @@ allowBuilds:
   esbuild: true
   protobufjs: true
 
+minimumReleaseAgeExclude:
+  - tsx@4.22.2
+
 publicHoistPattern:
   - 'playwright*'
   - 'bson'


### PR DESCRIPTION
## Summary

- pnpm v11 defaults to a 24-hour `minimumReleaseAge` supply-chain policy
- tsx@4.22.2 was published ~23h before CI ran, causing `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`
- Adds `tsx@4.22.2` to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` to unblock CI while keeping the policy active for all other packages

The `minimumReleaseAge: "3 days"` added to `renovate.json` in the previous commit prevents Renovate from creating PRs for packages newer than 3 days, so this situation won't recur.

## Test plan

- [ ] CI passes on this PR
- [ ] `pnpm install` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)