### PR TITLE
fix: play ready-up sound in background tabs

### DIFF
--- a/src/html/@client/play-sound.ts
+++ b/src/html/@client/play-sound.ts
@@ -14,6 +14,7 @@ function maybePlaySound(element: Element) {
   const sound = new Howl({
     src: [src],
     volume,
+    html5: true,
   })
   sound.play()
 }


### PR DESCRIPTION
## Summary

- Use `html5: true` when constructing the `Howl` in the `play-sound` HTMX extension
- Chrome suspends the Web Audio `AudioContext` when a tab is backgrounded, queuing sounds until the tab regains focus
- HTML5 audio (`<audio>` element) is not subject to this restriction and plays immediately regardless of tab visibility
- Applies the same fix as #623 (mention notification sound) to the ready-up / queue sounds

## Test plan

- [ ] Open the site in a background tab, have the queue fill up — the ready-up sound should play immediately without switching to the tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)