### PR TITLE
fix: retry server configuration up to 3 times on error

### DIFF
--- a/src/games/rcon/configure.ts
+++ b/src/games/rcon/configure.ts
@@ -1,5 +1,5 @@
 import { minutesToMilliseconds, secondsToMilliseconds } from 'date-fns'
-import { deburr, delay } from 'es-toolkit'
+import { deburr, delay, retry } from 'es-toolkit'
 import { configuration } from '../../configuration'
 import { collections } from '../../database/collections'
 import { GameEventType } from '../../database/models/game-event.model'
@@ -42,7 +42,28 @@ export async function configure(gameNumber: GameNumber): Promise<void> {
     if (!game) throw errors.notFound(`Game #${gameNumber} not found`)
     const timeout = AbortSignal.timeout(await configureTimeout(game))
     const signal = AbortSignal.any([controller.signal, timeout])
-    await doConfigure(game, { signal })
+    let configureAttempt = 0
+    await retry(
+      async () => {
+        if (configureAttempt++ > 0) {
+          game = await collections.games.findOne({ number: gameNumber })
+          if (!game) throw errors.notFound(`Game #${gameNumber} not found`)
+        }
+        await doConfigure(game!, { signal })
+      },
+      {
+        retries: 2,
+        delay: secondsToMilliseconds(5),
+        signal,
+        shouldRetry: (error, attempt) => {
+          logger.warn(
+            { error, attempt: attempt + 1 },
+            `configure attempt ${attempt + 1} failed for game #${gameNumber}, retrying...`,
+          )
+          return true
+        },
+      },
+    )
   } catch (error) {
     logger.error({ error }, `error configuring game #${gameNumber}`)
     if (game) {

--- a/src/games/rcon/configure.ts
+++ b/src/games/rcon/configure.ts
@@ -27,6 +27,7 @@ import { players } from '../../players'
 import type { RconCommand } from '../../shared/types/rcon-command'
 
 const configurators = new Map<GameNumber, AbortController>()
+const configureRetries = 2
 
 export function cancelConfigure(gameNumber: GameNumber) {
   configurators.get(gameNumber)?.abort()
@@ -52,15 +53,21 @@ export async function configure(gameNumber: GameNumber): Promise<void> {
         await doConfigure(game!, { signal })
       },
       {
-        retries: 2,
+        retries: configureRetries,
         delay: secondsToMilliseconds(5),
         signal,
         shouldRetry: (error, attempt) => {
+          if (error instanceof Error && 'statusCode' in error) {
+            return false
+          }
+          const willRetry = attempt < configureRetries
           logger.warn(
             { error, attempt: attempt + 1 },
-            `configure attempt ${attempt + 1} failed for game #${gameNumber}, retrying...`,
+            willRetry
+              ? `configure attempt ${attempt + 1} failed for game #${gameNumber}, retrying...`
+              : `configure attempt ${attempt + 1} failed for game #${gameNumber}`,
           )
-          return true
+          return willRetry
         },
       },
     )


### PR DESCRIPTION
## Summary

- Wraps `doConfigure` with `retry()` from es-toolkit (2 retries = 3 total attempts)
- Re-fetches game from DB before each retry to pick up any state changes (e.g. tf2QuickServer task resolution)
- Logs a warning on each failed attempt via `shouldRetry`; abort/timeout signals cancel retries natively via the `signal` option

## Test plan

- [ ] Trigger a game server configuration that fails transiently — verify it retries up to 3 times with ~5s gaps before giving up
- [ ] Verify that aborting (cancel or timeout) stops retries immediately without waiting for the next attempt
- [ ] Verify that after 3 failures the `game:gameServerConfigureFailed` event is emitted and the DB event is recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)