### PR TITLE
fix: add migration to fix players with missing avatar fields

### DIFF
--- a/src/migrations/022-fix-missing-player-avatars.ts
+++ b/src/migrations/022-fix-missing-player-avatars.ts
@@ -1,0 +1,61 @@
+import SteamAPI from 'steamapi'
+import { collections } from '../database/collections'
+import { environment } from '../environment'
+import { logger } from '../logger'
+import { steamId64 } from '../shared/schemas/steam-id-64'
+
+const steamApi = new SteamAPI(environment.STEAM_API_KEY)
+
+export async function up() {
+  const players = await collections.players
+    .find(
+      {
+        $or: [
+          { avatar: { $exists: false } },
+          { 'avatar.small': { $exists: false } },
+          { 'avatar.medium': { $exists: false } },
+          { 'avatar.large': { $exists: false } },
+        ],
+      },
+      { projection: { steamId: 1 } },
+    )
+    .toArray()
+
+  logger.info(`found ${players.length} players with missing avatar fields`)
+
+  const batchSize = 100
+  let updated = 0
+
+  for (let i = 0; i < players.length; i += batchSize) {
+    const batch = players.slice(i, i + batchSize)
+    const steamIds = batch.map(p => p.steamId)
+
+    let summaries: Awaited<ReturnType<typeof steamApi.getUserSummary>>
+    try {
+      summaries = await steamApi.getUserSummary(steamIds)
+    } catch (error) {
+      logger.warn({ steamIds, error }, 'failed to fetch Steam summaries for batch, skipping')
+      continue
+    }
+
+    const summaryArray = Array.isArray(summaries) ? summaries : [summaries]
+
+    for (const summary of summaryArray) {
+      await collections.players.updateOne(
+        { steamId: steamId64.parse(summary.steamID) },
+        {
+          $set: {
+            avatar: {
+              small: summary.avatar.small,
+              medium: summary.avatar.medium,
+              large: summary.avatar.large,
+            },
+          },
+        },
+      )
+      updated++
+    }
+  }
+
+  logger.info(`fixed avatars for ${updated} players`)
+}


### PR DESCRIPTION
## Summary

- Adds migration `022-fix-missing-player-avatars` that finds all players where `avatar` is missing entirely or any of `avatar.small`, `avatar.medium`, or `avatar.large` fields are absent
- Fetches the missing data from the Steam API in batches of 100 (the API maximum per request)
- Updates each player's avatar document with the three URL strings returned by Steam
- Failed batches are logged and skipped rather than aborting the whole migration

## Test plan

- [ ] Run migration locally against a dev database with players that have incomplete avatar fields and verify the avatars are filled in
- [ ] Confirm players without any avatar issues are not modified
- [ ] Confirm the migration logs the correct count of fixed players

🤖 Generated with [Claude Code](https://claude.com/claude-code)