### PR TITLE
fix: resume AudioContext before playing sounds in background tabs

### DIFF
--- a/src/html/@client/mention-notification.ts
+++ b/src/html/@client/mention-notification.ts
@@ -1,4 +1,4 @@
-import { Howl } from 'howler'
+import { Howl, Howler } from 'howler'
 
 const MENTION_PREFIX = '★ '
 
@@ -39,9 +39,16 @@ function setMention(event: CustomEvent<{ volume: number }>) {
   currentSound = new Howl({
     src: ['/sounds/mention.webm'],
     volume: event.detail.volume,
-    html5: true,
   })
-  currentSound.play()
+
+  const ctx = Howler.ctx
+  if (ctx.state === 'suspended') {
+    void ctx.resume().then(() => {
+      currentSound?.play()
+    })
+  } else {
+    currentSound.play()
+  }
 
   chatTabButton()?.classList.add('has-mention')
   applyMentionTitle()

--- a/src/html/@client/play-sound.ts
+++ b/src/html/@client/play-sound.ts
@@ -1,5 +1,5 @@
 import htmx from './htmx'
-import { Howl } from 'howler'
+import { Howl, Howler } from 'howler'
 
 function maybePlaySound(element: Element) {
   const src = element.getAttribute('data-play-sound-src') ?? element.getAttribute('play-sound-src')
@@ -14,9 +14,16 @@ function maybePlaySound(element: Element) {
   const sound = new Howl({
     src: [src],
     volume,
-    html5: true,
   })
-  sound.play()
+
+  const ctx = Howler.ctx
+  if (ctx.state === 'suspended') {
+    void ctx.resume().then(() => {
+      sound.play()
+    })
+  } else {
+    sound.play()
+  }
 }
 
 htmx.defineExtension('play-sound', {


### PR DESCRIPTION
## Summary

- Remove `html5: true` from Howler in both `play-sound` and `mention-notification` extensions, reverting to the Web Audio API
- Before calling `sound.play()`, check if `Howler.ctx.state === 'suspended'` and explicitly call `ctx.resume()` first

## Why `html5: true` didn't work

The previous fix (#627) switched to HTML5 Audio to avoid `AudioContext` suspension in background tabs. But it introduced a different timing problem: Howler creates a new `<audio>` element on each play call, which must fetch the sound file from the network. By the time that fetch completes, the browser's autoplay policy rejects or queues the `audio.play()` call because the tab is not in focus — causing the sound to play only once the tab regains focus.

## Why this fix works

The Web Audio API uses a single `AudioContext` that Howler unlocks on first user interaction (via `autoUnlock`). Once unlocked, `AudioContext.resume()` can be called programmatically without a user gesture, even in background tabs. This lets sounds play immediately when the ready-up event fires, regardless of tab visibility.

## Test plan

- [ ] Open the site in a background tab and wait for the queue to fill — the ready-up sound should play immediately without switching to the tab
- [ ] Verify mention notification sound still plays correctly when the chat tab is not visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)