### PR TITLE
refactor: pre-load sounds via data-sound-src, play via data-sound-play

### DIFF
--- a/src/games/views/html/server-ready-notification.tsx
+++ b/src/games/views/html/server-ready-notification.tsx
@@ -6,8 +6,8 @@ export async function ServerReadyNotification(actor: SteamId64) {
   return (
     <div id="notify-container" hx-swap-oob="beforeend">
       <div
-        play-sound-src="/sounds/fight.webm"
-        play-sound-volume={player.preferences.soundVolume ?? '1.0'}
+        data-sound-play="sound-fight"
+        data-sound-volume={player.preferences.soundVolume ?? 1.0}
       ></div>
     </div>
   )

--- a/src/html/@client/mention-notification.ts
+++ b/src/html/@client/mention-notification.ts
@@ -1,9 +1,8 @@
-import { Howl } from 'howler'
+import { playSound, stopSound } from './play-sound'
 
 const MENTION_PREFIX = '★ '
 
 let hasMention = false
-let currentSound: Howl | null = null
 
 function chatTabButton(): Element | null {
   return document.querySelector('[data-tabs-select="tab-chat"]')
@@ -35,13 +34,7 @@ function setMention(event: CustomEvent<{ volume: number }>) {
   }
 
   hasMention = true
-
-  currentSound = new Howl({
-    src: ['/sounds/mention.webm'],
-    volume: event.detail.volume,
-    html5: true,
-  })
-  currentSound.play()
+  playSound(document.getElementById('sound-mention'), event.detail.volume)
 
   chatTabButton()?.classList.add('has-mention')
   applyMentionTitle()
@@ -49,10 +42,7 @@ function setMention(event: CustomEvent<{ volume: number }>) {
 
 function clearMention() {
   hasMention = false
-
-  currentSound?.stop()
-  currentSound = null
-
+  stopSound(document.getElementById('sound-mention'))
   chatTabButton()?.classList.remove('has-mention')
   clearMentionTitle()
 }

--- a/src/html/@client/play-sound.ts
+++ b/src/html/@client/play-sound.ts
@@ -1,34 +1,59 @@
 import htmx from './htmx'
-import { Howl } from 'howler'
+import { Howl, Howler } from 'howler'
+
+const sounds = new Map<string, Howl>()
+
+function loadSound(element: Element) {
+  const src = element.getAttribute('data-sound-src')
+  const { id } = element
+  if (!src || !id || sounds.has(id)) return
+  sounds.set(id, new Howl({ src: [src] }))
+}
+
+async function resumeAndPlay(sound: Howl) {
+  if (Howler.ctx.state === 'suspended') {
+    await Howler.ctx.resume()
+  }
+  sound.play()
+}
+
+export function playSound(element: Element | null, volume?: number) {
+  if (!element?.id) return
+  const sound = sounds.get(element.id)
+  if (!sound) return
+  if (volume !== undefined) sound.volume(volume)
+  void resumeAndPlay(sound)
+}
+
+export function stopSound(element: Element | null) {
+  if (!element?.id) return
+  sounds.get(element.id)?.stop()
+}
 
 function maybePlaySound(element: Element) {
-  const src = element.getAttribute('data-play-sound-src') ?? element.getAttribute('play-sound-src')
-  if (!src) {
-    return
-  }
+  const targetId = element.getAttribute('data-sound-play')
+  if (!targetId) return
+  const volumeAttr = element.getAttribute('data-sound-volume')
+  const volume = volumeAttr !== null ? parseFloat(volumeAttr) : undefined
+  playSound(document.getElementById(targetId), volume)
+}
 
-  const playVolume =
-    element.getAttribute('data-play-sound-volume') ?? element.getAttribute('play-sound-volume')
-
-  const volume = playVolume ? parseFloat(playVolume) : 1.0
-  const sound = new Howl({
-    src: [src],
-    volume,
-    html5: true,
-  })
-  sound.play()
+for (const el of document.querySelectorAll('[data-sound-src]')) {
+  loadSound(el)
 }
 
 htmx.defineExtension('play-sound', {
   onEvent: (name: string, evt: Event | CustomEvent) => {
-    if (name !== 'htmx:afterProcessNode') {
-      return true
-    }
+    if (name !== 'htmx:afterProcessNode') return true
 
     const element = (evt as CustomEvent<{ elt: Element }>).detail.elt
+    loadSound(element)
     maybePlaySound(element)
-    const children = element.querySelectorAll('[data-play-sound-src], [play-sound-src]')
-    for (const child of children) {
+
+    for (const child of element.querySelectorAll('[data-sound-src]')) {
+      loadSound(child)
+    }
+    for (const child of element.querySelectorAll('[data-sound-play]')) {
       maybePlaySound(child)
     }
     return true

--- a/src/html/@client/play-sound.ts
+++ b/src/html/@client/play-sound.ts
@@ -7,12 +7,14 @@ function loadSound(element: Element) {
   const src = element.getAttribute('data-sound-src')
   const { id } = element
   if (!src || !id || sounds.has(id)) return
+  // html5: true is intentionally omitted — HTML5 Audio fetches on every play() call,
+  // which causes autoplay rejection in background tabs before the fetch completes (#633).
   sounds.set(id, new Howl({ src: [src] }))
 }
 
 async function resumeAndPlay(sound: Howl) {
   if (Howler.ctx.state === 'suspended') {
-    await Howler.ctx.resume()
+    await Howler.ctx.resume().catch(console.warn)
   }
   sound.play()
 }

--- a/src/html/@client/play-sound.ts
+++ b/src/html/@client/play-sound.ts
@@ -1,15 +1,22 @@
 import htmx from './htmx'
 import { Howl, Howler } from 'howler'
 
-const sounds = new Map<string, Howl>()
+interface HtmxNodeInternalData {
+  sound?: Howl
+}
+
+let api: {
+  getInternalData: (elt: Element) => HtmxNodeInternalData
+}
 
 function loadSound(element: Element) {
   const src = element.getAttribute('data-sound-src')
-  const { id } = element
-  if (!src || !id || sounds.has(id)) return
+  if (!src) return
+  const internalData = api.getInternalData(element)
+  if (internalData.sound) return
   // html5: true is intentionally omitted — HTML5 Audio fetches on every play() call,
   // which causes autoplay rejection in background tabs before the fetch completes (#633).
-  sounds.set(id, new Howl({ src: [src] }))
+  internalData.sound = new Howl({ src: [src] })
 }
 
 async function resumeAndPlay(sound: Howl) {
@@ -20,16 +27,16 @@ async function resumeAndPlay(sound: Howl) {
 }
 
 export function playSound(element: Element | null, volume?: number) {
-  if (!element?.id) return
-  const sound = sounds.get(element.id)
+  if (!element) return
+  const sound = api.getInternalData(element).sound
   if (!sound) return
   if (volume !== undefined) sound.volume(volume)
   void resumeAndPlay(sound)
 }
 
 export function stopSound(element: Element | null) {
-  if (!element?.id) return
-  sounds.get(element.id)?.stop()
+  if (!element) return
+  api.getInternalData(element).sound?.stop()
 }
 
 function maybePlaySound(element: Element) {
@@ -40,11 +47,14 @@ function maybePlaySound(element: Element) {
   playSound(document.getElementById(targetId), volume)
 }
 
-for (const el of document.querySelectorAll('[data-sound-src]')) {
-  loadSound(el)
-}
-
 htmx.defineExtension('play-sound', {
+  init: apiRef => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    api = apiRef
+    for (const el of document.querySelectorAll('[data-sound-src]')) {
+      loadSound(el)
+    }
+  },
   onEvent: (name: string, evt: Event | CustomEvent) => {
     if (name !== 'htmx:afterProcessNode') return true
 

--- a/src/html/layout.tsx
+++ b/src/html/layout.tsx
@@ -24,6 +24,14 @@ export async function Layout(
       {safeStyle ? <style type="text/css">{safeStyle}</style> : <></>}
       <div class="flex h-full flex-col">{props?.children}</div>
       <div id="notify-container"></div>
+      <div id="sound-ready-up" data-sound-src="/sounds/ready_up.webm" class="hidden"></div>
+      <div id="sound-fight" data-sound-src="/sounds/fight.webm" class="hidden"></div>
+      <div
+        id="sound-substitution"
+        data-sound-src="/sounds/cmon_tough_guy.webm"
+        class="hidden"
+      ></div>
+      <div id="sound-mention" data-sound-src="/sounds/mention.webm" class="hidden"></div>
       <ReadyUpDialog />
       <FlashMessageList />
     </>

--- a/src/queue/views/html/ready-up-dialog.tsx
+++ b/src/queue/views/html/ready-up-dialog.tsx
@@ -58,8 +58,8 @@ ReadyUpDialog.show = async (actor: SteamId64) => {
           notification-title="Ready up!"
           notification-body="A game is starting"
           notification-icon="/favicon.png"
-          play-sound-src="/sounds/ready_up.webm"
-          play-sound-volume={player.preferences.soundVolume ?? '1.0'}
+          data-sound-play="sound-ready-up"
+          data-sound-volume={player.preferences.soundVolume ?? 1.0}
         ></div>
       </div>
     </>

--- a/src/queue/views/html/substitution-requests.tsx
+++ b/src/queue/views/html/substitution-requests.tsx
@@ -58,8 +58,8 @@ SubstitutionRequests.notify = async ({
         notification-title="A substitute is needed!"
         notification-body={`Team ${slot.team} needs a substitute for ${slot.gameClass} in game #${game.number}`}
         notification-icon="/favicon.png"
-        play-sound-src="/sounds/cmon_tough_guy.webm"
-        play-sound-volume={volume}
+        data-sound-play="sound-substitution"
+        data-sound-volume={volume}
       ></div>
     </div>
   )


### PR DESCRIPTION
## Summary

- Add `data-sound-src` elements to the layout that eagerly create `Howl` instances on page load, one per sound file, keyed by element ID
- Replace `play-sound-src`/`play-sound-volume` trigger attributes with `data-sound-play="<id>"`/`data-sound-volume` across all notification components
- Export `playSound(el, volume?)` and `stopSound(el)` from the `play-sound` extension for programmatic use
- Migrate `mention-notification` to use the shared pre-loaded sound instead of creating a new `Howl` instance per mention
- Include AudioContext resume logic (`Howler.ctx.resume()` when suspended) to handle background-tab playback

## Motivation

Previously each notification created a `new Howl({ src })` at play time, requiring a network fetch and decode before the sound could play. Pre-loading eliminates that latency window and reuses a single `Howl` instance per sound. This also consolidates two divergent sound paths (`play-sound` extension and `mention-notification`) into a single mechanism.

## Test plan

- [ ] Open the site in a background tab, wait for the queue to fill — the ready-up sound plays immediately without switching to the tab
- [ ] Trigger a server-ready notification — fight sound plays correctly
- [ ] Trigger a substitution request — cmon_tough_guy sound plays correctly
- [ ] Receive a chat mention in a non-visible chat tab — mention sound plays and tab badge appears
- [ ] Navigate to the chat tab — mention sound stops and badge clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)