### PR TITLE
fix(players): move player verified checkbox into admin toolbox header

### DIFF
--- a/src/players/views/html/admin-toolbox.tsx
+++ b/src/players/views/html/admin-toolbox.tsx
@@ -18,6 +18,7 @@ import type { Tf2ClassName } from '../../../shared/types/tf2-class-name'
 import { pluckLastEdit } from '../../pluck-last-edit'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
 import { makeSkillSuggestions } from '../../make-skill-suggestions'
+import { PlayerVerifiedCheckbox } from './player-verified-checkbox'
 
 export async function AdminToolbox(props: {
   player: Pick<
@@ -50,28 +51,9 @@ export async function AdminToolbox(props: {
         }
       </script>
 
-      {requireVerification && (
-        <div class="bg-abru-light-5 flex items-center gap-3 rounded-md px-3 py-2">
-          <label for="playerVerified" class="cursor-pointer text-sm select-none">
-            Player verified
-          </label>
-          <input
-            type="checkbox"
-            id="playerVerified"
-            name="verified"
-            value="true"
-            checked={props.player.verified}
-            hx-put={`/players/${player.steamId}/verify`}
-            hx-trigger="change"
-            hx-target="#player-admin-toolbox"
-            hx-swap="outerHTML"
-            hx-include="this"
-          />
-        </div>
-      )}
-
       <div class="player-admin-toolbox">
         <div class="admin-toolbox-header">
+          {requireVerification && <PlayerVerifiedCheckbox player={player} />}
           <BanStatus bans={player.bans} steamId={player.steamId} />
           <a
             href={`/players/${player.steamId}/edit`}

--- a/src/players/views/html/player-verified-checkbox.tsx
+++ b/src/players/views/html/player-verified-checkbox.tsx
@@ -1,0 +1,30 @@
+import type { PlayerModel } from '../../../database/models/player.model'
+
+export function PlayerVerifiedCheckbox(props: {
+  player: Pick<PlayerModel, 'steamId' | 'verified'>
+}) {
+  const { player } = props
+  return (
+    <div
+      id="player-verified-checkbox"
+      class="bg-abru-light-5 flex shrink-0 items-center gap-3 rounded-md px-3 py-2"
+    >
+      <label for="playerVerified" class="cursor-pointer text-sm select-none">
+        Player verified
+      </label>
+      <input
+        type="checkbox"
+        id="playerVerified"
+        name="verified"
+        value="true"
+        checked={player.verified}
+        hx-put={`/players/${player.steamId}/verify`}
+        hx-trigger="change"
+        hx-target="#player-verified-checkbox"
+        hx-swap="outerHTML transition:false"
+        hx-include="this"
+        hx-disabled-elt="this"
+      />
+    </div>
+  )
+}

--- a/src/routes/players/:steamId/verify/index.ts
+++ b/src/routes/players/:steamId/verify/index.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { players } from '../../../../players'
 import { steamId64 } from '../../../../shared/schemas/steam-id-64'
 import { routes } from '../../../../utils/routes'
-import { AdminToolbox } from '../../../../players/views/html/admin-toolbox'
+import { PlayerVerifiedCheckbox } from '../../../../players/views/html/player-verified-checkbox'
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export default routes(async app => {
@@ -28,15 +28,8 @@ export default routes(async app => {
       const { steamId } = request.params
       const { verified } = request.body
       await players.setVerified(steamId, verified, request.user!.player.steamId)
-      const player = await players.bySteamId(steamId, [
-        'steamId',
-        'skill',
-        'skillHistory',
-        'verified',
-        'elo',
-        'stats',
-      ])
-      await reply.html(AdminToolbox({ player }))
+      const player = await players.bySteamId(steamId, ['steamId', 'verified'])
+      await reply.html(PlayerVerifiedCheckbox({ player }))
     },
   )
 })


### PR DESCRIPTION
## Summary

- Moves the "Player verified" checkbox inside the admin toolbox header row (before the ban status pill), so it is visually part of the toolbox rather than floating above it
- Extracts the checkbox into a dedicated `PlayerVerifiedCheckbox` component
- The verify endpoint now returns only the checkbox fragment (instead of re-rendering the whole toolbox), targets `#player-verified-checkbox` with `hx-swap="outerHTML transition:false"` — the `transition:false` prevents HTMX from triggering a view transition that caused the game list to flicker on toggle

## Test plan

- [ ] Open a player profile as admin with `queue.require_player_verification` enabled
- [ ] Confirm the "Player verified" checkbox appears inside the admin toolbox header, to the left of the ban status
- [ ] Toggle the checkbox — verify only the checkbox updates (no full-page flicker, no game list flicker)
- [ ] Confirm the checkbox is disabled while the request is in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)