### PR TITLE
fix: show informative page when Steam profile is private

### DIFF
--- a/src/auth/plugins/steam.ts
+++ b/src/auth/plugins/steam.ts
@@ -6,6 +6,8 @@ import { logger } from '../../logger'
 import type { SteamId64 } from '../../shared/types/steam-id-64'
 import { players } from '../../players'
 import type { User } from '../types/user'
+import { SteamApiError } from '../../steam/errors/steam-api.error'
+import { PrivateSteamProfilePage } from '../views/html/private-steam-profile.page'
 
 declare module '@fastify/secure-session' {
   interface SessionData {
@@ -84,7 +86,17 @@ export default fp(
       const user = await steamApi.getUserSummary(steamId)
 
       logger.debug({ user }, 'user logged in')
-      const player = await players.upsert(user)
+
+      let player
+      try {
+        player = await players.upsert(user)
+      } catch (error) {
+        if (error instanceof SteamApiError) {
+          return reply.code(403).html(PrivateSteamProfilePage())
+        }
+        throw error
+      }
+
       request.session.set('steamId', player.steamId)
 
       const returnUrl = environment.WEBSITE_URL

--- a/src/auth/views/html/private-steam-profile.page.tsx
+++ b/src/auth/views/html/private-steam-profile.page.tsx
@@ -1,0 +1,38 @@
+import { Footer } from '../../../html/components/footer'
+import { NavigationBar } from '../../../html/components/navigation-bar'
+import { Page } from '../../../html/components/page'
+import { Layout } from '../../../html/layout'
+import { makeTitle } from '../../../html/make-title'
+
+export function PrivateSteamProfilePage() {
+  return (
+    <Layout title={makeTitle('Private Steam profile')}>
+      <NavigationBar />
+      <Page>
+        <div class="flex h-full flex-col items-center justify-center gap-6">
+          <span class="text-abru-light-75 text-[36px] font-bold">
+            Your Steam profile is private
+          </span>
+          <p class="text-abru-light-75 max-w-prose text-center">
+            We were unable to verify your TF2 in-game hours because your Steam profile or game
+            statistics are set to private. To register, please make your game details public.
+          </p>
+          <div class="flex flex-row gap-4">
+            <a
+              href="https://docs.tf2pickup.org/docs/player-registration-issues#private-steam-profile-and-game-statistics"
+              class="button px-8"
+              data-variant="accent"
+              target="_blank"
+            >
+              How to fix this
+            </a>
+            <a href="/" class="button px-8">
+              Go back home
+            </a>
+          </div>
+        </div>
+      </Page>
+      <Footer />
+    </Layout>
+  )
+}


### PR DESCRIPTION
## Summary

- When `getTf2InGameHours()` fails with a `SteamApiError` (Steam returns 403 for private profiles or hidden game statistics), the `/auth/steam/return` handler now catches it and renders a dedicated page instead of a generic 500 error
- The page explains the issue and includes a link to https://docs.tf2pickup.org/docs/player-registration-issues#private-steam-profile-and-game-statistics

## Test plan

- [ ] Log in with a Steam account that has game statistics set to private — should see the new informative page instead of a 500 error
- [ ] Log in with a normal public Steam account — should still redirect to the homepage as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)