### PR TITLE
fix(players): fix admin toolbox layout for 9v9 config

### DIFF
--- a/src/players/views/html/admin-toolbox.tsx
+++ b/src/players/views/html/admin-toolbox.tsx
@@ -74,7 +74,7 @@ export async function AdminToolbox(props: {
 
         <div class="admin-toolbox-divider" />
 
-        <div class="admin-toolbox-body">
+        <div class={['admin-toolbox-body', compact && 'compact']}>
           <div class="admin-toolbox-skill">
             {player.skill === undefined && (
               <div class="flex items-center gap-2 rounded-md bg-green-800/30 px-3 py-2 text-sm text-green-400">
@@ -100,7 +100,7 @@ export async function AdminToolbox(props: {
                   </GameClassSkillInput>
                 ))}
 
-                <div class={['skill-buttons', compact && 'compact']}>
+                <div class="skill-buttons">
                   <button type="submit" class="button" data-variant="accent" title="Save">
                     <IconDeviceFloppy size={20} />
                     <span>Save</span>

--- a/src/players/views/html/style.css
+++ b/src/players/views/html/style.css
@@ -155,8 +155,25 @@
       gap: 16px;
 
       @media (width >= theme(--breakpoint-xl)) {
-        flex-direction: row;
-        align-items: flex-start;
+        &:not(.compact) {
+          flex-direction: row;
+          align-items: flex-start;
+
+          .admin-toolbox-skill {
+            padding-right: 24px;
+          }
+
+          .admin-toolbox-sep {
+            display: block;
+            width: 1px;
+            align-self: stretch;
+            background: var(--color-abru-light-10);
+          }
+
+          .admin-toolbox-winloss {
+            padding-left: 24px;
+          }
+        }
       }
     }
 
@@ -166,31 +183,16 @@
       gap: 8px;
       flex: 1;
       min-width: 0;
-
-      @media (width >= theme(--breakpoint-xl)) {
-        padding-right: 24px;
-      }
     }
 
     .admin-toolbox-sep {
       display: none;
-
-      @media (width >= theme(--breakpoint-xl)) {
-        display: block;
-        width: 1px;
-        align-self: stretch;
-        background: var(--color-abru-light-10);
-      }
     }
 
     .admin-toolbox-winloss {
       display: flex;
       flex-direction: column;
       gap: 8px;
-
-      @media (width >= theme(--breakpoint-xl)) {
-        padding-left: 24px;
-      }
     }
 
     .skill-inputs {

--- a/src/players/views/html/win-loss-chart.tsx
+++ b/src/players/views/html/win-loss-chart.tsx
@@ -6,6 +6,10 @@ import type { SteamId64 } from '../../../shared/types/steam-id-64'
 import { Tf2ClassName } from '../../../shared/types/tf2-class-name'
 import { Tf2Team } from '../../../shared/types/tf2-team'
 
+const config6v6Threshold = 4
+const defaultLimit = 12
+const config9v9Limit = 21
+
 interface GameResult {
   result: 'win' | 'loss' | 'tie'
   score: NonNullable<GameModel['score']>
@@ -16,6 +20,7 @@ export type ChartSelection = Tf2ClassName | 'all'
 
 export async function WinLossChart(props: { steamId: SteamId64; selection?: ChartSelection }) {
   const selection = props.selection ?? 'all'
+  const limit = queue.config.classes.length > config6v6Threshold ? config9v9Limit : defaultLimit
   const games: GameResult[] = (
     await collections.games
       .find(
@@ -29,7 +34,7 @@ export async function WinLossChart(props: { steamId: SteamId64; selection?: Char
           },
           score: { $exists: true },
         },
-        { limit: 12, sort: { 'events.0.at': -1 } },
+        { limit, sort: { 'events.0.at': -1 } },
       )
       .toArray()
   ).map(game => {
@@ -45,7 +50,7 @@ export async function WinLossChart(props: { steamId: SteamId64; selection?: Char
 
   return (
     <div class="flex flex-col gap-2" id="win-loss-chart">
-      <div class="flex flex-row justify-between">
+      <div class="flex flex-row gap-4">
         <div class="game-count-selection">
           <button
             type="button"
@@ -83,7 +88,7 @@ export async function WinLossChart(props: { steamId: SteamId64; selection?: Char
           <span class="losses">L: {games.filter(({ result }) => result === 'loss').length}</span>
         </div>
       </div>
-      <div class="grid min-h-[24px] grid-cols-12 justify-around gap-1">
+      <div class="flex min-h-[24px] flex-row flex-wrap gap-1">
         {games.map(game => (
           <a class={`game-result ${game.result}`} href={`/games/${game.gameNumber}`}>
             <div class="tooltip flex flex-col whitespace-nowrap" data-placement="bottom">


### PR DESCRIPTION
## Summary

- For configs with >4 classes (9v9), the win-loss chart now renders below the skill section instead of side-by-side, matching the mobile layout
- Save/Reset buttons always show their text labels (no longer hidden in compact mode)
- Win-loss chart fetches more results to fill the wider container
- W/T/L count is now placed next to the class selector instead of being pushed to the far right

## Test plan

- [ ] Open a player profile page on a 9v9 instance and verify the admin toolbox shows skill inputs on top and win-loss chart below
- [ ] Verify Save/Reset buttons show text labels on 9v9
- [ ] Verify win-loss chart shows more results (up to 21) on 9v9
- [ ] Verify W/T/L count appears next to the class selector
- [ ] Verify 6v6 layout is unchanged (skill + win-loss side-by-side at xl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)