### PR TITLE
feat: register instance on the atlas dashboard

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -50,6 +50,12 @@ GAME_SERVER_SECRET=your_game_server_secret
 # Don't change it unless you know what you're doing.
 THUMBNAIL_SERVICE_URL=https://mapthumbnails.tf2pickup.org
 
+# atlas integration (optional)
+# Registers this instance on the atlas dashboard (https://atlas.tf2pickup.org).
+# Heartbeats are sent only when ATLAS_SECRET is set.
+#ATLAS_URL=https://atlas.tf2pickup.org
+ATLAS_SECRET=
+
 # serveme.tf integration (optional)
 # Valid endpoints are:
 # serveme.tf

--- a/src/atlas/plugins/heartbeat.ts
+++ b/src/atlas/plugins/heartbeat.ts
@@ -1,0 +1,25 @@
+import { minutesToMilliseconds, secondsToMilliseconds } from 'date-fns'
+import { debounce } from 'es-toolkit'
+import fp from 'fastify-plugin'
+import { environment } from '../../environment'
+import { events } from '../../events'
+import { safe } from '../../utils/safe'
+import { sendHeartbeat } from '../send-heartbeat'
+
+export default fp(
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async () => {
+    if (!environment.ATLAS_SECRET) {
+      return
+    }
+
+    const send = debounce(safe(sendHeartbeat), secondsToMilliseconds(3))
+    events.on('queue/slots:updated', send)
+    events.on('player:connected', send)
+    events.on('player:disconnected', send)
+
+    setInterval(safe(sendHeartbeat), minutesToMilliseconds(3)).unref()
+    safe(sendHeartbeat)()
+  },
+  { name: 'atlas heartbeat' },
+)

--- a/src/atlas/send-heartbeat.test.ts
+++ b/src/atlas/send-heartbeat.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sendHeartbeat } from './send-heartbeat'
+import { environment } from '../environment'
+import { collections } from '../database/collections'
+import { logger } from '../logger'
+
+vi.mock('../environment', () => ({
+  environment: {
+    ATLAS_URL: 'https://atlas.tf2pickup.org',
+    ATLAS_SECRET: 'supersecret',
+    WEBSITE_URL: 'https://tf2pickup.pl',
+    WEBSITE_NAME: 'tf2pickup.pl',
+    QUEUE_CONFIG: '6v6',
+  },
+}))
+
+vi.mock('../version', () => ({
+  version: '1.2.3',
+}))
+
+vi.mock('../logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('../database/collections', () => ({
+  collections: {
+    queueSlots: {
+      countDocuments: vi.fn(),
+    },
+    onlinePlayers: {
+      countDocuments: vi.fn(),
+    },
+  },
+}))
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockResolvedValue({ ok: true, status: 204 })
+  vi.mocked(collections.queueSlots.countDocuments).mockImplementation(async filter =>
+    filter ? 7 : 12,
+  )
+  vi.mocked(collections.onlinePlayers.countDocuments).mockResolvedValue(23)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('when ATLAS_SECRET is not set', () => {
+  beforeEach(() => {
+    environment.ATLAS_SECRET = undefined
+  })
+
+  afterEach(() => {
+    environment.ATLAS_SECRET = 'supersecret'
+  })
+
+  it('should not send anything', async () => {
+    await sendHeartbeat()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('when ATLAS_SECRET is set', () => {
+  it('should send the heartbeat', async () => {
+    await sendHeartbeat()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url.toString()).toBe('https://atlas.tf2pickup.org/api/heartbeat')
+    expect(init.method).toBe('PUT')
+    expect(init.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer supersecret',
+    })
+    expect(JSON.parse(init.body)).toEqual({
+      url: 'https://tf2pickup.pl',
+      name: 'tf2pickup.pl',
+      version: '1.2.3',
+      queue: {
+        config: '6v6',
+        occupied: 7,
+        capacity: 12,
+      },
+      onlinePlayers: 23,
+    })
+  })
+
+  describe('and the heartbeat is rejected', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValue({ ok: false, status: 403 })
+    })
+
+    it('should log a warning and not throw', async () => {
+      await expect(sendHeartbeat()).resolves.toBeUndefined()
+      expect(logger.warn).toHaveBeenCalledWith({ status: 403 }, 'atlas heartbeat rejected')
+    })
+  })
+})

--- a/src/atlas/send-heartbeat.ts
+++ b/src/atlas/send-heartbeat.ts
@@ -1,0 +1,41 @@
+import { secondsToMilliseconds } from 'date-fns'
+import { collections } from '../database/collections'
+import { environment } from '../environment'
+import { logger } from '../logger'
+import { version } from '../version'
+
+export async function sendHeartbeat() {
+  if (!environment.ATLAS_SECRET) {
+    return
+  }
+
+  const [occupied, capacity, onlinePlayers] = await Promise.all([
+    collections.queueSlots.countDocuments({ player: { $ne: null } }),
+    collections.queueSlots.countDocuments(),
+    collections.onlinePlayers.countDocuments(),
+  ])
+
+  const response = await fetch(new URL('/api/heartbeat', environment.ATLAS_URL), {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${environment.ATLAS_SECRET}`,
+    },
+    body: JSON.stringify({
+      url: environment.WEBSITE_URL,
+      name: environment.WEBSITE_NAME,
+      version,
+      queue: {
+        config: environment.QUEUE_CONFIG,
+        occupied,
+        capacity,
+      },
+      onlinePlayers,
+    }),
+    signal: AbortSignal.timeout(secondsToMilliseconds(10)),
+  })
+
+  if (!response.ok) {
+    logger.warn({ status: response.status }, 'atlas heartbeat rejected')
+  }
+}

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -27,6 +27,9 @@ const environmentSchema = z.object({
   GAME_SERVER_SECRET: z.string(),
   THUMBNAIL_SERVICE_URL: z.url().default('https://mapthumbnails.tf2pickup.org'),
 
+  ATLAS_URL: z.url().default('https://atlas.tf2pickup.org'),
+  ATLAS_SECRET: z.string().optional(),
+
   SERVEME_TF_API_ENDPOINT: z.string().default(KnownEndpoint.europe),
   SERVEME_TF_API_KEY: z.string().optional(),
 

--- a/src/html/components/footer.tsx
+++ b/src/html/components/footer.tsx
@@ -1,5 +1,6 @@
 import { requestContext } from '@fastify/request-context'
 import { PlayerRole } from '../../database/models/player.model'
+import { environment } from '../../environment'
 import { version as safeVersion } from '../../version'
 
 const currentYear = new Date().getFullYear()
@@ -29,6 +30,9 @@ export function Footer() {
               data-umami-event="changelog-link"
             >
               Changelog
+            </a>
+            <a href={environment.ATLAS_URL} target="_blank" data-umami-event="atlas-link">
+              Atlas
             </a>
 
             {user?.player.roles.includes(PlayerRole.admin) && <a href="/admin">Admin panel</a>}


### PR DESCRIPTION
## Summary

When `ATLAS_SECRET` is set, the instance registers itself on the **atlas** dashboard (a new service listing all online tf2pickup.org instances, to be deployed at https://atlas.tf2pickup.org) and keeps its state fresh by sending authenticated heartbeats:

- once at boot,
- every 3 minutes,
- debounced (3 s) on `queue/slots:updated`, `player:connected` and `player:disconnected` events.

Each heartbeat is a `PUT /api/heartbeat` with a `Bearer` secret, reporting the website URL/name, app version, queue config, queue occupancy/capacity and online player count. The dashboard drops an instance 12 hours after its last heartbeat.

The feature is entirely optional — when `ATLAS_SECRET` is unset (the default), the plugin registers nothing. Atlas being unreachable degrades to warn-level logs only (`safe()` + 10 s fetch timeout).

## New environment variables

- `ATLAS_URL` — defaults to `https://atlas.tf2pickup.org`
- `ATLAS_SECRET` — heartbeat secret; enables the feature when set

## Test plan

- [x] unit tests for `sendHeartbeat()` (disabled when unset, payload/headers, non-OK response logs a warning and does not throw)
- [x] verified end-to-end against a locally running atlas: instance appears on the dashboard at boot and updates on queue changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)