### PR TITLE
feat(serveme-tf): add preferred gameserver configuration

### DIFF
--- a/src/database/models/configuration-entry.model.ts
+++ b/src/database/models/configuration-entry.model.ts
@@ -245,6 +245,14 @@ export const configurationSchema = z.discriminatedUnion('key', [
     key: z.literal('serveme_tf.ban_gameservers'),
     value: z.array(z.string()).default([]),
   }),
+  z
+    .object({
+      key: z.literal('serveme_tf.preferred_gameserver'),
+      value: z.string().nullable().default(null),
+    })
+    .describe(
+      'Name of the gameserver to always pick when reserving a serveme.tf server, if available',
+    ),
   z.object({
     key: z.literal('tf2_quick_server.region'),
     value: z.string().default('sa-saopaulo-1'),

--- a/src/database/models/configuration-entry.model.ts
+++ b/src/database/models/configuration-entry.model.ts
@@ -248,7 +248,7 @@ export const configurationSchema = z.discriminatedUnion('key', [
   z
     .object({
       key: z.literal('serveme_tf.preferred_gameserver'),
-      value: z.string().nullable().default(null),
+      value: z.string().min(1).nullable().default(null),
     })
     .describe(
       'Name of the gameserver to always pick when reserving a serveme.tf server, if available',

--- a/src/serveme-tf/pick-server.test.ts
+++ b/src/serveme-tf/pick-server.test.ts
@@ -74,7 +74,7 @@ describe('pickServer()', () => {
         ).toEqual(41)
       })
 
-      it('should not pick the preferred gameserver if it is banned', async () => {
+      it('should pick the preferred gameserver even if it is banned', async () => {
         configuration.set('serveme_tf.ban_gameservers', ['FAKE_GAMESERVER_42'])
 
         expect(
@@ -82,7 +82,7 @@ describe('pickServer()', () => {
             { id: 41 as ServerId, flag: 'de', name: 'FAKE_GAMESERVER_41' },
             { id: 42 as ServerId, flag: 'de', name: 'FAKE_GAMESERVER_42' },
           ]),
-        ).toEqual(41)
+        ).toEqual(42)
       })
     })
 

--- a/src/serveme-tf/pick-server.test.ts
+++ b/src/serveme-tf/pick-server.test.ts
@@ -13,6 +13,7 @@ describe('pickServer()', () => {
   beforeEach(() => {
     configuration.set('serveme_tf.preferred_region', null)
     configuration.set('serveme_tf.ban_gameservers', [])
+    configuration.set('serveme_tf.preferred_gameserver', null)
   })
 
   describe('when name is not provided', () => {
@@ -49,6 +50,38 @@ describe('pickServer()', () => {
       it('should pick another gameserver if preferred one is unavailable', async () => {
         expect(
           await pickServer([{ id: 41 as ServerId, flag: 'de', name: 'FAKE_GAMESERVER_41' }]),
+        ).toEqual(41)
+      })
+    })
+
+    describe('when a preferred gameserver is set', () => {
+      beforeEach(() => {
+        configuration.set('serveme_tf.preferred_gameserver', 'FAKE_GAMESERVER_42')
+      })
+
+      it('should pick the preferred gameserver', async () => {
+        expect(
+          await pickServer([
+            { id: 41 as ServerId, flag: 'de', name: 'FAKE_GAMESERVER_41' },
+            { id: 42 as ServerId, flag: 'de', name: 'FAKE_GAMESERVER_42' },
+          ]),
+        ).toEqual(42)
+      })
+
+      it('should pick another gameserver if the preferred one is unavailable', async () => {
+        expect(
+          await pickServer([{ id: 41 as ServerId, flag: 'de', name: 'FAKE_GAMESERVER_41' }]),
+        ).toEqual(41)
+      })
+
+      it('should not pick the preferred gameserver if it is banned', async () => {
+        configuration.set('serveme_tf.ban_gameservers', ['FAKE_GAMESERVER_42'])
+
+        expect(
+          await pickServer([
+            { id: 41 as ServerId, flag: 'de', name: 'FAKE_GAMESERVER_41' },
+            { id: 42 as ServerId, flag: 'de', name: 'FAKE_GAMESERVER_42' },
+          ]),
         ).toEqual(41)
       })
     })

--- a/src/serveme-tf/pick-server.ts
+++ b/src/serveme-tf/pick-server.ts
@@ -29,19 +29,19 @@ export async function pickServer(servers: ServerData[], name?: string): Promise<
     return server.id
   }
 
-  const bannedServers = await configuration.get('serveme_tf.ban_gameservers')
-
-  const notBanned = servers.filter(s => bannedServers.every(ban => !s.name.includes(ban)))
-
   const preferredGameServer = await configuration.get('serveme_tf.preferred_gameserver')
   if (preferredGameServer !== null) {
-    const preferred = notBanned.find(s => s.name === preferredGameServer)
+    const preferred = servers.find(s => s.name === preferredGameServer)
     if (preferred) {
       return preferred.id
     }
   }
 
-  const validServers = await byFilterRegion(notBanned)
+  const bannedServers = await configuration.get('serveme_tf.ban_gameservers')
+
+  const validServers = (await byFilterRegion(servers)).filter(s =>
+    bannedServers.every(ban => !s.name.includes(ban)),
+  )
 
   if (validServers.length === 0) {
     throw errors.notFound('could not find any gameservers meeting given criteria')

--- a/src/serveme-tf/pick-server.ts
+++ b/src/serveme-tf/pick-server.ts
@@ -31,9 +31,17 @@ export async function pickServer(servers: ServerData[], name?: string): Promise<
 
   const bannedServers = await configuration.get('serveme_tf.ban_gameservers')
 
-  const validServers = (await byFilterRegion(servers)).filter(s =>
-    bannedServers.every(ban => !s.name.includes(ban)),
-  )
+  const notBanned = servers.filter(s => bannedServers.every(ban => !s.name.includes(ban)))
+
+  const preferredGameServer = await configuration.get('serveme_tf.preferred_gameserver')
+  if (preferredGameServer !== null) {
+    const preferred = notBanned.find(s => s.name === preferredGameServer)
+    if (preferred) {
+      return preferred.id
+    }
+  }
+
+  const validServers = await byFilterRegion(notBanned)
 
   if (validServers.length === 0) {
     throw errors.notFound('could not find any gameservers meeting given criteria')


### PR DESCRIPTION
## Summary
- Adds a `serveme_tf.preferred_gameserver` configuration entry (string, default `null`)
- When set to a server's name, automatic serveme.tf reservations are pinned to that exact gameserver, falling back to the existing region-preference + random selection if it's unavailable or banned
- No dedicated admin UI — manage via Admin → View for Nerds (`/admin/view-for-nerds`), which lists all configuration entries automatically

## Test plan
- [x] `pnpm test -- src/serveme-tf/pick-server.test.ts` — new tests cover pinning, fallback when unavailable, and skipping a banned preferred server
- [x] `pnpm lint`