### PR TITLE
fix(atlas): report live games count in the heartbeat

### DIFF
--- a/src/atlas/send-heartbeat.test.ts
+++ b/src/atlas/send-heartbeat.test.ts
@@ -33,6 +33,9 @@ vi.mock('../database/collections', () => ({
     onlinePlayers: {
       countDocuments: vi.fn(),
     },
+    games: {
+      countDocuments: vi.fn(),
+    },
   },
 }))
 
@@ -41,10 +44,11 @@ const fetchMock = vi.fn()
 beforeEach(() => {
   vi.stubGlobal('fetch', fetchMock)
   fetchMock.mockResolvedValue({ ok: true, status: 204 })
-  vi.mocked(collections.queueSlots.countDocuments).mockImplementation(async filter =>
+  vi.mocked(collections.queueSlots.countDocuments).mockImplementation(async (filter?: unknown) =>
     filter ? 7 : 12,
   )
   vi.mocked(collections.onlinePlayers.countDocuments).mockResolvedValue(23)
+  vi.mocked(collections.games.countDocuments).mockResolvedValue(2)
 })
 
 afterEach(() => {
@@ -89,6 +93,7 @@ describe('when ATLAS_SECRET is set', () => {
         capacity: 12,
       },
       onlinePlayers: 23,
+      liveGames: 2,
     })
   })
 

--- a/src/atlas/send-heartbeat.ts
+++ b/src/atlas/send-heartbeat.ts
@@ -1,5 +1,6 @@
 import { secondsToMilliseconds } from 'date-fns'
 import { collections } from '../database/collections'
+import { GameState } from '../database/models/game.model'
 import { environment } from '../environment'
 import { logger } from '../logger'
 import { version } from '../version'
@@ -9,10 +10,15 @@ export async function sendHeartbeat() {
     return
   }
 
-  const [occupied, capacity, onlinePlayers] = await Promise.all([
+  const [occupied, capacity, onlinePlayers, liveGames] = await Promise.all([
     collections.queueSlots.countDocuments({ player: { $ne: null } }),
     collections.queueSlots.countDocuments(),
     collections.onlinePlayers.countDocuments(),
+    collections.games.countDocuments({
+      state: {
+        $in: [GameState.created, GameState.configuring, GameState.launching, GameState.started],
+      },
+    }),
   ])
 
   const response = await fetch(new URL('/api/heartbeat', environment.ATLAS_URL), {
@@ -31,6 +37,7 @@ export async function sendHeartbeat() {
         capacity,
       },
       onlinePlayers,
+      liveGames,
     }),
     signal: AbortSignal.timeout(secondsToMilliseconds(10)),
   })


### PR DESCRIPTION
Include the number of live games (created, configuring, launching or started) in the heartbeat sent to the atlas dashboard, so atlas can mark instances that have a game running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)