### PR TITLE
fix: notify on chat mutes and chat mute revokes

### DIFF
--- a/src/activity-log/fetch-players.ts
+++ b/src/activity-log/fetch-players.ts
@@ -10,7 +10,9 @@ export async function fetchPlayers(logs: ActivityLogEntryModel[]): Promise<Map<S
       log.type === 'player name change' ||
       log.type === 'player skill change' ||
       log.type === 'ban added' ||
-      log.type === 'ban revoked'
+      log.type === 'ban revoked' ||
+      log.type === 'chat mute added' ||
+      log.type === 'chat mute revoked'
     ) {
       ids.add(log.player)
     }
@@ -24,6 +26,12 @@ export async function fetchPlayers(logs: ActivityLogEntryModel[]): Promise<Map<S
       ids.add(log.actor)
     }
     if (log.type === 'ban revoked') {
+      ids.add(log.actor)
+    }
+    if (log.type === 'chat mute added' && log.actor !== 'bot') {
+      ids.add(log.actor)
+    }
+    if (log.type === 'chat mute revoked') {
       ids.add(log.actor)
     }
     if (log.type === 'configuration change' && log.actor !== 'bot') {

--- a/src/admin/activity-log/views/html/activity-log-entry-list.tsx
+++ b/src/admin/activity-log/views/html/activity-log-entry-list.tsx
@@ -25,6 +25,8 @@ const typeLabels: Record<ActivityLogEntryType, string> = {
   'configuration change': 'Config change',
   'ban added': 'Ban added',
   'ban revoked': 'Ban revoked',
+  'chat mute added': 'Chat mute added',
+  'chat mute revoked': 'Chat mute revoked',
   'map pool change': 'Map pool change',
   'map scramble': 'Map scramble',
   'game reconfigured': 'Game reconfigured',
@@ -40,6 +42,8 @@ const typeColors: Record<ActivityLogEntryType, string> = {
   'configuration change': 'text-purple-400',
   'ban added': 'text-red-400',
   'ban revoked': 'text-orange-400',
+  'chat mute added': 'text-red-300',
+  'chat mute revoked': 'text-orange-300',
   'map pool change': 'text-teal-400',
   'map scramble': 'text-yellow-400',
   'game reconfigured': 'text-sky-400',
@@ -177,6 +181,8 @@ function getPlayer(log: ActivityLogEntryModel): SteamId64 | undefined {
     log.type === 'player skill change' ||
     log.type === 'ban added' ||
     log.type === 'ban revoked' ||
+    log.type === 'chat mute added' ||
+    log.type === 'chat mute revoked' ||
     log.type === 'substitute requested'
   ) {
     return log.player
@@ -189,6 +195,8 @@ function getActor(log: ActivityLogEntryModel): SteamId64 | 'bot' | undefined {
   if (log.type === 'player skill change' || log.type === 'map scramble') return log.actor
   if (log.type === 'ban added') return log.actor
   if (log.type === 'ban revoked') return log.actor
+  if (log.type === 'chat mute added') return log.actor
+  if (log.type === 'chat mute revoked') return log.actor
   if (log.type === 'configuration change') return log.actor
   if (log.type === 'substitute requested') return log.actor
   if (log.type === 'queue cleared') return log.actor
@@ -237,6 +245,27 @@ function Details(props: { log: ActivityLogEntryModel; playerNames: Map<SteamId64
   }
 
   if (log.type === 'ban revoked') {
+    return (
+      <span>
+        <span class="text-abru-light-50">Reason was: </span>
+        <span safe>{log.reason}</span>
+      </span>
+    )
+  }
+
+  if (log.type === 'chat mute added') {
+    return (
+      <span>
+        <span safe>{log.reason}</span>
+        <span class="text-abru-light-50">
+          {' · expires '}
+          <span safe>{log.end.toLocaleDateString()}</span>
+        </span>
+      </span>
+    )
+  }
+
+  if (log.type === 'chat mute revoked') {
     return (
       <span>
         <span class="text-abru-light-50">Reason was: </span>

--- a/src/admin/activity-log/views/html/activity-log.page.tsx
+++ b/src/admin/activity-log/views/html/activity-log.page.tsx
@@ -24,6 +24,8 @@ const typeOptions: { value: ActivityLogEntryType; label: string }[] = [
   { value: 'configuration change', label: 'Configuration change' },
   { value: 'ban added', label: 'Ban added' },
   { value: 'ban revoked', label: 'Ban revoked' },
+  { value: 'chat mute added', label: 'Chat mute added' },
+  { value: 'chat mute revoked', label: 'Chat mute revoked' },
   { value: 'map pool change', label: 'Map pool changed' },
   { value: 'map scramble', label: 'Maps scrambled' },
   { value: 'game reconfigured', label: 'Game reconfigured' },

--- a/src/database/models/activity-log-entry.model.ts
+++ b/src/database/models/activity-log-entry.model.ts
@@ -46,6 +46,24 @@ export interface BanRevokedEntry {
   reason: string
 }
 
+export interface ChatMuteAddedEntry {
+  type: 'chat mute added'
+  timestamp: Date
+  player: SteamId64
+  actor: SteamId64 | 'bot'
+  reason: string
+  start: Date
+  end: Date
+}
+
+export interface ChatMuteRevokedEntry {
+  type: 'chat mute revoked'
+  timestamp: Date
+  player: SteamId64
+  actor: SteamId64
+  reason: string
+}
+
 export interface MapPoolChangeEntry {
   type: 'map pool change'
   timestamp: Date
@@ -105,6 +123,8 @@ export type ActivityLogEntryModel =
   | ConfigurationChangeEntry
   | BanAddedEntry
   | BanRevokedEntry
+  | ChatMuteAddedEntry
+  | ChatMuteRevokedEntry
   | MapPoolChangeEntry
   | MapScrambleEntry
   | GameReconfiguredEntry
@@ -121,6 +141,8 @@ export type ActivityLogInput =
   | Omit<ConfigurationChangeEntry, 'timestamp'>
   | Omit<BanAddedEntry, 'timestamp'>
   | Omit<BanRevokedEntry, 'timestamp'>
+  | Omit<ChatMuteAddedEntry, 'timestamp'>
+  | Omit<ChatMuteRevokedEntry, 'timestamp'>
   | Omit<MapPoolChangeEntry, 'timestamp'>
   | Omit<GameReconfiguredEntry, 'timestamp'>
   | Omit<GameServerReassignedEntry, 'timestamp'>

--- a/src/discord/plugins/notify-player-chat-mutes.ts
+++ b/src/discord/plugins/notify-player-chat-mutes.ts
@@ -1,0 +1,105 @@
+import fp from 'fastify-plugin'
+import { events } from '../../events'
+import { toAdmins } from '../to-admins'
+import { EmbedBuilder, type EmbedAuthorOptions } from 'discord.js'
+import { players } from '../../players'
+import { isBot } from '../../shared/types/bot'
+import { environment } from '../../environment'
+import { formatDistanceToNow } from 'date-fns'
+import { client } from '../client'
+import { safe } from '../../utils/safe'
+
+export default fp(
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async () => {
+    if (!client) {
+      return
+    }
+
+    events.on(
+      'player/chatMute:added',
+      safe(async ({ player, chatMute }) => {
+        let author: EmbedAuthorOptions
+        if (isBot(chatMute.actor)) {
+          author = { name: 'tf2pickup.org bot' }
+        } else {
+          const admin = await players.bySteamId(chatMute.actor, [
+            'name',
+            'steamId',
+            'avatar.medium',
+          ])
+          author = {
+            name: admin.name,
+            iconURL: admin.avatar.medium,
+            url: `${environment.WEBSITE_URL}/players/${admin.steamId}`,
+          }
+        }
+
+        const p = await players.bySteamId(player, ['name', 'steamId', 'avatar.large'])
+        await toAdmins({
+          embeds: [
+            new EmbedBuilder()
+              .setColor('#dc3545')
+              .setAuthor(author)
+              .setTitle('Player chat mute added')
+              .setThumbnail(p.avatar.large)
+              .setDescription(
+                [
+                  `Player: **[${p.name}](${environment.WEBSITE_URL}/players/${p.steamId})**`,
+                  `Reason: **${chatMute.reason}**`,
+                  `Ends: **${formatDistanceToNow(chatMute.end, { addSuffix: true })}**`,
+                ].join('\n'),
+              )
+              .setFooter({
+                text: environment.WEBSITE_NAME,
+                iconURL: `${environment.WEBSITE_URL}/favicon.png`,
+              })
+              .setTimestamp(),
+          ],
+        })
+      }),
+    )
+
+    events.on(
+      'player/chatMute:revoked',
+      safe(async ({ player, chatMute, admin }) => {
+        let author: EmbedAuthorOptions
+        if (isBot(admin)) {
+          author = { name: 'tf2pickup.org bot' }
+        } else {
+          const { name, avatar } = await players.bySteamId(admin, ['name', 'avatar.medium'])
+          author = {
+            name,
+            iconURL: avatar.medium,
+            url: `${environment.WEBSITE_URL}/players/${admin}`,
+          }
+        }
+
+        const p = await players.bySteamId(player, ['name', 'steamId', 'avatar.large'])
+        await toAdmins({
+          embeds: [
+            new EmbedBuilder()
+              .setColor('#9838dc')
+              .setAuthor(author)
+              .setTitle('Player chat mute revoked')
+              .setThumbnail(p.avatar.large)
+              .setDescription(
+                [
+                  `Player: **[${p.name}](${environment.WEBSITE_URL}/players/${p.steamId})**`,
+                  `Reason: **${chatMute.reason}**`,
+                ].join('\n'),
+              )
+              .setFooter({
+                text: environment.WEBSITE_NAME,
+                iconURL: `${environment.WEBSITE_URL}/favicon.png`,
+              })
+              .setTimestamp(),
+          ],
+        })
+      }),
+    )
+  },
+  {
+    name: 'discord - notify on player chat mutes',
+  },
+)

--- a/src/players/add-chat-mute.ts
+++ b/src/players/add-chat-mute.ts
@@ -2,6 +2,7 @@ import type { PlayerBan } from '../database/models/player.model'
 import { events } from '../events'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { update } from './update'
+import { activityLog } from '../activity-log'
 
 export async function addChatMute(props: {
   player: SteamId64
@@ -17,6 +18,14 @@ export async function addChatMute(props: {
   }
 
   await update(props.player, { $push: { chatMutes: chatMute } })
+  await activityLog.record({
+    type: 'chat mute added',
+    player: props.player,
+    actor: props.admin,
+    reason: chatMute.reason,
+    start: chatMute.start,
+    end: chatMute.end,
+  })
   events.emit('player/chatMute:added', { player: props.player, chatMute })
   return chatMute
 }

--- a/src/players/revoke-chat-mute.ts
+++ b/src/players/revoke-chat-mute.ts
@@ -3,6 +3,7 @@ import { events } from '../events'
 import { update } from './update'
 import type { PlayerBan } from '../database/models/player.model'
 import { errors } from '../errors'
+import { activityLog } from '../activity-log'
 
 export async function revokeChatMute(props: {
   player: SteamId64
@@ -30,6 +31,12 @@ export async function revokeChatMute(props: {
     player: after.steamId,
     chatMute,
     admin: props.admin,
+  })
+  await activityLog.record({
+    type: 'chat mute revoked',
+    player: after.steamId,
+    actor: props.admin,
+    reason: chatMute.reason,
   })
   return chatMute
 }


### PR DESCRIPTION
## Summary

Chat mutes and revokes were applied silently — unlike player bans, they produced no Discord notification and left no activity log trail. This brings them in line with the player-ban handling.

## Changes

- **Activity log model** (`activity-log-entry.model.ts`): new `ChatMuteAddedEntry` / `ChatMuteRevokedEntry` types, added to the union and `ActivityLogInput`.
- **Recording**: `add-chat-mute.ts` records a `chat mute added` entry; `revoke-chat-mute.ts` records a `chat mute revoked` entry.
- **Discord** (new `notify-player-chat-mutes.ts`): auto-loaded plugin subscribing to `player/chatMute:added` / `player/chatMute:revoked`, posting embeds to the admins channel (same style as ban notifications).
- **Admin activity log UI**: labels, colors, detail rendering, type-filter options, and player/actor name resolution for the two new entry types.

## Testing

- `pnpm lint` passes.
- `tsc --noEmit` shows the same pre-existing errors (all in unrelated `.test.ts` files) before and after — no new type errors.

Note: chat mutes are always created by a human admin, so the `'bot'` branches exist only for type-symmetry with bans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)