### PR TITLE
fix: prevent banned players from taking substitute spots

### DIFF
--- a/src/games/replace-player.ts
+++ b/src/games/replace-player.ts
@@ -8,6 +8,7 @@ import { update } from './update'
 import { GameEventType } from '../database/models/game-event.model'
 import { events } from '../events'
 import { applyCooldown } from './apply-cooldown'
+import { players } from '../players'
 
 const replacePlayerMutex = new Mutex()
 
@@ -45,6 +46,10 @@ export async function replacePlayer({
 
       if (rm.activeGame !== undefined) {
         throw new Error(`player denied: player has active game`)
+      }
+
+      if (players.hasActiveBan(rm)) {
+        throw new Error(`player denied: player is banned`)
       }
     }
 

--- a/src/games/views/html/game-slot.tsx
+++ b/src/games/views/html/game-slot.tsx
@@ -8,7 +8,7 @@ import { IconPlus, IconReplaceFilled } from '../../../html/components/icons'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
 import { PlayerConnectionStatusIndicator } from './player-connection-status-indicator'
 import { errors } from '../../../errors'
-import { players } from '../../../players'
+import { hasActiveBan } from '../../../players/has-active-ban'
 import type { PickDeep } from 'type-fest'
 
 export async function GameSlot(props: {
@@ -111,7 +111,7 @@ async function GameSlotContent(props: {
       if (
         actor &&
         (props.slot.player === actor.steamId ||
-          (actor.activeGame === undefined && !players.hasActiveBan(actor)))
+          (actor.activeGame === undefined && !hasActiveBan(actor)))
       ) {
         return (
           <button

--- a/src/games/views/html/game-slot.tsx
+++ b/src/games/views/html/game-slot.tsx
@@ -8,6 +8,7 @@ import { IconPlus, IconReplaceFilled } from '../../../html/components/icons'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
 import { PlayerConnectionStatusIndicator } from './player-connection-status-indicator'
 import { errors } from '../../../errors'
+import { players } from '../../../players'
 import type { PickDeep } from 'type-fest'
 
 export async function GameSlot(props: {
@@ -53,10 +54,9 @@ async function GameSlotContent(props: {
   actor: SteamId64 | undefined
 }) {
   const actor = props.actor
-    ? await collections.players.findOne<Pick<PlayerModel, 'roles' | 'steamId' | 'activeGame'>>(
-        { steamId: props.actor },
-        { projection: { roles: 1, steamId: 1, activeGame: 1 } },
-      )
+    ? await collections.players.findOne<
+        Pick<PlayerModel, 'roles' | 'steamId' | 'activeGame' | 'bans'>
+      >({ steamId: props.actor }, { projection: { roles: 1, steamId: 1, activeGame: 1, bans: 1 } })
     : null
   const isAdmin = actor?.roles.includes(PlayerRole.admin)
 
@@ -108,7 +108,11 @@ async function GameSlotContent(props: {
       )
 
     case SlotStatus.waitingForSubstitute: {
-      if (actor && (props.slot.player === actor.steamId || actor.activeGame === undefined)) {
+      if (
+        actor &&
+        (props.slot.player === actor.steamId ||
+          (actor.activeGame === undefined && !players.hasActiveBan(actor)))
+      ) {
         return (
           <button
             class="text-abru-light-60 hover:text-abru-light-70 flex flex-1 justify-center"

--- a/src/players/has-active-ban.test.ts
+++ b/src/players/has-active-ban.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { hasActiveBan } from './has-active-ban'
+import type { PlayerModel } from '../database/models/player.model'
+import type { SteamId64 } from '../shared/types/steam-id-64'
+
+const now = new Date('2026-01-15T12:00:00Z')
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(now)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+const basePlayer = {
+  steamId: '76561198074409147',
+} as Pick<PlayerModel, 'steamId' | 'bans'>
+
+describe('hasActiveBan()', () => {
+  it('returns false when bans is undefined', () => {
+    expect(hasActiveBan({ ...basePlayer })).toBe(false)
+  })
+
+  it('returns false when bans is empty', () => {
+    expect(hasActiveBan({ ...basePlayer, bans: [] })).toBe(false)
+  })
+
+  it('returns false when all bans have expired', () => {
+    expect(
+      hasActiveBan({
+        ...basePlayer,
+        bans: [
+          {
+            actor: '76561198074409148' as SteamId64,
+            start: new Date('2026-01-10T00:00:00Z'),
+            end: new Date('2026-01-14T00:00:00Z'), // before now
+            reason: 'cheating',
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  it('returns true when there is an active ban', () => {
+    expect(
+      hasActiveBan({
+        ...basePlayer,
+        bans: [
+          {
+            actor: '76561198074409148' as SteamId64,
+            start: new Date('2026-01-14T00:00:00Z'),
+            end: new Date('2026-01-16T00:00:00Z'), // after now
+            reason: 'cheating',
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when one of multiple bans is active', () => {
+    expect(
+      hasActiveBan({
+        ...basePlayer,
+        bans: [
+          {
+            actor: '76561198074409148' as SteamId64,
+            start: new Date('2026-01-01T00:00:00Z'),
+            end: new Date('2026-01-10T00:00:00Z'), // expired
+            reason: 'cheating',
+          },
+          {
+            actor: '76561198074409148' as SteamId64,
+            start: new Date('2026-01-14T00:00:00Z'),
+            end: new Date('2026-01-20T00:00:00Z'), // active
+            reason: 'griefing',
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+})

--- a/src/players/has-active-ban.ts
+++ b/src/players/has-active-ban.ts
@@ -1,0 +1,5 @@
+import type { PlayerModel } from '../database/models/player.model'
+
+export function hasActiveBan(player: Pick<PlayerModel, 'bans'>): boolean {
+  return (player.bans ?? []).some(ban => ban.end > new Date())
+}

--- a/src/players/index.ts
+++ b/src/players/index.ts
@@ -3,6 +3,7 @@ import { addChatMute } from './add-chat-mute'
 import { bySteamId } from './by-steam-id'
 import { findByName } from './find-by-name'
 import { getBanExpiryDate } from './get-ban-expiry-date'
+import { hasActiveBan } from './has-active-ban'
 import { hasActiveChatMute } from './has-active-chat-mute'
 import { revokeBan } from './revoke-ban'
 import { revokeChatMute } from './revoke-chat-mute'
@@ -17,6 +18,7 @@ export const players = {
   bySteamId,
   findByName,
   getBanExpiryDate,
+  hasActiveBan,
   hasActiveChatMute,
   revokeBan,
   revokeChatMute,

--- a/tests/20-game/14-banned-player-cannot-substitute.spec.ts
+++ b/tests/20-game/14-banned-player-cannot-substitute.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from '@playwright/test'
+import { launchGame as test } from '../fixtures/launch-game'
+
+test.use({ waitForStage: 'started' })
+
+test('banned players do not see the take-substitute-spot button @6v6 @9v9', async ({
+  gameNumber,
+  users,
+}) => {
+  const admin = users.getAdmin()
+  const adminsPage = await admin.gamePage(gameNumber)
+  await adminsPage.requestSubstitute('Mayflower')
+
+  const ghostWalker = users.byName('GhostWalker')
+  const adminPage = await admin.adminPage()
+  await adminPage.banPlayer(ghostWalker.steamId, { reason: 'testing' })
+
+  const ghostWalkersPage = await ghostWalker.gamePage(gameNumber)
+  await expect(
+    ghostWalkersPage.playerSlot('Mayflower').getByRole('button', { name: 'Replace player' }),
+  ).not.toBeVisible()
+
+  await adminPage.revokeAllBans(ghostWalker.steamId)
+})


### PR DESCRIPTION
## Summary
- Banned players could previously take a `waitingForSubstitute` slot via `PUT /games/:number/replace-player` — the endpoint and `replacePlayer()` only checked `activeGame`, never `bans`.
- Added `players.hasActiveBan()` (mirrors the existing `hasActiveChatMute()` helper) and use it in `replacePlayer()` to reject banned replacements.
- Hid the "take this spot" button in the game slot UI for currently-banned players.

## Test plan
- [x] `pnpm test` — new `has-active-ban.test.ts` and full suite pass
- [x] `pnpm lint` passes