### PR TITLE
test(e2e): add missing queue-config tags so all tests run in CI

### DIFF
--- a/tests/00-misc/04-handles-back-button.spec.ts
+++ b/tests/00-misc/04-handles-back-button.spec.ts
@@ -5,7 +5,7 @@ import { QueuePage } from '../pages/queue.page'
 
 const test = mergeTests(authUsers, waitForEmptyQueue)
 
-test('handle back button', async ({ page, users }) => {
+test('handle back button @6v6 @9v9', async ({ page, users }) => {
   // Make sure htmx caching is disabled.
 
   const queuePage = new QueuePage(page)

--- a/tests/10-queue/06-queue-locked-when-active-game.spec.ts
+++ b/tests/10-queue/06-queue-locked-when-active-game.spec.ts
@@ -2,7 +2,7 @@ import { expect, launchGame } from '../fixtures/launch-game'
 import { queueSlots } from '../queue-slots'
 
 launchGame(
-  'queue is locked for players that are involved in active game',
+  'queue is locked for players that are involved in active game @6v6 @9v9',
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async ({ players, gameNumber }) => {
     await Promise.all(

--- a/tests/20-game/01-configure-game-server.spec.ts
+++ b/tests/20-game/01-configure-game-server.spec.ts
@@ -2,7 +2,7 @@ import { launchGame, expect } from '../fixtures/launch-game'
 import { secondsToMilliseconds } from 'date-fns'
 import { GamePage } from '../pages/game.page'
 
-launchGame('configure game server', async ({ players, gameNumber, page, gameServer }) => {
+launchGame('configure game server @6v6 @9v9', async ({ players, gameNumber, page, gameServer }) => {
   await Promise.all(
     players.map(async player => {
       const page = await player.gamePage(gameNumber)

--- a/tests/20-game/03-update-player-connection-status.spec.ts
+++ b/tests/20-game/03-update-player-connection-status.spec.ts
@@ -1,21 +1,24 @@
 import { expect, launchGame } from '../fixtures/launch-game'
 
 launchGame.use({ waitForStage: 'launching' })
-launchGame('update player connection status', async ({ players, gameNumber, gameServer }) => {
-  await Promise.all(
-    players.map(async player => {
-      const page = await player.gamePage(gameNumber)
-      const slot = page.playerSlot(player.playerName)
-      await expect(slot.getByLabel('Player connection status')).toHaveClass(/offline/)
+launchGame(
+  'update player connection status @6v6 @9v9',
+  async ({ players, gameNumber, gameServer }) => {
+    await Promise.all(
+      players.map(async player => {
+        const page = await player.gamePage(gameNumber)
+        const slot = page.playerSlot(player.playerName)
+        await expect(slot.getByLabel('Player connection status')).toHaveClass(/offline/)
 
-      await gameServer.playerConnects(player.playerName)
-      await expect(slot.getByLabel('Player connection status')).toHaveClass(/joining/)
+        await gameServer.playerConnects(player.playerName)
+        await expect(slot.getByLabel('Player connection status')).toHaveClass(/joining/)
 
-      await gameServer.playerJoinsTeam(player.playerName)
-      await expect(slot.getByLabel('Player connection status')).toHaveClass(/connected/)
+        await gameServer.playerJoinsTeam(player.playerName)
+        await expect(slot.getByLabel('Player connection status')).toHaveClass(/connected/)
 
-      await gameServer.playerDisconnects(player.playerName)
-      await expect(slot.getByLabel('Player connection status')).toHaveClass(/offline/)
-    }),
-  )
-})
+        await gameServer.playerDisconnects(player.playerName)
+        await expect(slot.getByLabel('Player connection status')).toHaveClass(/offline/)
+      }),
+    )
+  },
+)

--- a/tests/20-game/04-cleanup-game-server.spec.ts
+++ b/tests/20-game/04-cleanup-game-server.spec.ts
@@ -4,7 +4,7 @@ import { delay } from 'es-toolkit'
 
 launchGame.use({ waitForStage: 'started' })
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-launchGame('cleanup game server', async ({ gameServer, gameNumber }) => {
+launchGame('cleanup game server @6v6 @9v9', async ({ gameServer, gameNumber }) => {
   launchGame.setTimeout(minutesToMilliseconds(2))
 
   await delay(secondsToMilliseconds(3))

--- a/tests/20-game/05-report-rounds.spec.ts
+++ b/tests/20-game/05-report-rounds.spec.ts
@@ -4,7 +4,7 @@ import { GamePage } from '../pages/game.page'
 import { delay } from 'es-toolkit'
 
 launchGame.use({ waitForStage: 'started' })
-launchGame('report rounds', async ({ gameNumber, page, gameServer }) => {
+launchGame('report rounds @6v6 @9v9', async ({ gameNumber, page, gameServer }) => {
   // wait for the gameserver to be configured
   const gamePage = new GamePage(page, gameNumber)
   await gamePage.goto()

--- a/tests/90-admin/02-force-end-game.spec.ts
+++ b/tests/90-admin/02-force-end-game.spec.ts
@@ -1,6 +1,6 @@
 import { expect, launchGame } from '../fixtures/launch-game'
 
-launchGame('force end game', async ({ users, gameNumber }) => {
+launchGame('force end game @6v6 @9v9', async ({ users, gameNumber }) => {
   const admin = users.getAdmin()
   const adminsPage = await admin.gamePage(gameNumber)
   await adminsPage.goto()

--- a/tests/90-admin/03-reinitialize-game-server.spec.ts
+++ b/tests/90-admin/03-reinitialize-game-server.spec.ts
@@ -3,7 +3,7 @@ import { expect, launchGame } from '../fixtures/launch-game'
 
 launchGame.use({ waitForStage: 'launching' })
 
-launchGame('reinitialize game server', async ({ users, gameNumber }) => {
+launchGame('reinitialize game server @6v6 @9v9', async ({ users, gameNumber }) => {
   const admin = users.getAdmin()
   const page = await admin.gamePage(gameNumber)
   await page.goto()

--- a/tests/90-admin/05-skill-import-export.spec.ts
+++ b/tests/90-admin/05-skill-import-export.spec.ts
@@ -4,17 +4,20 @@ import { resolve } from 'node:path'
 import { writeFile, unlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 
-authUsers('skill import/export page is accessible for admins', async ({ users: userManager }) => {
-  const adminPage = await userManager.getAdmin().page()
-  await adminPage.goto('/admin/skill-import-export')
-  await expect(adminPage.getByRole('heading', { name: 'Export player skills' })).toBeVisible()
-  await expect(adminPage.getByRole('heading', { name: 'Import player skills' })).toBeVisible()
-  await expect(adminPage.getByRole('link', { name: 'Download CSV' })).toBeVisible()
-  await expect(adminPage.getByRole('button', { name: 'Upload and preview' })).toBeVisible()
-})
+authUsers(
+  'skill import/export page is accessible for admins @6v6 @9v9',
+  async ({ users: userManager }) => {
+    const adminPage = await userManager.getAdmin().page()
+    await adminPage.goto('/admin/skill-import-export')
+    await expect(adminPage.getByRole('heading', { name: 'Export player skills' })).toBeVisible()
+    await expect(adminPage.getByRole('heading', { name: 'Import player skills' })).toBeVisible()
+    await expect(adminPage.getByRole('link', { name: 'Download CSV' })).toBeVisible()
+    await expect(adminPage.getByRole('button', { name: 'Upload and preview' })).toBeVisible()
+  },
+)
 
 authUsers(
-  'skill import/export page is not accessible for non-admins',
+  'skill import/export page is not accessible for non-admins @6v6 @9v9',
   async ({ users: userManager }) => {
     const userPage = await userManager.getNext(u => !u.isAdmin).page()
     await userPage.goto('/admin/skill-import-export')
@@ -23,7 +26,7 @@ authUsers(
   },
 )
 
-authUsers('export skills downloads a CSV file', async ({ users: userManager }) => {
+authUsers('export skills downloads a CSV file @6v6 @9v9', async ({ users: userManager }) => {
   const adminPage = await userManager.getAdmin().page()
   await adminPage.goto('/admin/skill-import-export')
 
@@ -34,7 +37,7 @@ authUsers('export skills downloads a CSV file', async ({ users: userManager }) =
   expect(download.suggestedFilename()).toMatch(/player-skills-.*\.csv/)
 })
 
-authUsers('upload CSV shows preview page', async ({ users: userManager }) => {
+authUsers('upload CSV shows preview page @6v6 @9v9', async ({ users: userManager }) => {
   const adminPage = await userManager.getAdmin().page()
   await adminPage.goto('/admin/skill-import-export')
 
@@ -59,7 +62,7 @@ ${users[1].steamId},${users[1].name},3,4,3,4`
   }
 })
 
-authUsers('apply import updates player skills', async ({ users: userManager, db }) => {
+authUsers('apply import updates player skills @6v6 @9v9', async ({ users: userManager, db }) => {
   const adminPage = await userManager.getAdmin().page()
   const adminSteamId = users[0].steamId
   const targetSteamId = users[1].steamId
@@ -116,7 +119,7 @@ ${targetSteamId},TestPlayer,7,8,9,10`
 })
 
 authUsers(
-  'future player skills are stored for unregistered players',
+  'future player skills are stored for unregistered players @6v6 @9v9',
   async ({ users: userManager, db }) => {
     const adminPage = await userManager.getAdmin().page()
     const futureSteamId = '76561198000000001' // A Steam ID that doesn't exist in the database


### PR DESCRIPTION
## Summary

- 9 spec files had no `@6v6` or `@9v9` tag in their test names and were silently skipped in CI by the `--grep @<queue-config>` filter used in the `Run Playwright tests` step
- Added `@6v6 @9v9` to all affected tests since they are config-agnostic (game server lifecycle, admin actions, skill import/export, queue lock, back button)

## Affected files

| File | Test |
|------|------|
| `tests/00-misc/04-handles-back-button.spec.ts` | `handle back button` |
| `tests/10-queue/06-queue-locked-when-active-game.spec.ts` | `queue is locked for players that are involved in active game` |
| `tests/20-game/01-configure-game-server.spec.ts` | `configure game server` |
| `tests/20-game/03-update-player-connection-status.spec.ts` | `update player connection status` |
| `tests/20-game/04-cleanup-game-server.spec.ts` | `cleanup game server` |
| `tests/20-game/05-report-rounds.spec.ts` | `report rounds` |
| `tests/90-admin/02-force-end-game.spec.ts` | `force end game` |
| `tests/90-admin/03-reinitialize-game-server.spec.ts` | `reinitialize game server` |
| `tests/90-admin/05-skill-import-export.spec.ts` | 5 tests |

## Test plan

- [ ] CI e2e jobs now pick up and run all 9 previously-skipped test files for both `6v6` and `9v9` queue configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)