### PR TITLE
refactor: persist in-progress round state to survive restarts

### DIFF
--- a/src/database/collections.ts
+++ b/src/database/collections.ts
@@ -29,6 +29,7 @@ import type { FuturePlayerSkillModel } from './models/future-player-skill.model'
 import type { PendingImportModel } from './models/pending-import.model'
 import type { LogsTfLogModel } from './models/logs-tf-log.model'
 import type { DeferredKickModel } from './models/deferred-kick.model'
+import type { GameRoundProgressModel } from './models/game-round-progress.model'
 import { ensureIndexes } from './ensure-indexes'
 
 export const collections = {
@@ -46,6 +47,7 @@ export const collections = {
   gameLogs: database.collection<GameLogsModel>('gamelogs'),
   games: database.collection<GameModel>('games'),
   gamesDeferredKicks: database.collection<DeferredKickModel>('games.deferredkicks'),
+  gamesRoundProgress: database.collection<GameRoundProgressModel>('games.roundprogress'),
   gamesSubstituteRequests: database.collection<SubstituteRequestModel>('games.substituterequests'),
   keys: database.collection<KeyModel>('keys'),
   logsTfLogs: database.collection<LogsTfLogModel>('logstf.logs'),

--- a/src/database/ensure-indexes.ts
+++ b/src/database/ensure-indexes.ts
@@ -55,6 +55,7 @@ const definitions: Partial<Record<keyof typeof collections, IndexDefinition[]>> 
     { spec: { gameNumber: 1, slotId: 1 }, options: { unique: true } },
     { spec: { gameNumber: 1, replacement: 1 } },
   ],
+  gamesRoundProgress: [{ spec: { gameNumber: 1 }, options: { unique: true } }],
   futurePlayerSkills: [{ spec: { steamId: 1 }, options: { unique: true } }],
   pendingImports: [{ spec: { actor: 1 }, options: { unique: true } }],
   logsTfLogs: [

--- a/src/database/models/game-round-progress.model.ts
+++ b/src/database/models/game-round-progress.model.ts
@@ -1,0 +1,26 @@
+import type { Tf2Team } from '../../shared/types/tf2-team'
+import type { GameNumber } from './game.model'
+
+/**
+ * The in-progress assembly of a single round, persisted so that a partially
+ * observed round — and the pending side-swap on stopwatch maps — survives an
+ * app restart. TF2 reports a round's outcome across several log lines
+ * (Round_Win, Round_Length, the per-team score) that may arrive at any time, so
+ * we accumulate them here and commit a `roundEnded` game event once complete.
+ * The document is cleared between rounds and removed when the match ends.
+ */
+export interface GameRoundProgressModel {
+  gameNumber: GameNumber
+
+  // fields of the round currently being assembled; absent once committed
+  round?: {
+    winner?: Tf2Team
+    lengthMs?: number
+    score?: Partial<Record<Tf2Team, number>>
+    captures?: Partial<Record<Tf2Team, number[]>>
+  }
+
+  // the teams will switch sides when the next round starts (stopwatch maps);
+  // deferred to the next round start so the final round produces no trailing swap
+  swapPending?: boolean
+}

--- a/src/games/plugins/track-match-rounds.test.ts
+++ b/src/games/plugins/track-match-rounds.test.ts
@@ -26,6 +26,99 @@ vi.mock('../find-one', () => ({
   findOne: vi.fn(),
 }))
 
+// A tiny in-memory stand-in for the games.roundprogress collection, supporting
+// just the MongoDB operators track-match-rounds relies on ($set/$push/$unset
+// with dotted paths, $exists filters, and findOneAndUpdate's before-image). This
+// lets the test drive the real claim/commit logic without a live database.
+const { roundProgressStore, gamesRoundProgress } = vi.hoisted(() => {
+  type Doc = Record<string, unknown>
+  const store = new Map<number, Doc>()
+
+  const getPath = (obj: Doc, path: string): unknown =>
+    path.split('.').reduce<unknown>((o, k) => (o == null ? undefined : (o as Doc)[k]), obj)
+
+  const setPath = (obj: Doc, path: string, value: unknown) => {
+    const keys = path.split('.')
+    let o = obj
+    for (const k of keys.slice(0, -1)) {
+      o[k] ??= {}
+      o = o[k] as Doc
+    }
+    o[keys[keys.length - 1]!] = value
+  }
+
+  const unsetPath = (obj: Doc, path: string) => {
+    const keys = path.split('.')
+    let o: Doc | undefined = obj
+    for (const k of keys.slice(0, -1)) {
+      o = o?.[k] as Doc | undefined
+    }
+    if (o) {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete o[keys[keys.length - 1]!]
+    }
+  }
+
+  const matches = (doc: Doc, filter: Doc): boolean =>
+    Object.entries(filter).every(([key, expected]) => {
+      const actual = getPath(doc, key)
+      if (expected && typeof expected === 'object' && '$exists' in expected) {
+        return (actual !== undefined) === (expected as { $exists: boolean }).$exists
+      }
+      return actual === expected
+    })
+
+  const applyUpdate = (doc: Doc, update: Doc) => {
+    for (const [k, v] of Object.entries((update['$set'] as Doc) ?? {})) {
+      setPath(doc, k, v)
+    }
+    for (const [k, v] of Object.entries((update['$push'] as Doc) ?? {})) {
+      setPath(doc, k, [...((getPath(doc, k) as unknown[]) ?? []), v])
+    }
+    for (const k of Object.keys((update['$unset'] as Doc) ?? {})) {
+      unsetPath(doc, k)
+    }
+  }
+
+  const find = (filter: Doc): Doc | undefined =>
+    [...store.values()].find(doc => matches(doc, filter))
+
+  return {
+    roundProgressStore: store,
+    gamesRoundProgress: {
+      updateOne: (filter: Doc, update: Doc, options?: { upsert?: boolean }) => {
+        let doc = find(filter)
+        if (!doc) {
+          if (!options?.upsert) {
+            return Promise.resolve()
+          }
+          doc = { gameNumber: filter['gameNumber'] }
+          store.set(filter['gameNumber'] as number, doc)
+        }
+        applyUpdate(doc, update)
+        return Promise.resolve()
+      },
+      findOneAndUpdate: (filter: Doc, update: Doc, options?: { returnDocument?: string }) => {
+        const doc = find(filter)
+        if (!doc) {
+          return Promise.resolve(null)
+        }
+        const before = structuredClone(doc)
+        applyUpdate(doc, update)
+        return Promise.resolve(options?.returnDocument === 'before' ? before : doc)
+      },
+      deleteOne: (filter: Doc) => {
+        store.delete(filter['gameNumber'] as number)
+        return Promise.resolve()
+      },
+    },
+  }
+})
+
+vi.mock('../../database/collections', () => ({
+  collections: { gamesRoundProgress },
+}))
+
 import { events } from '../../events'
 import { update } from '../update'
 import { findOne } from '../find-one'
@@ -54,14 +147,14 @@ describe('track-match-rounds', () => {
     captures: { blu: number[]; red: number[] }
   }) {
     for (const cp of opts.captures.blu) {
-      handlerFor('match/controlPoint:captured')({
+      await handlerFor('match/controlPoint:captured')({
         gameNumber,
         team: Tf2Team.blu,
         controlPoint: cp,
       } as never)
     }
     for (const cp of opts.captures.red) {
-      handlerFor('match/controlPoint:captured')({
+      await handlerFor('match/controlPoint:captured')({
         gameNumber,
         team: Tf2Team.red,
         controlPoint: cp,
@@ -83,8 +176,52 @@ describe('track-match-rounds', () => {
 
   beforeEach(async () => {
     vi.resetAllMocks()
+    roundProgressStore.clear()
     vi.mocked(update).mockResolvedValue({} as never)
     await (plugin as unknown as () => Promise<void>)()
+  })
+
+  it('commits a roundEnded event once the round is complete', async () => {
+    vi.mocked(findOne).mockResolvedValue({ score: { [Tf2Team.blu]: 0, [Tf2Team.red]: 0 } } as never)
+    await playRound({
+      winner: Tf2Team.blu,
+      score: { blu: 4, red: 0 },
+      captures: { blu: [0, 1, 2, 3], red: [] },
+    })
+
+    expect(update).toHaveBeenCalledWith(
+      { number: gameNumber },
+      expect.objectContaining({
+        $set: { 'score.blu': 4, 'score.red': 0 },
+        $push: {
+          events: expect.objectContaining({
+            event: GameEventType.roundEnded,
+            winner: Tf2Team.blu,
+            lengthMs: 300_000,
+            score: { [Tf2Team.blu]: 4, [Tf2Team.red]: 0 },
+            captures: { [Tf2Team.blu]: [0, 1, 2, 3], [Tf2Team.red]: [] },
+          }),
+        },
+      }),
+    )
+  })
+
+  it('commits the round exactly once even though several events complete it', async () => {
+    vi.mocked(findOne).mockResolvedValue({ score: { [Tf2Team.blu]: 0, [Tf2Team.red]: 0 } } as never)
+    await playRound({
+      winner: Tf2Team.blu,
+      score: { blu: 4, red: 0 },
+      captures: { blu: [0, 1, 2, 3], red: [] },
+    })
+
+    const roundEndedCalls = vi
+      .mocked(update)
+      .mock.calls.filter(
+        ([, u]: [unknown, unknown]) =>
+          (u as { $push?: { events?: { event?: string } } }).$push?.events?.event ===
+          GameEventType.roundEnded,
+      )
+    expect(roundEndedCalls).toHaveLength(1)
   })
 
   it('emits a teams swapped event when a stopwatch round ends and the next round starts', async () => {
@@ -153,7 +290,7 @@ describe('track-match-rounds', () => {
     })
 
     // match ends; the pending swap must be discarded, not flushed on a later start
-    handlerFor('match:ended')({ gameNumber } as never)
+    await handlerFor('match:ended')({ gameNumber } as never)
     await handlerFor('match:started')({ gameNumber } as never)
 
     expect(update).not.toHaveBeenCalledWith(

--- a/src/games/plugins/track-match-rounds.ts
+++ b/src/games/plugins/track-match-rounds.ts
@@ -1,6 +1,8 @@
 import fp from 'fastify-plugin'
+import { MongoError, type UpdateFilter } from 'mongodb'
 import { Tf2Team } from '../../shared/types/tf2-team'
 import type { GameNumber } from '../../database/models/game.model'
+import type { GameRoundProgressModel } from '../../database/models/game-round-progress.model'
 import { events } from '../../events'
 import { logger } from '../../logger'
 import { update } from '../update'
@@ -8,6 +10,25 @@ import { GameEventType } from '../../database/models/game-event.model'
 import { findOne } from '../find-one'
 import { isStopwatchRound } from '../is-stopwatch-round'
 import { collections } from '../../database/collections'
+
+// Upserting into the progress document races on its unique gameNumber index:
+// when two log lines for a brand-new game arrive near-simultaneously, both
+// upserts try to insert and one fails with a duplicate key error. Retrying once
+// succeeds, since the document now exists (same pattern as game-log-sink).
+async function upsertRoundProgress(
+  gameNumber: GameNumber,
+  patch: UpdateFilter<GameRoundProgressModel>,
+) {
+  try {
+    await collections.gamesRoundProgress.updateOne({ gameNumber }, patch, { upsert: true })
+  } catch (error) {
+    if (error instanceof MongoError && error.code === 11000) {
+      await collections.gamesRoundProgress.updateOne({ gameNumber }, patch, { upsert: true })
+    } else {
+      throw error
+    }
+  }
+}
 
 // TF2 reports a round's outcome across several log lines that may arrive in any
 // order — Round_Win, Round_Length and the per-team score. We accumulate them in
@@ -71,11 +92,7 @@ export default fp(
           captures,
         })
       ) {
-        await collections.gamesRoundProgress.updateOne(
-          { gameNumber },
-          { $set: { swapPending: true } },
-          { upsert: true },
-        )
+        await upsertRoundProgress(gameNumber, { $set: { swapPending: true } })
       }
 
       await update(
@@ -103,40 +120,22 @@ export default fp(
     }
 
     events.on('match:roundWon', async ({ gameNumber, winner }) => {
-      await collections.gamesRoundProgress.updateOne(
-        { gameNumber },
-        { $set: { 'round.winner': winner } },
-        { upsert: true },
-      )
+      await upsertRoundProgress(gameNumber, { $set: { 'round.winner': winner } })
       await maybeRoundEnded(gameNumber)
     })
 
     events.on('match:roundLength', async ({ gameNumber, lengthMs }) => {
-      await collections.gamesRoundProgress.updateOne(
-        { gameNumber },
-        { $set: { 'round.lengthMs': lengthMs } },
-        { upsert: true },
-      )
+      await upsertRoundProgress(gameNumber, { $set: { 'round.lengthMs': lengthMs } })
       await maybeRoundEnded(gameNumber)
     })
 
     events.on('match/score:reported', async ({ gameNumber, teamName, score }) => {
-      await collections.gamesRoundProgress.updateOne(
-        { gameNumber },
-        { $set: { [`round.score.${teamName}`]: score } },
-        { upsert: true },
-      )
+      await upsertRoundProgress(gameNumber, { $set: { [`round.score.${teamName}`]: score } })
       await maybeRoundEnded(gameNumber)
     })
 
     events.on('match/controlPoint:captured', async ({ gameNumber, team, controlPoint }) => {
-      await collections.gamesRoundProgress.updateOne(
-        { gameNumber },
-        {
-          $push: { [`round.captures.${team}`]: controlPoint },
-        },
-        { upsert: true },
-      )
+      await upsertRoundProgress(gameNumber, { $push: { [`round.captures.${team}`]: controlPoint } })
     })
 
     events.on('match:started', async ({ gameNumber }) => {

--- a/src/games/plugins/track-match-rounds.ts
+++ b/src/games/plugins/track-match-rounds.ts
@@ -7,122 +7,146 @@ import { update } from '../update'
 import { GameEventType } from '../../database/models/game-event.model'
 import { findOne } from '../find-one'
 import { isStopwatchRound } from '../is-stopwatch-round'
+import { collections } from '../../database/collections'
 
-interface RoundData {
-  winner?: Tf2Team
-  lengthMs?: number
-  score?: {
-    [Tf2Team.blu]?: number
-    [Tf2Team.red]?: number
-  }
-  captures?: {
-    [Tf2Team.blu]: number[]
-    [Tf2Team.red]: number[]
-  }
-}
-
+// TF2 reports a round's outcome across several log lines that may arrive in any
+// order — Round_Win, Round_Length and the per-team score. We accumulate them in
+// the games.roundprogress collection (instead of in memory) so that a partially
+// observed round, and the pending side-swap on stopwatch maps, survive an app
+// restart. A round is committed as a `roundEnded` game event once complete.
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
   async () => {
-    const rounds = new Map<GameNumber, RoundData>()
-    // games whose teams will switch sides when the next round starts (see the
-    // attack/defend detection in maybeRoundEnded below)
-    const swapPending = new Set<GameNumber>()
+    // Atomically claim a complete round: clear it from the progress document and
+    // return its pre-clear snapshot. Only the caller that observes the round as
+    // complete gets a non-null result, so the round is committed exactly once
+    // even if several log lines complete it near-simultaneously.
+    async function maybeRoundEnded(gameNumber: GameNumber) {
+      const claimed = await collections.gamesRoundProgress.findOneAndUpdate(
+        {
+          gameNumber,
+          'round.winner': { $exists: true },
+          'round.lengthMs': { $exists: true },
+          'round.score.red': { $exists: true },
+          'round.score.blu': { $exists: true },
+        },
+        { $unset: { round: '' } },
+        { returnDocument: 'before' },
+      )
 
-    async function maybeRoundEnded() {
-      for (const [gameNumber, value] of rounds) {
-        if (
-          value.winner &&
-          value.lengthMs !== undefined &&
-          value.score?.blu !== undefined &&
-          value.score.red !== undefined
-        ) {
-          logger.info({ ...value, gameNumber }, `round ended`)
-
-          const game = await findOne({ number: gameNumber }, ['score'])
-          if (value.score.red === game.score?.red && value.score.blu === game.score.blu) {
-            logger.info(`score is the same, not updating`)
-            rounds.delete(gameNumber)
-            continue
-          }
-
-          // On stopwatch (attack/defend & payload) rounds TF2 switches the
-          // teams' sides afterwards. We defer the swap event to the next round
-          // start so the final round doesn't produce a trailing swap.
-          if (
-            isStopwatchRound({
-              previousScore: {
-                [Tf2Team.blu]: game.score?.blu ?? 0,
-                [Tf2Team.red]: game.score?.red ?? 0,
-              },
-              score: { [Tf2Team.blu]: value.score.blu, [Tf2Team.red]: value.score.red },
-              captures: value.captures,
-            })
-          ) {
-            swapPending.add(gameNumber)
-          }
-
-          await update(
-            { number: gameNumber },
-            {
-              $set: {
-                'score.blu': value.score.blu,
-                'score.red': value.score.red,
-              },
-              $push: {
-                events: {
-                  at: new Date(),
-                  event: GameEventType.roundEnded,
-                  winner: value.winner,
-                  lengthMs: value.lengthMs,
-                  score: {
-                    [Tf2Team.red]: value.score.red,
-                    [Tf2Team.blu]: value.score.blu,
-                  },
-                  captures: value.captures ?? {
-                    [Tf2Team.blu]: [],
-                    [Tf2Team.red]: [],
-                  },
-                },
-              },
-            },
-          )
-          rounds.delete(gameNumber)
-        }
+      const round = claimed?.round
+      if (
+        round?.winner === undefined ||
+        round.lengthMs === undefined ||
+        round.score?.blu === undefined ||
+        round.score.red === undefined
+      ) {
+        return
       }
+
+      const { winner, lengthMs } = round
+      const score = { [Tf2Team.blu]: round.score.blu, [Tf2Team.red]: round.score.red }
+      const captures = {
+        [Tf2Team.blu]: round.captures?.[Tf2Team.blu] ?? [],
+        [Tf2Team.red]: round.captures?.[Tf2Team.red] ?? [],
+      }
+      logger.info({ gameNumber, winner, lengthMs, score, captures }, `round ended`)
+
+      const game = await findOne({ number: gameNumber }, ['score'])
+      if (score.red === game.score?.red && score.blu === game.score.blu) {
+        logger.info(`score is the same, not updating`)
+        return
+      }
+
+      // On stopwatch (attack/defend & payload) rounds TF2 switches the teams'
+      // sides afterwards. We defer the swap event to the next round start so the
+      // final round doesn't produce a trailing swap.
+      if (
+        isStopwatchRound({
+          previousScore: {
+            [Tf2Team.blu]: game.score?.blu ?? 0,
+            [Tf2Team.red]: game.score?.red ?? 0,
+          },
+          score,
+          captures,
+        })
+      ) {
+        await collections.gamesRoundProgress.updateOne(
+          { gameNumber },
+          { $set: { swapPending: true } },
+          { upsert: true },
+        )
+      }
+
+      await update(
+        { number: gameNumber },
+        {
+          $set: {
+            'score.blu': score.blu,
+            'score.red': score.red,
+          },
+          $push: {
+            events: {
+              at: new Date(),
+              event: GameEventType.roundEnded,
+              winner,
+              lengthMs,
+              score: {
+                [Tf2Team.red]: score.red,
+                [Tf2Team.blu]: score.blu,
+              },
+              captures,
+            },
+          },
+        },
+      )
     }
 
     events.on('match:roundWon', async ({ gameNumber, winner }) => {
-      const round = rounds.get(gameNumber) ?? {}
-      rounds.set(gameNumber, { ...round, winner })
-      await maybeRoundEnded()
+      await collections.gamesRoundProgress.updateOne(
+        { gameNumber },
+        { $set: { 'round.winner': winner } },
+        { upsert: true },
+      )
+      await maybeRoundEnded(gameNumber)
     })
 
     events.on('match:roundLength', async ({ gameNumber, lengthMs }) => {
-      const round = rounds.get(gameNumber) ?? {}
-      rounds.set(gameNumber, { ...round, lengthMs })
-      await maybeRoundEnded()
+      await collections.gamesRoundProgress.updateOne(
+        { gameNumber },
+        { $set: { 'round.lengthMs': lengthMs } },
+        { upsert: true },
+      )
+      await maybeRoundEnded(gameNumber)
     })
 
     events.on('match/score:reported', async ({ gameNumber, teamName, score }) => {
-      const round = rounds.get(gameNumber) ?? {}
-      round.score = { ...round.score, [teamName]: score }
-      rounds.set(gameNumber, round)
-      await maybeRoundEnded()
+      await collections.gamesRoundProgress.updateOne(
+        { gameNumber },
+        { $set: { [`round.score.${teamName}`]: score } },
+        { upsert: true },
+      )
+      await maybeRoundEnded(gameNumber)
     })
 
-    events.on('match/controlPoint:captured', ({ gameNumber, team, controlPoint }) => {
-      const round = rounds.get(gameNumber) ?? {}
-      const captures = round.captures ?? { [Tf2Team.blu]: [], [Tf2Team.red]: [] }
-      captures[team] = [...captures[team], controlPoint]
-      rounds.set(gameNumber, { ...round, captures })
+    events.on('match/controlPoint:captured', async ({ gameNumber, team, controlPoint }) => {
+      await collections.gamesRoundProgress.updateOne(
+        { gameNumber },
+        {
+          $push: { [`round.captures.${team}`]: controlPoint },
+        },
+        { upsert: true },
+      )
     })
 
     events.on('match:started', async ({ gameNumber }) => {
-      if (!swapPending.has(gameNumber)) {
+      const before = await collections.gamesRoundProgress.findOneAndUpdate(
+        { gameNumber, swapPending: true },
+        { $set: { swapPending: false } },
+      )
+      if (!before) {
         return
       }
-      swapPending.delete(gameNumber)
       logger.info({ gameNumber }, 'teams swapped sides')
       await update(
         { number: gameNumber },
@@ -130,8 +154,8 @@ export default fp(
       )
     })
 
-    events.on('match:ended', ({ gameNumber }) => {
-      swapPending.delete(gameNumber)
+    events.on('match:ended', async ({ gameNumber }) => {
+      await collections.gamesRoundProgress.deleteOne({ gameNumber })
     })
   },
   {


### PR DESCRIPTION
Builds on #672. Stacked on `fix/payload-final-score`; retarget to `master` once that merges.

## Problem
`track-match-rounds` kept each in-progress round (winner, length, per-team score, captures) and the pending stopwatch side-swap in module-level in-memory Maps. An app restart mid-round dropped the partially observed round, and a restart between a stopwatch round end and the next round start silently dropped the "teams swapped" event.

## Change
Persist that transient state in a dedicated `games.roundprogress` collection (one document per game), so it survives restarts. A completed round is claimed atomically (`findOneAndUpdate` + `$unset`) so it commits exactly once even when several log lines complete it near-simultaneously; the document is removed when the match ends. Using a side collection keeps this per-log-line churn off the hot `games` document (whose every update emits `game:updated` and triggers re-renders).

Behaviour is unchanged — existing `track-match-rounds` tests were ported to a small in-memory stand-in for the collection and still pass, plus a couple of new cases (commit-once, roundEnded payload).

## Open questions for review
- Side collection vs. a field on the game document — went with a side collection to avoid `game:updated` churn.
- Whether to also clear progress on `match:restarted` (current behaviour, like the old in-memory version, leaves it until the next match end).
- Whether to extract the round assembly into a pure reducer as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)