### PR TITLE
fix: await reply.html/send/redirect to prevent double-send errors

### DIFF
--- a/src/routes/admin/games/index.ts
+++ b/src/routes/admin/games/index.ts
@@ -18,7 +18,7 @@ export default routes(async app => {
         },
       },
       async (_request, reply) => {
-        reply.status(200).html(await GamesPage())
+        await reply.status(200).html(GamesPage())
       },
     )
     .post(
@@ -59,7 +59,7 @@ export default routes(async app => {
           configuration.set('games.logs_tf_upload_method', request.body.logsTfUploadMethod, actor),
         ])
         requestContext.set('messages', { success: ['Configuration saved'] })
-        reply.status(200).html(await GamesPage())
+        await reply.status(200).html(GamesPage())
       },
     )
 })

--- a/src/routes/admin/map-pool/index.ts
+++ b/src/routes/admin/map-pool/index.ts
@@ -21,7 +21,7 @@ export default routes(async app => {
         },
       },
       async (_request, reply) => {
-        reply.status(200).html(await MapPoolPage())
+        await reply.status(200).html(MapPoolPage())
       },
     )
     .post(
@@ -55,7 +55,7 @@ export default routes(async app => {
         const newMaps = await mapPool.set(request.body.maps)
         await activityLog.record({ type: 'map pool change', maps: newMaps.map(m => m.name) })
         requestContext.set('messages', { success: ['Configuration saved'] })
-        reply.status(200).html(await MapPoolPage())
+        await reply.status(200).html(MapPoolPage())
       },
     )
     .post('/create', async (_request, response) => {

--- a/src/routes/admin/privacy-policy/index.ts
+++ b/src/routes/admin/privacy-policy/index.ts
@@ -16,7 +16,7 @@ export default routes(async app => {
         },
       },
       async (_request, reply) => {
-        reply.status(200).html(await DocumentsPage({ name: 'privacy policy' }))
+        await reply.status(200).html(DocumentsPage({ name: 'privacy policy' }))
       },
     )
     .post(
@@ -35,7 +35,7 @@ export default routes(async app => {
           { $set: { body: request.body.body } },
         )
         requestContext.set('messages', { success: ['Configuration saved'] })
-        reply.status(200).html(await DocumentsPage({ name: 'privacy policy' }))
+        await reply.status(200).html(DocumentsPage({ name: 'privacy policy' }))
       },
     )
 })

--- a/src/routes/admin/rules/index.ts
+++ b/src/routes/admin/rules/index.ts
@@ -16,7 +16,7 @@ export default routes(async app => {
         },
       },
       async (_request, reply) => {
-        reply.status(200).html(await DocumentsPage({ name: 'rules' }))
+        await reply.status(200).html(DocumentsPage({ name: 'rules' }))
       },
     )
     .post(
@@ -35,7 +35,7 @@ export default routes(async app => {
           { $set: { body: request.body.body } },
         )
         requestContext.set('messages', { success: ['Configuration saved'] })
-        reply.status(200).html(await DocumentsPage({ name: 'rules' }))
+        await reply.status(200).html(DocumentsPage({ name: 'rules' }))
       },
     )
 })

--- a/src/routes/admin/skill-import-export/index.ts
+++ b/src/routes/admin/skill-import-export/index.ts
@@ -20,7 +20,7 @@ export default routes(async app => {
         },
       },
       async (_request, reply) => {
-        reply.status(200).html(await SkillImportExportPage())
+        await reply.status(200).html(SkillImportExportPage())
       },
     )
     .get(
@@ -52,7 +52,7 @@ export default routes(async app => {
         const data = await request.file()
         if (!data) {
           requestContext.set('messages', { error: ['No file uploaded'] })
-          reply.status(400).html(await SkillImportExportPage())
+          await reply.status(400).html(SkillImportExportPage())
           return
         }
 
@@ -62,7 +62,7 @@ export default routes(async app => {
         const parseResult = parseCsv(csvContent)
         if (!parseResult.success) {
           requestContext.set('messages', { error: [parseResult.error] })
-          reply.status(400).html(await SkillImportExportPage())
+          await reply.status(400).html(SkillImportExportPage())
           return
         }
 
@@ -120,7 +120,7 @@ export default routes(async app => {
             `Successfully applied ${totalChanges} skill change${totalChanges !== 1 ? 's' : ''}`,
           ],
         })
-        reply.status(200).html(await SkillImportExportPage())
+        await reply.status(200).html(SkillImportExportPage())
       },
     )
 })

--- a/src/routes/admin/voice-server/index.ts
+++ b/src/routes/admin/voice-server/index.ts
@@ -22,7 +22,7 @@ export default routes(async app => {
         },
       },
       async (_request, reply) => {
-        reply.status(200).html(await VoiceServerPage())
+        await reply.status(200).html(VoiceServerPage())
       },
     )
     .post(
@@ -67,7 +67,7 @@ export default routes(async app => {
           ])
         }
         requestContext.set('messages', { success: ['Configuration saved'] })
-        reply.status(200).html(await VoiceServerPage())
+        await reply.status(200).html(VoiceServerPage())
       },
     )
 })

--- a/src/routes/players/:steamId/edit/bans/add/index.ts
+++ b/src/routes/players/:steamId/edit/bans/add/index.ts
@@ -23,7 +23,7 @@ export default routes(async app => {
       },
       async (request, reply) => {
         const { steamId } = request.params
-        reply.status(200).html(await AddBanPage({ steamId }))
+        await reply.status(200).html(AddBanPage({ steamId }))
       },
     )
     .post(
@@ -56,7 +56,7 @@ export default routes(async app => {
           anonymous: request.body.anonymous,
         })
         request.flash('success', `Player ban added`)
-        reply.redirect(`/players/${request.params.steamId}/edit/bans`)
+        await reply.redirect(`/players/${request.params.steamId}/edit/bans`)
       },
     )
 })

--- a/src/routes/players/:steamId/edit/bans/index.ts
+++ b/src/routes/players/:steamId/edit/bans/index.ts
@@ -22,7 +22,7 @@ export default routes(async app => {
       },
       async (req, reply) => {
         const { steamId } = req.params
-        reply.status(200).html(await EditPlayerBansPage({ steamId }))
+        await reply.status(200).html(EditPlayerBansPage({ steamId }))
       },
     )
     .put(
@@ -46,7 +46,7 @@ export default routes(async app => {
           banStart,
           actor: request.user!.player.steamId,
         })
-        reply.status(200).html(await BanDetails({ player, ban }))
+        await reply.status(200).html(BanDetails({ player, ban }))
       },
     )
 })

--- a/src/routes/players/:steamId/edit/chat-mutes/add/index.ts
+++ b/src/routes/players/:steamId/edit/chat-mutes/add/index.ts
@@ -23,7 +23,7 @@ export default routes(async app => {
       },
       async (request, reply) => {
         const { steamId } = request.params
-        reply.status(200).html(await AddChatMutePage({ steamId }))
+        await reply.status(200).html(AddChatMutePage({ steamId }))
       },
     )
     .post(
@@ -52,7 +52,7 @@ export default routes(async app => {
           reason: request.body.reason,
         })
         request.flash('success', `Player chat mute added`)
-        reply.redirect(`/players/${request.params.steamId}/edit/chat-mutes`)
+        await reply.redirect(`/players/${request.params.steamId}/edit/chat-mutes`)
       },
     )
 })

--- a/src/routes/players/:steamId/edit/chat-mutes/index.ts
+++ b/src/routes/players/:steamId/edit/chat-mutes/index.ts
@@ -25,7 +25,7 @@ export default routes(async app => {
       },
       async (req, reply) => {
         const { steamId } = req.params
-        reply.status(200).html(await EditPlayerChatMutesPage({ steamId }))
+        await reply.status(200).html(EditPlayerChatMutesPage({ steamId }))
       },
     )
     .put(
@@ -49,7 +49,7 @@ export default routes(async app => {
           muteStart,
           admin: request.user!.player.steamId,
         })
-        reply.status(200).html(await ChatMuteDetails({ player, chatMute }))
+        await reply.status(200).html(ChatMuteDetails({ player, chatMute }))
       },
     )
 })

--- a/src/routes/players/:steamId/edit/roles/index.ts
+++ b/src/routes/players/:steamId/edit/roles/index.ts
@@ -22,7 +22,7 @@ export default routes(async app => {
       },
       async (req, reply) => {
         const { steamId } = req.params
-        reply.status(200).html(await EditPlayerRolesPage({ steamId }))
+        await reply.status(200).html(EditPlayerRolesPage({ steamId }))
       },
     )
     .post(

--- a/src/routes/players/:steamId/win-loss-chart/index.ts
+++ b/src/routes/players/:steamId/win-loss-chart/index.ts
@@ -22,7 +22,7 @@ export default routes(async app => {
     },
     async (request, reply) => {
       const { steamId, selection } = request.params
-      reply.status(200).html(await WinLossChart({ steamId, selection }))
+      await reply.status(200).html(WinLossChart({ steamId, selection }))
     },
   )
 })

--- a/src/routes/players/ban-expiry/index.ts
+++ b/src/routes/players/ban-expiry/index.ts
@@ -15,6 +15,7 @@ export default routes(async app => {
     async (request, reply) => {
       const banExpiryDate = players.getBanExpiryDate(request.query)
       reply.status(200).html(format(banExpiryDate, 'dd.MM.yyyy HH:mm'))
+      return reply
     },
   )
 })

--- a/src/routes/queue/players/index.ts
+++ b/src/routes/queue/players/index.ts
@@ -31,7 +31,7 @@ export default routes(async app => {
         })
       }
 
-      reply.status(204).send()
+      await reply.status(204).send()
     },
   )
 })

--- a/src/routes/twitch/auth/index.ts
+++ b/src/routes/twitch/auth/index.ts
@@ -18,7 +18,7 @@ export default routes(async app => {
       const url = twitchTv.makeOauthRedirectUrl(
         await twitchTv.state.make({ steamId: request.user!.player.steamId }),
       )
-      reply.redirect(url, 302)
+      await reply.redirect(url, 302)
     },
   )
 })

--- a/src/routes/twitch/auth/return/index.ts
+++ b/src/routes/twitch/auth/return/index.ts
@@ -41,7 +41,7 @@ export default routes(async app => {
 
       const { steamId } = await twitchTv.state.verify(request.query.state)
       await twitchTv.saveUserProfile({ steamId, code: request.query.code })
-      reply.redirect('/settings', 302)
+      await reply.redirect('/settings', 302)
     },
   )
 })


### PR DESCRIPTION
## Problem

Production logs (SigNoz, last 7 days) showed **100+** occurrences of:

> Error: Cannot write headers after they are sent to the client

Each error log carried a `trace_id` but the stack was entirely Fastify internals (`onSendEnd → safeWriteHead → writeHead`), so I correlated the traces back to request URLs to find the offending routes.

## Root cause

Affected handlers did:

```ts
async (req, reply) => {
  reply.status(200).html(await Body())   // ❌ html() not awaited/returned
}
```

`reply.html()` calls `reply.send()` internally, but since the async handler then resolves to `undefined` while that send is still flowing through the (async) `onSend` hooks, Fastify races a second `writeHead` → "headers already sent". The same applies to bare `reply.send()` / `reply.redirect()` statements.

## Fix

Move the `await` out onto the send call — the pattern already used correctly elsewhere in the codebase (e.g. `skill-import-export` preview, `statistics/game-launches-per-day`):

```ts
await reply.status(200).html(Body())   // ✅
```

`ban-expiry` renders a synchronous string (so `html()` returns `void` there); it `return reply`s instead, which is the equivalent Fastify "handled" signal and avoids the `await`-of-`void` / void-return lint rules.

## Routes fixed

admin: games, map-pool, voice-server, rules, privacy-policy, skill-import-export · players: edit bans (+add), chat-mutes (+add), roles, win-loss-chart, ban-expiry · queue clear · twitch auth (+return)

This also covers the `chat-mutes` routes, which share the same bug but weren't in the (100-capped) error sample.

## Verification

- `pnpm lint` — passes (prettier + eslint, including the `ban-expiry` edge case)
- `tsc` — no new type errors in touched files (pre-existing failures are all in unrelated `*.test.ts` fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)