### PR TITLE
perf(queue): target queue-page clients for slot updates

### DIFF
--- a/src/queue-auto/plugins/sync-clients.test.ts
+++ b/src/queue-auto/plugins/sync-clients.test.ts
@@ -170,10 +170,16 @@ describe('sync-clients', () => {
   })
 
   describe('queue/slots:updated handler', () => {
-    it('pre-fetches all connected players in a single batch query', async () => {
-      ;(app.websocketServer.clients as Set<unknown>).add({ player: { steamId: steamId1 } })
-      ;(app.websocketServer.clients as Set<unknown>).add({ player: { steamId: steamId2 } })
-      ;(app.websocketServer.clients as Set<unknown>).add({ player: undefined })
+    it('pre-fetches queue-page players in a single batch query', async () => {
+      ;(app.websocketServer.clients as Set<unknown>).add({
+        currentUrl: '/',
+        player: { steamId: steamId1 },
+      })
+      ;(app.websocketServer.clients as Set<unknown>).add({
+        currentUrl: '/',
+        player: { steamId: steamId2 },
+      })
+      ;(app.websocketServer.clients as Set<unknown>).add({ currentUrl: '/', player: undefined })
       mockPlayersFind.mockReturnValue({
         toArray: vi.fn().mockResolvedValue([{ steamId: steamId1 }, { steamId: steamId2 }]),
       })
@@ -189,8 +195,24 @@ describe('sync-clients', () => {
       expect(vi.mocked(players.bySteamId)).not.toHaveBeenCalled()
     })
 
-    it('does not include unauthenticated clients in the batch query', async () => {
-      ;(app.websocketServer.clients as Set<unknown>).add({ player: undefined })
+    it('targets only clients on the queue page', async () => {
+      ;(app.websocketServer.clients as Set<unknown>).add({
+        currentUrl: '/',
+        player: { steamId: steamId1 },
+      })
+      const handler = getHandler<{ slots: unknown[] }>('queue/slots:updated')
+
+      await handler({ slots: [] })
+
+      expect(app.gateway.to).toHaveBeenCalledWith({ url: '/' })
+    })
+
+    it('ignores players that are not on the queue page', async () => {
+      ;(app.websocketServer.clients as Set<unknown>).add({
+        currentUrl: '/players',
+        player: { steamId: steamId1 },
+      })
+      ;(app.websocketServer.clients as Set<unknown>).add({ currentUrl: '/', player: undefined })
       const handler = getHandler<{ slots: unknown[] }>('queue/slots:updated')
 
       await handler({ slots: [] })
@@ -199,6 +221,21 @@ describe('sync-clients', () => {
         { steamId: { $in: [] } },
         expect.objectContaining({ projection: expect.any(Object) }),
       )
+    })
+
+    it('skips DB work and slot updates when no client is on the queue page', async () => {
+      ;(app.websocketServer.clients as Set<unknown>).add({
+        currentUrl: '/players',
+        player: { steamId: steamId1 },
+      })
+      const handler = getHandler<{ slots: unknown[] }>('queue/slots:updated')
+
+      await handler({ slots: [] })
+
+      expect(mockPlayersFind).not.toHaveBeenCalled()
+      expect(app.gateway.to).not.toHaveBeenCalled()
+      // the document title is still broadcast to every client
+      expect(app.gateway.broadcast).toHaveBeenCalledOnce()
     })
   })
 })

--- a/src/queue-auto/plugins/sync-clients.ts
+++ b/src/queue-auto/plugins/sync-clients.ts
@@ -133,22 +133,36 @@ export default fp(
     events.on(
       'queue/slots:updated',
       safe(async ({ slots }) => {
-        const connectedPlayers = [...(app.websocketServer.clients as Set<AppWebSocket>)]
-          .map(c => c.player?.steamId)
-          .filter((id): id is SteamId64 => id !== undefined)
+        let hasQueuePageClients = false
+        const queuePagePlayers = new Set<SteamId64>()
+        for (const client of app.websocketServer.clients as Set<AppWebSocket>) {
+          if (client.currentUrl !== '/') {
+            continue
+          }
+          hasQueuePageClients = true
+          if (client.player) {
+            queuePagePlayers.add(client.player.steamId)
+          }
+        }
 
-        const [playerCount, actorMap] = await Promise.all([
-          CurrentPlayerCount(),
-          fetchActorMap(connectedPlayers),
-        ])
-
-        app.gateway.broadcast(player => {
-          const actor = player ? actorMap.get(player) : undefined
-          return Promise.all(slots.map(slot => QueueSlot({ slot, actor }))).then(items => [
-            ...items,
-            playerCount,
+        if (hasQueuePageClients) {
+          const [playerCount, anonymousSlots, actorMap] = await Promise.all([
+            CurrentPlayerCount(),
+            Promise.all(slots.map(slot => QueueSlot({ slot }))),
+            fetchActorMap([...queuePagePlayers]),
           ])
-        })
+
+          app.gateway.to({ url: '/' }).send(player => {
+            const actor = player ? actorMap.get(player) : undefined
+            if (!actor) {
+              return [...anonymousSlots, playerCount]
+            }
+            return Promise.all(slots.map(slot => QueueSlot({ slot, actor }))).then(items => [
+              ...items,
+              playerCount,
+            ])
+          })
+        }
 
         app.gateway.broadcast(() => SetTitle())
       }),


### PR DESCRIPTION
Follow-up to #602 (closed as superseded).

The actor-caching idea from #602 is already on master — `fetchActorMap` does a single batched `{ steamId: { $in: recipientIds } }` query, which is better than the N parallel `players.bySteamId()` calls that PR used. This PR carries over the parts of #602 that master still lacks, rebased on the batched query.

## What changed

The `queue/slots:updated` handler previously used `app.gateway.broadcast(...)`, sending queue-slot fragments and the player-count to **every** connected client regardless of page. Those fragments only have a render target on the queue page (`/`), so clients elsewhere received wasted no-op messages — and the actor batch query ran even when nobody was on the queue page.

- Collect only clients whose `currentUrl` is `/` and send via `to({ url: '/' })` instead of `broadcast`.
- **Early-return** (skipping `CurrentPlayerCount` and the actor batch query) when no client is on the queue page.
- Render the anonymous slot variant **once** and reuse it across all unauthenticated recipients, instead of re-rendering per client.

`SetTitle` is intentionally left as a global `broadcast` so the queue count keeps updating in the document title on every page (no behavior change there).

## Tests

Updated `queue/slots:updated` tests to reflect queue-page targeting and added coverage for the targeting filter, non-`/` players being excluded, and the no-queue-page-client early return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)