### PR TITLE
fix(players): fall back to default Steam avatar when avatar is missing

### DIFF
--- a/src/discord/plugins/notify-player-bans.ts
+++ b/src/discord/plugins/notify-player-bans.ts
@@ -8,6 +8,7 @@ import { environment } from '../../environment'
 import { formatDistanceToNow } from 'date-fns'
 import { client } from '../client'
 import { safe } from '../../utils/safe'
+import { playerAvatarUrl } from '../../shared/player-avatar-url'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -26,7 +27,7 @@ export default fp(
           const admin = await players.bySteamId(ban.actor, ['name', 'steamId', 'avatar.medium'])
           author = {
             name: admin.name,
-            iconURL: admin.avatar.medium,
+            iconURL: playerAvatarUrl(admin.avatar, 'medium'),
             url: `${environment.WEBSITE_URL}/players/${admin.steamId}`,
           }
         }
@@ -38,7 +39,7 @@ export default fp(
               .setColor('#dc3545')
               .setAuthor(author)
               .setTitle('Player ban added')
-              .setThumbnail(p.avatar.large)
+              .setThumbnail(playerAvatarUrl(p.avatar, 'large'))
               .setDescription(
                 [
                   `Player: **[${p.name}](${environment.WEBSITE_URL}/players/${p.steamId})**`,
@@ -66,7 +67,7 @@ export default fp(
           const { name, avatar } = await players.bySteamId(admin, ['name', 'avatar.medium'])
           author = {
             name,
-            iconURL: avatar.medium,
+            iconURL: playerAvatarUrl(avatar, 'medium'),
             url: `${environment.WEBSITE_URL}/players/${admin}`,
           }
         }
@@ -78,7 +79,7 @@ export default fp(
               .setColor('#9838dc')
               .setAuthor(author)
               .setTitle('Player ban revoked')
-              .setThumbnail(p.avatar.large)
+              .setThumbnail(playerAvatarUrl(p.avatar, 'large'))
               .setDescription(
                 [
                   `Player: **[${p.name}](${environment.WEBSITE_URL}/players/${p.steamId})**`,

--- a/src/discord/plugins/notify-player-change.ts
+++ b/src/discord/plugins/notify-player-change.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environment'
 import { client } from '../client'
 import { makePlayerChangesNotificationBody } from '../make-player-changes-notification-body'
 import { safe } from '../../utils/safe'
+import { playerAvatarUrl } from '../../shared/player-avatar-url'
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
   async () => {
@@ -33,11 +34,11 @@ export default fp(
               .setColor('#5230dc')
               .setAuthor({
                 name: admin.name,
-                iconURL: admin.avatar.medium,
+                iconURL: playerAvatarUrl(admin.avatar, 'medium'),
                 url: `${environment.WEBSITE_URL}/players/${admin.steamId}`,
               })
               .setTitle('Player profile updated')
-              .setThumbnail(after.avatar.large)
+              .setThumbnail(playerAvatarUrl(after.avatar, 'large'))
               .setDescription(
                 `Player: **[${after.name}](${environment.WEBSITE_URL}/players/${after.steamId})**\n${changes}`,
               )

--- a/src/discord/plugins/notify-player-chat-mutes.ts
+++ b/src/discord/plugins/notify-player-chat-mutes.ts
@@ -8,6 +8,7 @@ import { environment } from '../../environment'
 import { formatDistanceToNow } from 'date-fns'
 import { client } from '../client'
 import { safe } from '../../utils/safe'
+import { playerAvatarUrl } from '../../shared/player-avatar-url'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -30,7 +31,7 @@ export default fp(
           ])
           author = {
             name: admin.name,
-            iconURL: admin.avatar.medium,
+            iconURL: playerAvatarUrl(admin.avatar, 'medium'),
             url: `${environment.WEBSITE_URL}/players/${admin.steamId}`,
           }
         }
@@ -42,7 +43,7 @@ export default fp(
               .setColor('#dc3545')
               .setAuthor(author)
               .setTitle('Player chat mute added')
-              .setThumbnail(p.avatar.large)
+              .setThumbnail(playerAvatarUrl(p.avatar, 'large'))
               .setDescription(
                 [
                   `Player: **[${p.name}](${environment.WEBSITE_URL}/players/${p.steamId})**`,
@@ -70,7 +71,7 @@ export default fp(
           const { name, avatar } = await players.bySteamId(admin, ['name', 'avatar.medium'])
           author = {
             name,
-            iconURL: avatar.medium,
+            iconURL: playerAvatarUrl(avatar, 'medium'),
             url: `${environment.WEBSITE_URL}/players/${admin}`,
           }
         }
@@ -82,7 +83,7 @@ export default fp(
               .setColor('#9838dc')
               .setAuthor(author)
               .setTitle('Player chat mute revoked')
-              .setThumbnail(p.avatar.large)
+              .setThumbnail(playerAvatarUrl(p.avatar, 'large'))
               .setDescription(
                 [
                   `Player: **[${p.name}](${environment.WEBSITE_URL}/players/${p.steamId})**`,

--- a/src/discord/plugins/notify-player-created.ts
+++ b/src/discord/plugins/notify-player-created.ts
@@ -6,6 +6,7 @@ import { EmbedBuilder } from 'discord.js'
 import { environment } from '../../environment'
 import { client } from '../client'
 import { safe } from '../../utils/safe'
+import { playerAvatarUrl } from '../../shared/player-avatar-url'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -27,7 +28,7 @@ export default fp(
                 name: 'Name',
                 value: player.name,
               })
-              .setThumbnail(player.avatar.large)
+              .setThumbnail(playerAvatarUrl(player.avatar, 'large'))
               .setURL(`${environment.WEBSITE_URL}/players/${player.steamId}`)
               .setFooter({
                 text: environment.WEBSITE_NAME,

--- a/src/discord/plugins/notify-player-skill-changes.ts
+++ b/src/discord/plugins/notify-player-skill-changes.ts
@@ -9,6 +9,7 @@ import { EmbedBuilder } from 'discord.js'
 import { environment } from '../../environment'
 import { client } from '../client'
 import { safe } from '../../utils/safe'
+import { playerAvatarUrl } from '../../shared/player-avatar-url'
 
 function generateChangesText(
   oldSkill: PlayerModel['skill'],
@@ -47,11 +48,11 @@ export default fp(
                 .setColor('#ff953e')
                 .setAuthor({
                   name: admin.name,
-                  iconURL: admin.avatar.medium,
+                  iconURL: playerAvatarUrl(admin.avatar, 'medium'),
                   url: `${environment.WEBSITE_URL}/players/${admin.steamId}`,
                 })
                 .setTitle('Player skill updated')
-                .setThumbnail(after.avatar.large)
+                .setThumbnail(playerAvatarUrl(after.avatar, 'large'))
                 .setDescription(
                   `Player: **[${after.name}](${environment.WEBSITE_URL}/players/${after.steamId})**\n${changes}`,
                 )

--- a/src/discord/plugins/notify-player-verification.ts
+++ b/src/discord/plugins/notify-player-verification.ts
@@ -6,6 +6,7 @@ import { players } from '../../players'
 import { environment } from '../../environment'
 import { client } from '../client'
 import { safe } from '../../utils/safe'
+import { playerAvatarUrl } from '../../shared/player-avatar-url'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -33,11 +34,11 @@ export default fp(
               .setColor(isVerified ? '#33dc7f' : '#ff953e')
               .setAuthor({
                 name: admin.name,
-                iconURL: admin.avatar.medium,
+                iconURL: playerAvatarUrl(admin.avatar, 'medium'),
                 url: `${environment.WEBSITE_URL}/players/${admin.steamId}`,
               })
               .setTitle(isVerified ? 'Player verified' : 'Player verification revoked')
-              .setThumbnail(after.avatar.large)
+              .setThumbnail(playerAvatarUrl(after.avatar, 'large'))
               .setDescription(
                 `Player: **[${after.name}](${environment.WEBSITE_URL}/players/${after.steamId})**`,
               )

--- a/src/games/views/html/game-slot.tsx
+++ b/src/games/views/html/game-slot.tsx
@@ -10,6 +10,7 @@ import { PlayerConnectionStatusIndicator } from './player-connection-status-indi
 import { errors } from '../../../errors'
 import { hasActiveBan } from '../../../players/has-active-ban'
 import type { PickDeep } from 'type-fest'
+import { playerAvatarUrl } from '../../../shared/player-avatar-url'
 
 export async function GameSlot(props: {
   game: GameModel
@@ -75,7 +76,7 @@ async function GameSlotContent(props: {
             <GameClassIcon gameClass={props.slot.gameClass} size={32} />
           </div>
           <img
-            src={props.player.avatar.medium}
+            src={playerAvatarUrl(props.player.avatar, 'medium')}
             width="38"
             height="38"
             alt={`${props.player.name}'s avatar`}

--- a/src/hall-of-game/views/html/hall-of-fame.page.tsx
+++ b/src/hall-of-game/views/html/hall-of-fame.page.tsx
@@ -6,6 +6,7 @@ import { Footer } from '../../../html/components/footer'
 import { collections } from '../../../database/collections'
 import { Tf2ClassName } from '../../../shared/types/tf2-class-name'
 import type { PlayerModel } from '../../../database/models/player.model'
+import { playerAvatarUrl } from '../../../shared/player-avatar-url'
 import { IconAwardFilled } from '../../../html/components/icons'
 import { makeTitle } from '../../../html/make-title'
 
@@ -50,7 +51,7 @@ function Board(props: { title: string; entries: HallOfFameEntry[] }) {
         <a class="hof-record" href={`/players/${record.player.steamId}`} preload="mousedown">
           <MaybeAward i={i} />
           <img
-            src={record.player.avatar.medium}
+            src={playerAvatarUrl(record.player.avatar, 'medium')}
             width="64"
             height="64"
             class="h-[38px] w-[38px]"

--- a/src/html/components/profile.tsx
+++ b/src/html/components/profile.tsx
@@ -3,6 +3,7 @@ import type { PlayerModel } from '../../database/models/player.model'
 import { bundle } from '../bundle'
 import { IconLogout, IconSettings, IconSettingsFilled, IconUserCircle } from './icons'
 import type { PickDeep } from 'type-fest'
+import { playerAvatarUrl } from '../../shared/player-avatar-url'
 
 export async function Profile(player: PickDeep<PlayerModel, 'steamId' | 'name' | 'avatar.medium'>) {
   const animateProfileMenuJs = await bundle(
@@ -13,7 +14,7 @@ export async function Profile(player: PickDeep<PlayerModel, 'steamId' | 'name' |
       <div class="relative grow lg:grow-0">
         <button class="nav-profile-button" id="open-profile-menu-button">
           <img
-            src={player.avatar.medium}
+            src={playerAvatarUrl(player.avatar, 'medium')}
             width="64"
             class="h-[42px] w-[42px] rounded-[3px]"
             alt="{name}'s avatar"

--- a/src/online-players/plugins/index.ts
+++ b/src/online-players/plugins/index.ts
@@ -8,6 +8,7 @@ import { tasks } from '../../tasks'
 import { meter } from '../../otel'
 import { ValueType } from '@opentelemetry/api'
 import type { AppWebSocket } from '../../websocket/types'
+import { playerAvatarUrl } from '../../shared/player-avatar-url'
 
 const verifyPlayerTimeout = secondsToMilliseconds(10)
 
@@ -49,7 +50,7 @@ export default fp(
           {
             $set: {
               name: player.name,
-              avatar: player.avatar.small,
+              avatar: playerAvatarUrl(player.avatar, 'small'),
             },
           },
           {

--- a/src/players/views/html/edit-player.page.tsx
+++ b/src/players/views/html/edit-player.page.tsx
@@ -24,6 +24,7 @@ import {
   IconX,
 } from '../../../html/components/icons'
 import { GameClassIcon } from '../../../html/components/game-class-icon'
+import { playerAvatarUrl } from '../../../shared/player-avatar-url'
 import { queue } from '../../../queue-auto'
 import { defaultElo, provisionalThreshold } from '../../../games/calculate-elo-updates'
 import type { Children } from '@kitajs/html'
@@ -76,7 +77,7 @@ export async function EditPlayerProfilePage(props: { steamId: SteamId64 }) {
 
             <div class="row-span-3">
               <img
-                src={player.avatar.large}
+                src={playerAvatarUrl(player.avatar, 'large')}
                 width="184"
                 height="184"
                 class="player-avatar rounded-sm"

--- a/src/players/views/html/player.page.tsx
+++ b/src/players/views/html/player.page.tsx
@@ -2,6 +2,7 @@ import { collections } from '../../../database/collections'
 import { Layout } from '../../../html/layout'
 import { NavigationBar } from '../../../html/components/navigation-bar'
 import { PlayerRole, type PlayerModel } from '../../../database/models/player.model'
+import { playerAvatarUrl } from '../../../shared/player-avatar-url'
 import { format } from 'date-fns'
 import { Tf2ClassName } from '../../../shared/types/tf2-class-name'
 import { queue } from '../../../queue-auto'
@@ -150,7 +151,7 @@ function PlayerPresentation(props: {
   return (
     <div class="player-presentation">
       <img
-        src={props.player.avatar.large}
+        src={playerAvatarUrl(props.player.avatar, 'large')}
         width="184"
         height="184"
         class="player-avatar"

--- a/src/queue-auto/join.ts
+++ b/src/queue-auto/join.ts
@@ -12,6 +12,7 @@ import { getState } from '../queue/get-state'
 import { meetsSkillThreshold } from './meets-skill-threshold'
 import { withQueueLock } from '../queue/with-queue-lock'
 import type { QueueSlotId } from '../queue/types/queue-slot-id'
+import { playerAvatarUrl } from '../shared/player-avatar-url'
 
 export async function join(slotId: QueueSlotId, steamId: SteamId64): Promise<QueueSlotModel[]> {
   logger.trace({ steamId, slotId }, `queue.join()`)
@@ -61,7 +62,7 @@ export async function join(slotId: QueueSlotId, steamId: SteamId64): Promise<Que
           player: {
             steamId: player.steamId,
             name: player.name,
-            avatarUrl: player.avatar.medium,
+            avatarUrl: playerAvatarUrl(player.avatar, 'medium'),
           },
           ready: state === QueueState.ready,
         },

--- a/src/shared/default-player-avatar.ts
+++ b/src/shared/default-player-avatar.ts
@@ -1,0 +1,14 @@
+import type { PlayerAvatar } from '../database/models/player.model'
+
+// Steam's standard placeholder avatar, used when a player has no avatar stored
+// (e.g. accounts Steam no longer returns a summary for, so the avatar backfill
+// migration could not reach them). Keeps profile pages rendering instead of
+// crashing on `avatar.large`.
+const steamDefaultAvatarHash = 'fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb'
+const steamAvatarBaseUrl = 'https://avatars.steamstatic.com'
+
+export const defaultPlayerAvatar: PlayerAvatar = {
+  small: `${steamAvatarBaseUrl}/${steamDefaultAvatarHash}.jpg`,
+  medium: `${steamAvatarBaseUrl}/${steamDefaultAvatarHash}_medium.jpg`,
+  large: `${steamAvatarBaseUrl}/${steamDefaultAvatarHash}_full.jpg`,
+}

--- a/src/shared/default-player-avatar.ts
+++ b/src/shared/default-player-avatar.ts
@@ -1,9 +1,5 @@
 import type { PlayerAvatar } from '../database/models/player.model'
 
-// Steam's standard placeholder avatar, used when a player has no avatar stored
-// (e.g. accounts Steam no longer returns a summary for, so the avatar backfill
-// migration could not reach them). Keeps profile pages rendering instead of
-// crashing on `avatar.large`.
 const steamDefaultAvatarHash = 'fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb'
 const steamAvatarBaseUrl = 'https://avatars.steamstatic.com'
 

--- a/src/shared/player-avatar-url.test.ts
+++ b/src/shared/player-avatar-url.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { playerAvatarUrl } from './player-avatar-url'
+import { defaultPlayerAvatar } from './default-player-avatar'
+
+describe('playerAvatarUrl', () => {
+  it("should return the player's avatar url for the requested size", () => {
+    const avatar = {
+      small: 'https://example.com/small.jpg',
+      medium: 'https://example.com/medium.jpg',
+      large: 'https://example.com/large.jpg',
+    }
+    expect(playerAvatarUrl(avatar, 'small')).toBe(avatar.small)
+    expect(playerAvatarUrl(avatar, 'medium')).toBe(avatar.medium)
+    expect(playerAvatarUrl(avatar, 'large')).toBe(avatar.large)
+  })
+
+  it('should fall back to the default avatar when the avatar is missing', () => {
+    expect(playerAvatarUrl(undefined, 'large')).toBe(defaultPlayerAvatar.large)
+    expect(playerAvatarUrl(undefined, 'medium')).toBe(defaultPlayerAvatar.medium)
+    expect(playerAvatarUrl(undefined, 'small')).toBe(defaultPlayerAvatar.small)
+  })
+
+  it('should fall back to the default avatar when the requested size is missing', () => {
+    expect(playerAvatarUrl({ medium: 'https://example.com/medium.jpg' }, 'large')).toBe(
+      defaultPlayerAvatar.large,
+    )
+  })
+})

--- a/src/shared/player-avatar-url.ts
+++ b/src/shared/player-avatar-url.ts
@@ -1,11 +1,6 @@
 import type { PlayerAvatar } from '../database/models/player.model'
 import { defaultPlayerAvatar } from './default-player-avatar'
 
-// Resolve an avatar image URL, falling back to Steam's placeholder avatar when
-// the player has no avatar stored. The model types `avatar` as required, but the
-// database can hold documents without it (accounts Steam no longer returns a
-// summary for, which the avatar backfill migration could not reach), so guarding
-// here keeps profile pages from crashing on `avatar.large`.
 export function playerAvatarUrl(
   avatar: Partial<PlayerAvatar> | undefined,
   size: keyof PlayerAvatar,

--- a/src/shared/player-avatar-url.ts
+++ b/src/shared/player-avatar-url.ts
@@ -1,0 +1,14 @@
+import type { PlayerAvatar } from '../database/models/player.model'
+import { defaultPlayerAvatar } from './default-player-avatar'
+
+// Resolve an avatar image URL, falling back to Steam's placeholder avatar when
+// the player has no avatar stored. The model types `avatar` as required, but the
+// database can hold documents without it (accounts Steam no longer returns a
+// summary for, which the avatar backfill migration could not reach), so guarding
+// here keeps profile pages from crashing on `avatar.large`.
+export function playerAvatarUrl(
+  avatar: Partial<PlayerAvatar> | undefined,
+  size: keyof PlayerAvatar,
+): string {
+  return avatar?.[size] ?? defaultPlayerAvatar[size]
+}


### PR DESCRIPTION
## Problem

Player profile pages were crashing in production (observed on `hl-tf2pickup-eu`, v4.12.0) with:

```
TypeError: Cannot read properties of undefined (reading 'large')
    at PlayerPresentation (src/players/views/html/player.page.tsx:153)
```

The `avatar` field is typed as required on `PlayerModel`, but the database can hold documents without it. The avatar backfill migration (`022-fix-missing-player-avatars`) is a **one-time, best-effort** job: it skips whole batches on Steam API errors and never updates players Steam omits from its response (deleted / banned / unfetchable accounts). Those players keep an `undefined` avatar and crash every view that reads `avatar.large` / `avatar.medium`.

## Fix

- Add `src/shared/default-player-avatar.ts` — Steam's standard placeholder avatar typed as a `PlayerAvatar`.
- Add `src/shared/player-avatar-url.ts` — `playerAvatarUrl(avatar, size)` helper that returns the requested size or falls back to the default. Its param accepts a possibly-undefined avatar, so the guard is legitimate (the type-aware `no-unnecessary-condition` lint rule rejects an inline `?.`/`??` because the model types `avatar` as required).
- Route every runtime avatar read through the helper:
  - Views: player page, edit-player page, nav profile, game slot, hall of fame
  - Discord notifications: bans, chat mutes, change, created, verification, skill changes
  - Hot paths: queue join, online-players

DTO passthroughs (`player-to-dto.ts`, `online-players/index.ts`) are left untouched — they emit the avatar object into JSON and never dereference `.large`/`.medium`, so they cannot crash.

## Why not make `avatar` optional?

That would ripple into ~15 sites and change API DTO semantics. A contained helper fixes the crash with a single source of truth for the fallback.

## Tests

- New `player-avatar-url.test.ts` covering present avatar, missing avatar, and missing-size cases.
- `pnpm lint` and `pnpm test` (285 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)