### PR TITLE
feat(players): periodically re-sync player avatars from Steam

### DIFF
--- a/src/database/ensure-indexes.ts
+++ b/src/database/ensure-indexes.ts
@@ -23,6 +23,7 @@ const definitions: Partial<Record<keyof typeof collections, IndexDefinition[]>> 
     { spec: { steamId: 1 }, options: { unique: true } },
     { spec: { 'stats.totalGames': -1 } },
     { spec: { 'stats.gamesByClass.medic': -1 } },
+    { spec: { avatarLastSyncedAt: 1 } },
   ],
   games: [
     { spec: { number: 1 }, options: { unique: true } },

--- a/src/database/models/player.model.ts
+++ b/src/database/models/player.model.ts
@@ -53,6 +53,7 @@ export interface PlayerModel {
   steamId: SteamId64
   joinedAt: Date
   avatar: PlayerAvatar
+  avatarLastSyncedAt?: Date
   roles: PlayerRole[]
   hasAcceptedRules: boolean
   etf2lProfile?: Etf2lProfile

--- a/src/players/plugins/auto-resync-avatars.ts
+++ b/src/players/plugins/auto-resync-avatars.ts
@@ -1,0 +1,18 @@
+import { minutesToMilliseconds } from 'date-fns'
+import fp from 'fastify-plugin'
+import { safe } from '../../utils/safe'
+import { syncAvatars } from '../sync-avatars'
+
+// One batch (up to 100 players) every 5 minutes keeps Steam API usage low while
+// still refreshing tens of thousands of avatars per day.
+const syncInterval = minutesToMilliseconds(5)
+
+export default fp(
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async app => {
+    app.addHook('onReady', () => {
+      setInterval(safe(syncAvatars), syncInterval)
+    })
+  },
+  { name: 'auto resync avatars' },
+)

--- a/src/players/sync-avatars.test.ts
+++ b/src/players/sync-avatars.test.ts
@@ -21,8 +21,7 @@ vi.mock('../database/collections', () => ({
   collections: {
     players: {
       find: vi.fn(() => ({ toArray })),
-      updateOne: vi.fn(),
-      updateMany: vi.fn(),
+      bulkWrite: vi.fn(),
     },
   },
 }))
@@ -46,7 +45,7 @@ describe('syncAvatars', () => {
     await syncAvatars()
 
     expect(getUserSummary).not.toHaveBeenCalled()
-    expect(collections.players.updateOne).not.toHaveBeenCalled()
+    expect(collections.players.bulkWrite).not.toHaveBeenCalled()
   })
 
   it('updates avatars for the players Steam returns', async () => {
@@ -59,17 +58,30 @@ describe('syncAvatars', () => {
     await syncAvatars()
 
     expect(getUserSummary).toHaveBeenCalledWith(['11', '22'])
-    expect(collections.players.updateOne).toHaveBeenCalledWith(
-      { steamId: '11' },
+    expect(collections.players.bulkWrite).toHaveBeenCalledWith([
       {
-        $set: {
-          avatar: { small: 's1', medium: 'm1', large: 'l1' },
-          avatarLastSyncedAt: expect.any(Date),
+        updateOne: {
+          filter: { steamId: '11' },
+          update: {
+            $set: {
+              avatar: { small: 's1', medium: 'm1', large: 'l1' },
+              avatarLastSyncedAt: expect.any(Date),
+            },
+          },
         },
       },
-    )
-    expect(collections.players.updateOne).toHaveBeenCalledTimes(2)
-    expect(collections.players.updateMany).not.toHaveBeenCalled()
+      {
+        updateOne: {
+          filter: { steamId: '22' },
+          update: {
+            $set: {
+              avatar: { small: 's2', medium: 'm2', large: 'l2' },
+              avatarLastSyncedAt: expect.any(Date),
+            },
+          },
+        },
+      },
+    ])
   })
 
   it('marks players Steam does not return as synced so they stop blocking the queue', async () => {
@@ -80,11 +92,25 @@ describe('syncAvatars', () => {
 
     await syncAvatars()
 
-    expect(collections.players.updateOne).toHaveBeenCalledTimes(1)
-    expect(collections.players.updateMany).toHaveBeenCalledWith(
-      { steamId: { $in: ['99'] } },
-      { $set: { avatarLastSyncedAt: expect.any(Date) } },
-    )
+    expect(collections.players.bulkWrite).toHaveBeenCalledWith([
+      {
+        updateOne: {
+          filter: { steamId: '11' },
+          update: {
+            $set: {
+              avatar: { small: 's1', medium: 'm1', large: 'l1' },
+              avatarLastSyncedAt: expect.any(Date),
+            },
+          },
+        },
+      },
+      {
+        updateMany: {
+          filter: { steamId: { $in: ['99'] } },
+          update: { $set: { avatarLastSyncedAt: expect.any(Date) } },
+        },
+      },
+    ])
   })
 
   it('writes nothing when the Steam request fails', async () => {
@@ -93,7 +119,6 @@ describe('syncAvatars', () => {
 
     await syncAvatars()
 
-    expect(collections.players.updateOne).not.toHaveBeenCalled()
-    expect(collections.players.updateMany).not.toHaveBeenCalled()
+    expect(collections.players.bulkWrite).not.toHaveBeenCalled()
   })
 })

--- a/src/players/sync-avatars.test.ts
+++ b/src/players/sync-avatars.test.ts
@@ -119,11 +119,14 @@ describe('syncAvatars', () => {
 
     await syncAvatars()
 
-    expect(collections.players.updateOne).not.toHaveBeenCalled()
-    expect(collections.players.updateMany).toHaveBeenCalledWith(
-      { steamId: { $in: ['11', '22'] } },
-      { $set: { avatarLastSyncedAt: expect.any(Date) } },
-    )
+    expect(collections.players.bulkWrite).toHaveBeenCalledWith([
+      {
+        updateMany: {
+          filter: { steamId: { $in: ['11', '22'] } },
+          update: { $set: { avatarLastSyncedAt: expect.any(Date) } },
+        },
+      },
+    ])
   })
 
   it('writes nothing when the Steam request fails', async () => {

--- a/src/players/sync-avatars.test.ts
+++ b/src/players/sync-avatars.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { getUserSummary } = vi.hoisted(() => ({ getUserSummary: vi.fn() }))
+
+vi.mock('steamapi', () => ({
+  default: class {
+    getUserSummary = getUserSummary
+  },
+}))
+
+vi.mock('../environment', () => ({
+  environment: { STEAM_API_KEY: 'test-key' },
+}))
+
+vi.mock('../shared/schemas/steam-id-64', () => ({
+  steamId64: { parse: (value: string) => value },
+}))
+
+const toArray = vi.fn()
+vi.mock('../database/collections', () => ({
+  collections: {
+    players: {
+      find: vi.fn(() => ({ toArray })),
+      updateOne: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('../logger', () => ({
+  logger: { warn: vi.fn(), debug: vi.fn() },
+}))
+
+import { collections } from '../database/collections'
+import { syncAvatars } from './sync-avatars'
+
+describe('syncAvatars', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    toArray.mockResolvedValue([])
+  })
+
+  it('does nothing when no players need syncing', async () => {
+    toArray.mockResolvedValue([])
+
+    await syncAvatars()
+
+    expect(getUserSummary).not.toHaveBeenCalled()
+    expect(collections.players.updateOne).not.toHaveBeenCalled()
+  })
+
+  it('updates avatars for the players Steam returns', async () => {
+    toArray.mockResolvedValue([{ steamId: '11' }, { steamId: '22' }])
+    getUserSummary.mockResolvedValue([
+      { steamID: '11', avatar: { small: 's1', medium: 'm1', large: 'l1' } },
+      { steamID: '22', avatar: { small: 's2', medium: 'm2', large: 'l2' } },
+    ])
+
+    await syncAvatars()
+
+    expect(getUserSummary).toHaveBeenCalledWith(['11', '22'])
+    expect(collections.players.updateOne).toHaveBeenCalledWith(
+      { steamId: '11' },
+      {
+        $set: {
+          avatar: { small: 's1', medium: 'm1', large: 'l1' },
+          avatarLastSyncedAt: expect.any(Date),
+        },
+      },
+    )
+    expect(collections.players.updateOne).toHaveBeenCalledTimes(2)
+    expect(collections.players.updateMany).not.toHaveBeenCalled()
+  })
+
+  it('marks players Steam does not return as synced so they stop blocking the queue', async () => {
+    toArray.mockResolvedValue([{ steamId: '11' }, { steamId: '99' }])
+    getUserSummary.mockResolvedValue([
+      { steamID: '11', avatar: { small: 's1', medium: 'm1', large: 'l1' } },
+    ])
+
+    await syncAvatars()
+
+    expect(collections.players.updateOne).toHaveBeenCalledTimes(1)
+    expect(collections.players.updateMany).toHaveBeenCalledWith(
+      { steamId: { $in: ['99'] } },
+      { $set: { avatarLastSyncedAt: expect.any(Date) } },
+    )
+  })
+
+  it('writes nothing when the Steam request fails', async () => {
+    toArray.mockResolvedValue([{ steamId: '11' }])
+    getUserSummary.mockRejectedValue(new Error('rate limited'))
+
+    await syncAvatars()
+
+    expect(collections.players.updateOne).not.toHaveBeenCalled()
+    expect(collections.players.updateMany).not.toHaveBeenCalled()
+  })
+})

--- a/src/players/sync-avatars.test.ts
+++ b/src/players/sync-avatars.test.ts
@@ -113,6 +113,19 @@ describe('syncAvatars', () => {
     ])
   })
 
+  it('marks the whole batch as synced when Steam returns no players', async () => {
+    toArray.mockResolvedValue([{ steamId: '11' }, { steamId: '22' }])
+    getUserSummary.mockRejectedValue(new Error('No players found'))
+
+    await syncAvatars()
+
+    expect(collections.players.updateOne).not.toHaveBeenCalled()
+    expect(collections.players.updateMany).toHaveBeenCalledWith(
+      { steamId: { $in: ['11', '22'] } },
+      { $set: { avatarLastSyncedAt: expect.any(Date) } },
+    )
+  })
+
   it('writes nothing when the Steam request fails', async () => {
     toArray.mockResolvedValue([{ steamId: '11' }])
     getUserSummary.mockRejectedValue(new Error('rate limited'))

--- a/src/players/sync-avatars.ts
+++ b/src/players/sync-avatars.ts
@@ -7,32 +7,16 @@ import { steamId64 } from '../shared/schemas/steam-id-64'
 
 const steamApi = new SteamAPI(environment.STEAM_API_KEY)
 
-// Steam's GetPlayerSummaries accepts up to 100 steam ids per request, so one
-// batch is a single API call.
 const batchSize = 100
-
-// How long a synced avatar is considered fresh before it is refreshed again.
 const staleAfterDays = 7
 
-/**
- * Refresh stored player avatars from Steam, one batch per call.
- *
- * Players are picked oldest-first by `avatarLastSyncedAt`, so accounts that have
- * never been synced (e.g. those the avatar backfill migration could not reach,
- * which currently fall back to the default avatar) are prioritised, followed by
- * the players whose avatars are the most stale.
- *
- * Avatars are written directly to the collection (no `player:updated` event) to
- * avoid triggering downstream listeners on a routine refresh.
- */
 export async function syncAvatars() {
-  const staleThreshold = subDays(new Date(), staleAfterDays)
   const candidates = await collections.players
     .find(
       {
         $or: [
           { avatarLastSyncedAt: { $exists: false } },
-          { avatarLastSyncedAt: { $lt: staleThreshold } },
+          { avatarLastSyncedAt: { $lt: subDays(new Date(), staleAfterDays) } },
         ],
       },
       { projection: { steamId: 1 }, sort: { avatarLastSyncedAt: 1 }, limit: batchSize },
@@ -50,8 +34,15 @@ export async function syncAvatars() {
   try {
     summaries = await steamApi.getUserSummary(steamIds)
   } catch (error) {
-    logger.warn({ error }, 'failed to fetch Steam summaries while syncing avatars')
-    return
+    // steamapi throws when Steam returns no players at all (the whole batch is
+    // deleted / banned / private). Treat that as an empty result so the batch
+    // still gets marked as synced below and stops sorting first forever.
+    if (error instanceof Error && error.message === 'No players found') {
+      summaries = []
+    } else {
+      logger.warn({ error }, 'failed to fetch Steam summaries while syncing avatars')
+      return
+    }
   }
 
   const summaryArray = Array.isArray(summaries) ? summaries : [summaries]

--- a/src/players/sync-avatars.ts
+++ b/src/players/sync-avatars.ts
@@ -1,0 +1,91 @@
+import SteamAPI from 'steamapi'
+import { subDays } from 'date-fns'
+import { collections } from '../database/collections'
+import { environment } from '../environment'
+import { logger } from '../logger'
+import { steamId64 } from '../shared/schemas/steam-id-64'
+
+const steamApi = new SteamAPI(environment.STEAM_API_KEY)
+
+// Steam's GetPlayerSummaries accepts up to 100 steam ids per request, so one
+// batch is a single API call.
+const batchSize = 100
+
+// How long a synced avatar is considered fresh before it is refreshed again.
+const staleAfterDays = 7
+
+/**
+ * Refresh stored player avatars from Steam, one batch per call.
+ *
+ * Players are picked oldest-first by `avatarLastSyncedAt`, so accounts that have
+ * never been synced (e.g. those the avatar backfill migration could not reach,
+ * which currently fall back to the default avatar) are prioritised, followed by
+ * the players whose avatars are the most stale.
+ *
+ * Avatars are written directly to the collection (no `player:updated` event) to
+ * avoid triggering downstream listeners on a routine refresh.
+ */
+export async function syncAvatars() {
+  const staleThreshold = subDays(new Date(), staleAfterDays)
+  const candidates = await collections.players
+    .find(
+      {
+        $or: [
+          { avatarLastSyncedAt: { $exists: false } },
+          { avatarLastSyncedAt: { $lt: staleThreshold } },
+        ],
+      },
+      { projection: { steamId: 1 }, sort: { avatarLastSyncedAt: 1 }, limit: batchSize },
+    )
+    .toArray()
+
+  if (candidates.length === 0) {
+    return
+  }
+
+  const steamIds = candidates.map(p => p.steamId)
+  const now = new Date()
+
+  let summaries: Awaited<ReturnType<typeof steamApi.getUserSummary>>
+  try {
+    summaries = await steamApi.getUserSummary(steamIds)
+  } catch (error) {
+    logger.warn({ error }, 'failed to fetch Steam summaries while syncing avatars')
+    return
+  }
+
+  const summaryArray = Array.isArray(summaries) ? summaries : [summaries]
+
+  for (const summary of summaryArray) {
+    await collections.players.updateOne(
+      { steamId: steamId64.parse(summary.steamID) },
+      {
+        $set: {
+          avatar: {
+            small: summary.avatar.small,
+            medium: summary.avatar.medium,
+            large: summary.avatar.large,
+          },
+          avatarLastSyncedAt: now,
+        },
+      },
+    )
+  }
+
+  // Mark players Steam returned no summary for (deleted / banned / private
+  // accounts) as synced too, so they don't keep sorting first and starving the
+  // rest of the player base on every cycle.
+  const syncedIds = new Set(summaryArray.map(summary => steamId64.parse(summary.steamID)))
+  const notReturned = steamIds.filter(steamId => !syncedIds.has(steamId))
+  if (notReturned.length > 0) {
+    await collections.players.updateMany(
+      { steamId: { $in: notReturned } },
+      { $set: { avatarLastSyncedAt: now } },
+    )
+  }
+
+  logger.debug(
+    { requested: steamIds.length, updated: summaryArray.length, skipped: notReturned.length },
+    'synced player avatars',
+  )
+}

--- a/src/players/sync-avatars.ts
+++ b/src/players/sync-avatars.ts
@@ -56,10 +56,11 @@ export async function syncAvatars() {
 
   const summaryArray = Array.isArray(summaries) ? summaries : [summaries]
 
-  for (const summary of summaryArray) {
-    await collections.players.updateOne(
-      { steamId: steamId64.parse(summary.steamID) },
-      {
+  type AvatarSyncOp = Parameters<typeof collections.players.bulkWrite>[0][number]
+  const operations: AvatarSyncOp[] = summaryArray.map(summary => ({
+    updateOne: {
+      filter: { steamId: steamId64.parse(summary.steamID) },
+      update: {
         $set: {
           avatar: {
             small: summary.avatar.small,
@@ -69,8 +70,8 @@ export async function syncAvatars() {
           avatarLastSyncedAt: now,
         },
       },
-    )
-  }
+    },
+  }))
 
   // Mark players Steam returned no summary for (deleted / banned / private
   // accounts) as synced too, so they don't keep sorting first and starving the
@@ -78,11 +79,16 @@ export async function syncAvatars() {
   const syncedIds = new Set(summaryArray.map(summary => steamId64.parse(summary.steamID)))
   const notReturned = steamIds.filter(steamId => !syncedIds.has(steamId))
   if (notReturned.length > 0) {
-    await collections.players.updateMany(
-      { steamId: { $in: notReturned } },
-      { $set: { avatarLastSyncedAt: now } },
-    )
+    operations.push({
+      updateMany: {
+        filter: { steamId: { $in: notReturned } },
+        update: { $set: { avatarLastSyncedAt: now } },
+      },
+    })
   }
+
+  // A single batched round-trip instead of one write per player.
+  await collections.players.bulkWrite(operations)
 
   logger.debug(
     { requested: steamIds.length, updated: summaryArray.length, skipped: notReturned.length },


### PR DESCRIPTION
## Why

Player avatars are only fetched at login/registration and by the one-time `022-fix-missing-player-avatars` backfill migration. As noted in #679, that leaves two gaps:

- Players Steam couldn't return a summary for at backfill time (deleted / banned / private accounts) keep **no avatar** and fall back to the default placeholder forever.
- Everyone else's avatar goes stale — a player who changes their Steam avatar but never re-logs in keeps the old one indefinitely.

This adds a background job that keeps avatars fresh and gradually repairs missing ones.

## How

- **New field** `avatarLastSyncedAt?: Date` on `PlayerModel`. Optional, populated over time — no migration needed. Documents missing it sort first in MongoDB, so never-synced players (including those currently on the default avatar) get priority.
- **`syncAvatars()`** (`src/players/sync-avatars.ts`) — one batch per call:
  - Picks up to 100 players where `avatarLastSyncedAt` is missing or older than 7 days, oldest-first.
  - Fetches summaries in a single `getUserSummary` call and writes `avatar` + `avatarLastSyncedAt`.
  - Marks players Steam returns *no* summary for as synced too, so they don't sort first forever and starve the rest of the player base.
  - Writes go **straight to the collection** (no `player:updated` event) so a routine refresh doesn't trigger Discord notifications or other listeners.
- **Plugin** `src/players/plugins/auto-resync-avatars.ts` — runs `syncAvatars` every 5 minutes via `setInterval` on `onReady` (same pattern as `twitch-tv/auto-refresh-streams`).

## Rate / throughput

100 players every 5 min = one Steam API call per cycle, ~28,800 avatars/day. A community of a few thousand players fully refreshes well within a day, then the job idles (no-op) until avatars age past the 7-day threshold.

## Tests

- `src/players/sync-avatars.test.ts` covers: nothing to sync, normal batch update, marking Steam-omitted players as synced, and no writes on a failed Steam request.
- `pnpm lint` and `pnpm test` (286 unit tests) pass.

## Relationship to #679

Complementary but independent (branched from `master`). #679 stops the crash and shows a default avatar; this PR repairs the underlying data so those players get real avatars again when possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)