### PR TITLE
chore(logging): log client errors below error level

### DIFF
--- a/src/etf2l/sync-player-profile.ts
+++ b/src/etf2l/sync-player-profile.ts
@@ -32,7 +32,7 @@ export async function syncPlayerProfile(playerId: SteamId64) {
           })
           break
         case 429:
-          logger.warn(
+          logger.debug(
             { steamId: player.steamId },
             'ETF2L API rate limited while syncing player profile, rescheduling',
           )

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,9 +89,8 @@ app.addHook('onSend', async (request, reply) => {
 })
 
 app.setErrorHandler((error, request, reply) => {
-  logger.error(error)
-
   if (!(error instanceof Error)) {
+    logger.error(error)
     return
   }
 
@@ -100,6 +99,17 @@ app.setErrorHandler((error, request, reply) => {
   if ('statusCode' in error && typeof error.statusCode === 'number') {
     statusCode = error.statusCode
     message = error.message
+  }
+
+  // Only server faults (5xx) are genuine errors. Client errors (4xx) are routine
+  // — unknown players, aborted games, queue races, validation — so don't log
+  // them at error level. 404s and 429s are noisy enough to belong at info.
+  if (statusCode >= 500) {
+    logger.error(error)
+  } else if (statusCode === 404 || statusCode === 429) {
+    logger.info(error)
+  } else {
+    logger.warn(error)
   }
 
   const accept = request.accepts()


### PR DESCRIPTION
## Why

The global error handler logged **every** error at error level regardless of HTTP status:

```ts
app.setErrorHandler((error, request, reply) => {
  logger.error(error)   // fires for 429s, 404s, 400s alike
```

Over 24h that meant routine 4xx client responses dominated the error stream (~700/day, roughly half of all error+warn volume):

| /day | Status | Message |
|-----:|--------|---------|
| 455 | 429 | `Rate limit exceeded, retry in N second(s)` (@fastify/rate-limit throttling) |
| 119 | 404 | `Player with steamId … does not exist` |
| 98 | 404 | `game (…) not found` |
| 29 | 400 | `slot occupied` |
| 9 | 404 | `Not Found` |
| 2 | 400 | `params/steamId Invalid string …` (Zod) |

These are normal client-side conditions, not server faults.

## Changes

1. **`src/main.ts` error handler** — pick log severity by status code: 5xx (or non-`Error` throwables / unknown status) → `error`; 404 and 429 → `info`; other 4xx → `warn`. Response behaviour is unchanged. Non-`Error` throwables still log at error and return as before.
2. **`src/etf2l/sync-player-profile.ts`** — the ETF2L 429 backoff message (~690/day) is expected rescheduling, not a problem; dropped from `warn` to `debug`.

Combined, this moves ~1,400 routine entries/day out of error/warn without hiding anything: real server faults still log at error, and everything is still emitted (just at an appropriate level).

## Not included

- The double-reply bug (`Cannot write headers after they are sent` / `Reply was already sent…` on `/players/:steamId` and `/admin/*`) is a genuine code fault, not log noise — left for a separate PR so it isn't silenced.
- The high ETF2L 429 rate itself may warrant pacing the sync scheduler; that's a behaviour change, out of scope here.

## Tests

`pnpm lint` and `pnpm test` (282 unit tests) pass. No tests assert on these log calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)