### PR TITLE
fix(logger): use pino-princess as inline stream in dev

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,3 +28,5 @@ publicHoistPattern:
   - '@fastify/*'
   - '@opentelemetry/*'
   - 'thread-stream'
+  - 'sonic-boom'
+  - 'pino-std-serializers'

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,4 @@
 import pino from 'pino'
-import princess from 'pino-princess'
 import { logs } from '@opentelemetry/api-logs'
 import { trace } from '@opentelemetry/api'
 import type { AttributeValue, Attributes } from '@opentelemetry/api'
@@ -82,6 +81,8 @@ const otelStream = {
 const stream =
   environment.NODE_ENV === 'production'
     ? pino.multistream([{ stream: process.stdout }, { stream: otelStream }])
-    : (princess() as pino.DestinationStream)
+    : // pino-princess is a devDependency and absent from the production image,
+      // so it must be loaded lazily and only on the dev path.
+      ((await import('pino-princess')).default() as pino.DestinationStream)
 
 export const logger = pino({ level: environment.LOG_LEVEL }, stream)

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,5 @@
 import pino from 'pino'
+import princess from 'pino-princess'
 import { logs } from '@opentelemetry/api-logs'
 import { trace } from '@opentelemetry/api'
 import type { AttributeValue, Attributes } from '@opentelemetry/api'
@@ -81,6 +82,6 @@ const otelStream = {
 const stream =
   environment.NODE_ENV === 'production'
     ? pino.multistream([{ stream: process.stdout }, { stream: otelStream }])
-    : (pino.transport({ target: 'pino-princess' }) as pino.DestinationStream)
+    : (princess() as pino.DestinationStream)
 
 export const logger = pino({ level: environment.LOG_LEVEL }, stream)


### PR DESCRIPTION
## Problem

`pnpm dev` crashes on startup with:

```
Error: this should not happen: undefined
    at Worker.onWorkerMessage (.../thread-stream@4.0.0/.../index.js:190:23)
```

## Root cause

`src/logger.ts` set up the dev log prettifier via `pino.transport({ target: 'pino-princess' })`, which runs the transport in a **worker thread** (via `thread-stream`). `tsx --watch` is incompatible with pino worker-thread transports — its loader hooks break the worker's message channel, so `thread-stream` throws and the process dies before `main.ts` runs.

Confirmed with a minimal repro: plain `node` and plain `tsx` both work; only `tsx --watch` crashes.

## Fix

Use `pino-princess` as an inline stream instead of via `pino.transport`, avoiding the worker thread entirely. Same pretty dev logs, no crash. Production logging (multistream → stdout + OTel) is unchanged.

Verified: `pnpm dev` now starts cleanly through to `Server listening at http://127.0.0.1:3000`, and `pnpm lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)