### PR TITLE
fix(etf2l): surface the real cause in scheduled task error logs

### DIFF
--- a/src/etf2l/errors/etf2l-api.error.ts
+++ b/src/etf2l/errors/etf2l-api.error.ts
@@ -2,8 +2,9 @@ export class Etf2lApiError extends Error {
   constructor(
     public readonly url: string,
     public readonly response: Response,
-    public override readonly message: string,
+    public readonly detail: string,
   ) {
-    super(`ETF2L API error (${url}): ${message}`)
+    super(`ETF2L API error (${url}): ${detail}`)
+    this.name = 'Etf2lApiError'
   }
 }

--- a/src/tasks/arm.test.ts
+++ b/src/tasks/arm.test.ts
@@ -105,7 +105,10 @@ describe('arm()', () => {
     arm(task)
 
     await vi.advanceTimersByTimeAsync(5000)
-    expect(logger.error).toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.stringContaining('games.freePlayer'),
+    )
     expect(taskExecutionCount.add).toHaveBeenCalledWith(1, {
       name: 'games.freePlayer',
       result: 'error',

--- a/src/tasks/arm.ts
+++ b/src/tasks/arm.ts
@@ -49,7 +49,7 @@ export function arm(task: WithId<TaskModel>) {
       )
     } catch (error) {
       assertIsError(error)
-      logger.error(error)
+      logger.error(error, `scheduled task failed: ${task.name}`)
     }
   }
 }


### PR DESCRIPTION
## Why

The new `tf2pickup.tasks.execution.count{result=error}` metric (from #671) surfaced a flood of `etf2l:syncPlayerProfile` failures, but the logs only said `403 Forbidden` — no URL, no error type, no indication of which task. The actual cause (ETF2L temporarily putting `api-v2.etf2l.org` behind a Cloudflare challenge after a DDoS) was hard to pin down from the log alone.

Root cause of the unhelpful message: `Etf2lApiError` declared `public override readonly message`, a parameter property that runs **after** `super(...)` and overwrites the descriptive message with the bare status text.

## What

- **`Etf2lApiError`**: rename the constructor param `message` → `detail` so the descriptive `ETF2L API error (<url>): <detail>` message survives, and set `this.name = 'Etf2lApiError'`. The raw status is still available via `.detail`.
- **`arm()`**: include the task name in the failure log (`scheduled task failed: <name>`) so *any* scheduled task error identifies which task failed.

A failed sync now logs:
- **body:** `scheduled task failed: etf2l:syncPlayerProfile`
- **exception.type:** `Etf2lApiError`
- **exception.message:** `ETF2L API error (http://api-v2.etf2l.org/player/…): 403 Forbidden`

No behavior change — failures still throw and are still counted by the error metric; only the logged context improves.

## Tests

- Updated `arm.test.ts` to assert the failure log carries the task name.
- Full suite + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)