### PR TITLE
ci: pin mumble-server image to v1.5.901

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,10 @@ jobs:
           - 27017:27017
 
       mumble:
-        image: mumblevoip/mumble-server:latest
+        # Pinned: mumble-server 1.6.x rejects the SuperUser password login the
+        # e2e suite relies on ("Wrong certificate or password for existing user").
+        # 1.5.901 is the last version known to work. See tests/20-game/10-setup-mumble-server.spec.ts
+        image: mumblevoip/mumble-server:v1.5.901
         ports:
           - 64738:64738/tcp
           - 64738:64738/udp


### PR DESCRIPTION
## Problem

CI has been failing across **all** branches (renovate, docs, feature branches alike). The failing job is `end to end (...)` → **Run Playwright tests**, specifically:

```
tests/20-game/10-setup-mumble-server.spec.ts:7 › renders join voice button @6v6 @9v9
Error: Wrong certificate or password for existing user
```

It fails deterministically on all 3 retries, which ruled out flakiness.

## Root cause

The e2e workflow uses `mumblevoip/mumble-server:latest`. That tag rolled over:

| When | Mumble version | Result |
|------|----------------|--------|
| ≤ 2026-06-20 | `1.5.901` | ✅ passing |
| 2026-06-21 | `1.6.870` | ❌ failing |

The test connects to the Mumble server as `SuperUser` with a password (`configure-mumble-server.ts`). Mumble 1.6.x rejects that login with *"Wrong certificate or password for existing user"*, so the fixture can never connect.

Because the image is unpinned and the test infra is shared, every branch's CI broke at once — independent of the code under test.

## Fix

Pin the service image to `mumblevoip/mumble-server:v1.5.901` (the last known-good version) to restore CI. Adapting the test/fixture to Mumble 1.6's auth behavior can be done as separate follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)