### PR TITLE
perf: serve player list query from a covering index

### DIFF
--- a/src/database/ensure-indexes.ts
+++ b/src/database/ensure-indexes.ts
@@ -21,6 +21,8 @@ const definitions: Partial<Record<keyof typeof collections, IndexDefinition[]>> 
   ],
   players: [
     { spec: { steamId: 1 }, options: { unique: true } },
+    // Covers the player list query (steamId + name, no _id) so it runs index-only.
+    { spec: { steamId: 1, name: 1 } },
     { spec: { 'stats.totalGames': -1 } },
     { spec: { 'stats.gamesByClass.medic': -1 } },
   ],

--- a/src/players/views/html/player-list.page.tsx
+++ b/src/players/views/html/player-list.page.tsx
@@ -13,7 +13,9 @@ const groups = ['#', ...alpha.map(x => String.fromCharCode(x))]
 
 export async function PlayerListPage() {
   const players = await collections.players
-    .find<Pick<PlayerModel, 'steamId' | 'name'>>({}, { projection: { steamId: 1, name: 1 } })
+    .find<
+      Pick<PlayerModel, 'steamId' | 'name'>
+    >({}, { projection: { _id: 0, steamId: 1, name: 1 } })
     .toArray()
   const groupedPlayers = groupPlayers(players)
 


### PR DESCRIPTION
The `/players` page reads only `steamId` and `name`, but the projection still implicitly included `_id` and no index covered both fields. So MongoDB ran `COLLSCAN → FETCH`, loading every full player document — including the unbounded `skillHistory[]` / `eloHistory[]` / `nameHistory[]` arrays — into the working set just to keep two fields and discard the rest.

## What changed
- Add a `{ steamId: 1, name: 1 }` index to the `players` collection.
- Drop `_id` from the query projection (`{ _id: 0, steamId: 1, name: 1 }`); the view never uses it.

Together these make the query **index-only** (`IXSCAN`, no `FETCH`) — the heavy documents are never read. It's a constant-factor I/O win (the page still lists all players), but a meaningful one given how large player docs grow.

Independent of #692 — branched off `master`.