### PR TITLE
fix: stop logging routine queue and match events as errors

### DIFF
--- a/src/games/plugins/match-event-handler.ts
+++ b/src/games/plugins/match-event-handler.ts
@@ -14,6 +14,16 @@ export default fp(
     events.on(
       'match:started',
       safe(async ({ gameNumber }) => {
+        // Game servers fire match:started repeatedly (map load, mp_restartgame).
+        // The first event transitions the game launching -> started; ignore the
+        // rest instead of failing to find a launching game.
+        const game = await collections.games.findOne(
+          { number: gameNumber },
+          { projection: { state: 1 } },
+        )
+        if (game?.state !== GameState.launching) {
+          return
+        }
         await update(
           { number: gameNumber, state: GameState.launching },
           {

--- a/src/queue-auto/plugins/gateway-listeners.ts
+++ b/src/queue-auto/plugins/gateway-listeners.ts
@@ -55,7 +55,23 @@ export default fp(
             })
           },
         ).catch(async (error: unknown) => {
-          logger.error(error)
+          // Mirror the HTTP error handler (src/main.ts): only server faults (5xx)
+          // are genuine errors. Client errors (4xx) — queue races ('slot occupied'),
+          // invalid state, unauthorized — are routine, so don't log them at error level.
+          if (
+            error instanceof Error &&
+            'statusCode' in error &&
+            typeof error.statusCode === 'number' &&
+            error.statusCode < 500
+          ) {
+            if (error.statusCode === 404 || error.statusCode === 429) {
+              logger.info(error)
+            } else {
+              logger.warn(error)
+            }
+          } else {
+            logger.error(error)
+          }
           if (error instanceof Error) {
             const msg = await FlashMessage({
               message: `Error: ${error.message}`,


### PR DESCRIPTION
Two high-volume log lines on production are routine outcomes logged at **error** level with stacktraces, because they're raised outside the HTTP path and so bypass the status-aware error handler in `src/main.ts`.

### `slot occupied` (~320/7d)
A `400` thrown in `queue-auto/join.ts` when two players race for the same queue slot — the loser's atomic `findOneAndUpdate` matches nothing. Caught by `wsSafe`, which logged everything at `error`. Now mirrors the HTTP handler: 4xx → warn/info.

### `game not found` (clusters of ~5-7 per game)
Game servers fire `match:started` repeatedly (map load, `mp_restartgame`). The first event flips the game `launching → started`; the rest no longer match the `{ state: launching }` filter and `games/update` throws. The `match:started` handler now ignores the event when the game already left `launching`.

Both are independent, isolated changes. Existing games/queue plugin tests (308) pass.