### PR TITLE
feat: report daily game launch counts to atlas

### DIFF
--- a/src/atlas/plugins/heartbeat.ts
+++ b/src/atlas/plugins/heartbeat.ts
@@ -1,10 +1,11 @@
-import { minutesToMilliseconds, secondsToMilliseconds } from 'date-fns'
+import { minutesToMilliseconds, secondsToMilliseconds, subDays } from 'date-fns'
 import { debounce } from 'es-toolkit'
 import fp from 'fastify-plugin'
 import { environment } from '../../environment'
 import { events } from '../../events'
 import { safe } from '../../utils/safe'
 import { sendHeartbeat } from '../send-heartbeat'
+import { sendActivity } from '../send-activity'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -20,6 +21,13 @@ export default fp(
 
     setInterval(safe(sendHeartbeat), minutesToMilliseconds(3)).unref()
     safe(sendHeartbeat)()
+
+    // backfill the full history once on boot, then keep recent days fresh
+    setInterval(
+      safe(() => sendActivity(subDays(new Date(), 2))),
+      minutesToMilliseconds(3),
+    ).unref()
+    safe(() => sendActivity())()
   },
   { name: 'atlas heartbeat' },
 )

--- a/src/atlas/send-activity.test.ts
+++ b/src/atlas/send-activity.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sendActivity } from './send-activity'
+import { environment } from '../environment'
+import { getGameLaunchesPerDay } from '../statistics/get-game-launches-per-day'
+import { logger } from '../logger'
+
+vi.mock('../environment', () => ({
+  environment: {
+    ATLAS_URL: 'https://atlas.tf2pickup.org',
+    ATLAS_SECRET: 'supersecret',
+    WEBSITE_URL: 'https://tf2pickup.pl',
+  },
+}))
+
+vi.mock('../logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('../statistics/get-game-launches-per-day', () => ({
+  getGameLaunchesPerDay: vi.fn(),
+}))
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockResolvedValue({ ok: true, status: 204 })
+  vi.mocked(getGameLaunchesPerDay).mockResolvedValue([
+    { day: '2026-06-21', count: 4 },
+    { day: '2026-06-22', count: 7 },
+  ])
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('when ATLAS_SECRET is not set', () => {
+  beforeEach(() => {
+    environment.ATLAS_SECRET = undefined
+  })
+
+  afterEach(() => {
+    environment.ATLAS_SECRET = 'supersecret'
+  })
+
+  it('should not send anything', async () => {
+    await sendActivity()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('when ATLAS_SECRET is set', () => {
+  it('should report the per-day counts as gamesLaunched', async () => {
+    await sendActivity()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url.toString()).toBe('https://atlas.tf2pickup.org/api/activity')
+    expect(init.method).toBe('PUT')
+    expect(init.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer supersecret',
+    })
+    expect(JSON.parse(init.body)).toEqual({
+      url: 'https://tf2pickup.pl',
+      days: [
+        { day: '2026-06-21', gamesLaunched: 4 },
+        { day: '2026-06-22', gamesLaunched: 7 },
+      ],
+    })
+  })
+
+  it('should pass the since bound through to the aggregation', async () => {
+    const since = new Date('2026-06-20T00:00:00Z')
+    await sendActivity(since)
+    expect(getGameLaunchesPerDay).toHaveBeenCalledWith(since)
+  })
+
+  it('should not send anything when there are no launches', async () => {
+    vi.mocked(getGameLaunchesPerDay).mockResolvedValue([])
+    await sendActivity()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  describe('and the request is rejected', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValue({ ok: false, status: 403 })
+    })
+
+    it('should log a warning and not throw', async () => {
+      await expect(sendActivity()).resolves.toBeUndefined()
+      expect(logger.warn).toHaveBeenCalledWith({ status: 403 }, 'atlas activity rejected')
+    })
+  })
+})

--- a/src/atlas/send-activity.ts
+++ b/src/atlas/send-activity.ts
@@ -1,0 +1,37 @@
+import { secondsToMilliseconds } from 'date-fns'
+import { environment } from '../environment'
+import { logger } from '../logger'
+import { getGameLaunchesPerDay } from '../statistics/get-game-launches-per-day'
+
+/**
+ * Reports this instance's daily game launch counts to atlas. Without `since`
+ * the full history is sent (used on boot to backfill); atlas overwrites each
+ * day, so re-sending is idempotent.
+ */
+export async function sendActivity(since?: Date) {
+  if (!environment.ATLAS_SECRET) {
+    return
+  }
+
+  const launches = await getGameLaunchesPerDay(since)
+  if (launches.length === 0) {
+    return
+  }
+
+  const response = await fetch(new URL('/api/activity', environment.ATLAS_URL), {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${environment.ATLAS_SECRET}`,
+    },
+    body: JSON.stringify({
+      url: environment.WEBSITE_URL,
+      days: launches.map(({ day, count }) => ({ day, gamesLaunched: count })),
+    }),
+    signal: AbortSignal.timeout(secondsToMilliseconds(30)),
+  })
+
+  if (!response.ok) {
+    logger.warn({ status: response.status }, 'atlas activity rejected')
+  }
+}


### PR DESCRIPTION
## Why

Companion to atlas#1 (the games activity heatmap). atlas only receives current snapshots via heartbeat and can't reconstruct game history — only each instance's DB has the games and their creation times. So instances now report their own per-day launch counts.

- Reuses `getGameLaunchesPerDay` (groups games by the `GameCreated` event's UTC day) and posts to atlas's new `PUT /api/activity`, authenticated with the existing `ATLAS_SECRET`.
- **Full history on boot** backfills atlas; **recent days on the heartbeat interval** keep today current.
- Sent from the heartbeat plugin (not a migration) on purpose: atlas stores per `{instance, day}` and overwrites, so resends are idempotent — an atlas outage can neither block instance startup nor permanently drop the backfill.

Related: tf2pickup-org/atlas#1