### PR TITLE
fix: key rate limiter on real client IP

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { logger, logger as loggerInstance } from './logger'
 import { secrets } from './secrets'
 import { environment } from './environment'
 import { version } from './version'
+import { realIp } from './utils/real-ip'
 import { ErrorPage } from './error-pages/views/html/error.page'
 import { secondsInWeek } from 'date-fns/constants'
 import autoload from '@fastify/autoload'
@@ -19,7 +20,9 @@ app.setValidatorCompiler(validatorCompiler)
 logger.info(`starting tf2pickup.org ${version}`)
 
 if (process.env['CI'] !== 'true') {
-  await app.register(await import('@fastify/rate-limit'))
+  await app.register(await import('@fastify/rate-limit'), {
+    keyGenerator: req => realIp(req),
+  })
 }
 
 await app.register(await import('@fastify/helmet'), {


### PR DESCRIPTION
## Why

Our weekly automated SigNoz log review surfaced a recurring full-site scraper that enumerates every `/players/<id>` and `/games/<n>` in tight bursts, tripping the rate limiter (4 bursts last week, up to 4,626 × 429 in a single hour on `tf2pickup-eu`).

The root cause that makes those bursts hurt: `@fastify/rate-limit` was registered with no `keyGenerator`, so it used the default `req.ip`. Behind nginx/docker that collapses to the internal proxy address (`172.20.0.1`), making the ~1000/min limit a **single global bucket per instance** rather than per client. During a scrape, the throughput that passes the limit is shared between the scraper and real users, so **legitimate players on that instance get intermittently throttled**.

## What

Key the limiter on `realIp()` (the existing helper in `src/utils/real-ip.ts`, which reads `X-Forwarded-For` and falls back to the socket address). Each client now gets its own bucket, so an abuser trips its own limit without degrading others. Limits (`max`/`timeWindow`) are unchanged.