### PR TITLE
fix: hide game server info from spectators to mitigate DDoS

### DIFF
--- a/src/admin/game-servers/views/html/game-servers.page.tsx
+++ b/src/admin/game-servers/views/html/game-servers.page.tsx
@@ -1,6 +1,7 @@
 import { servemeTf } from '../../../../serveme-tf'
 import { tf2QuickServer } from '../../../../tf2-quick-server'
 import { Admin } from '../../../views/html/admin'
+import { HideServerInfoSetting } from './hide-server-info-setting'
 import { ServemeTfBanGameServers } from './serveme-tf-ban-gameservers'
 import { ServemeTfPreferredRegion } from './serveme-tf-preferred-region'
 import { ServemeTfStatus } from './serveme-tf-status'
@@ -12,6 +13,11 @@ export async function GameServersPage() {
   return (
     <Admin activePage="game-servers">
       <div class="admin-panel-set">
+        <h4 class="pb-4">General</h4>
+        <HideServerInfoSetting />
+      </div>
+
+      <div class="admin-panel-set mt-4">
         <h4 class="pb-4">Static servers</h4>
         <StaticGameServerList />
       </div>

--- a/src/admin/game-servers/views/html/hide-server-info-setting.tsx
+++ b/src/admin/game-servers/views/html/hide-server-info-setting.tsx
@@ -1,0 +1,60 @@
+import { configuration } from '../../../../configuration'
+import { IconLoader3 } from '../../../../html/components/icons'
+import { HideServerInfoMode } from '../../../../shared/types/hide-server-info-mode'
+
+const labels: Record<HideServerInfoMode, string> = {
+  [HideServerInfoMode.never]: 'never (show to everyone)',
+  [HideServerInfoMode.auto]: 'auto (hide for non-serveme.tf servers)',
+  [HideServerInfoMode.always]: 'always (hide for all servers)',
+}
+
+export function HideServerInfoSetting() {
+  return (
+    <p class="mt-2">
+      <dl>
+        <dt>
+          <label for="hide-server-info-select">Hide server info from spectators</label>
+        </dt>
+        <dd>
+          <HideServerInfoSelect />
+          <span class="text-abru-light-75 text-sm">
+            Hides the game server connect info (including SourceTV) from everyone except match
+            participants, to mitigate DDoS attacks. serveme.tf servers have built-in DDoS
+            protection, so "auto" leaves them visible.
+          </span>
+        </dd>
+      </dl>
+    </p>
+  )
+}
+
+export async function HideServerInfoSelect(props?: { saveResult?: { success: true } }) {
+  const selected = await configuration.get('games.hide_server_info_from_spectators')
+
+  return (
+    <div id="hide-server-info" class="flex flex-row items-center gap-2">
+      <select
+        name="hideServerInfoMode"
+        id="hide-server-info-select"
+        hx-put="/admin/game-servers/hide-server-info"
+        hx-trigger="change"
+        hx-target="#hide-server-info"
+        hx-swap="outerHTML"
+        hx-disabled-elt="this"
+        class="peer"
+      >
+        {Object.values(HideServerInfoMode).map(mode => (
+          <option value={mode} selected={mode === selected} safe>
+            {labels[mode]}
+          </option>
+        ))}
+      </select>
+      <IconLoader3 class="hidden animate-spin peer-[.htmx-request]:block" />
+      {props?.saveResult?.success === true && (
+        <span remove-me="3s" class="text-green-600">
+          saved!
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/database/models/configuration-entry.model.ts
+++ b/src/database/models/configuration-entry.model.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { Tf2ClassName } from '../../shared/types/tf2-class-name'
 import { LogsTfUploadMethod } from '../../shared/types/logs-tf-upload-method'
 import { VoiceServerType } from '../../shared/types/voice-server-type'
+import { HideServerInfoMode } from '../../shared/types/hide-server-info-mode'
 import { steamId64 } from '../../shared/schemas/steam-id-64'
 
 export const configurationSchema = z.discriminatedUnion('key', [
@@ -121,6 +122,14 @@ export const configurationSchema = z.discriminatedUnion('key', [
       value: z.enum(LogsTfUploadMethod).default(LogsTfUploadMethod.backend),
     })
     .describe('Method of uploading logs to the logs.tf service'),
+  z
+    .object({
+      key: z.literal('games.hide_server_info_from_spectators'),
+      value: z.enum(HideServerInfoMode).default(HideServerInfoMode.auto),
+    })
+    .describe(
+      'Hide the game server connect info (incl. SourceTV) from non-participants to mitigate DDoS. "auto" only hides it for non-serveme.tf servers, which have built-in DDoS protection.',
+    ),
   z.object({
     key: z.literal('games.voice_server_type'),
     value: z.enum(VoiceServerType).default(VoiceServerType.none),

--- a/src/games/should-hide-server-info.test.ts
+++ b/src/games/should-hide-server-info.test.ts
@@ -47,6 +47,6 @@ describe('shouldHideServerInfo()', () => {
 
   it('hides when mode is auto and there is no game server yet', async () => {
     vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.auto)
-    expect(await shouldHideServerInfo({ gameServer: undefined })).toBe(true)
+    expect(await shouldHideServerInfo({})).toBe(true)
   })
 })

--- a/src/games/should-hide-server-info.test.ts
+++ b/src/games/should-hide-server-info.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { shouldHideServerInfo } from './should-hide-server-info'
+import { configuration } from '../configuration'
+import { GameServerProvider } from '../database/models/game.model'
+import { HideServerInfoMode } from '../shared/types/hide-server-info-mode'
+
+vi.mock('../configuration', () => ({
+  configuration: { get: vi.fn() },
+}))
+
+function gameServer(provider: GameServerProvider) {
+  return {
+    gameServer: {
+      id: 'gs1',
+      provider,
+      name: 'server',
+      address: '1.2.3.4',
+      port: '27015',
+      rcon: { address: '1.2.3.4', port: '27015', password: 'secret' },
+    },
+  }
+}
+
+describe('shouldHideServerInfo()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('never hides when mode is never', async () => {
+    vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.never)
+    expect(await shouldHideServerInfo(gameServer(GameServerProvider.static))).toBe(false)
+    expect(await shouldHideServerInfo(gameServer(GameServerProvider.servemeTf))).toBe(false)
+  })
+
+  it('always hides when mode is always', async () => {
+    vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.always)
+    expect(await shouldHideServerInfo(gameServer(GameServerProvider.static))).toBe(true)
+    expect(await shouldHideServerInfo(gameServer(GameServerProvider.servemeTf))).toBe(true)
+  })
+
+  it('hides only non-serveme.tf servers when mode is auto', async () => {
+    vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.auto)
+    expect(await shouldHideServerInfo(gameServer(GameServerProvider.static))).toBe(true)
+    expect(await shouldHideServerInfo(gameServer(GameServerProvider.tf2QuickServer))).toBe(true)
+    expect(await shouldHideServerInfo(gameServer(GameServerProvider.servemeTf))).toBe(false)
+  })
+
+  it('hides when mode is auto and there is no game server yet', async () => {
+    vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.auto)
+    expect(await shouldHideServerInfo({ gameServer: undefined })).toBe(true)
+  })
+})

--- a/src/games/should-hide-server-info.ts
+++ b/src/games/should-hide-server-info.ts
@@ -1,0 +1,15 @@
+import { configuration } from '../configuration'
+import { GameServerProvider, type GameModel } from '../database/models/game.model'
+import { HideServerInfoMode } from '../shared/types/hide-server-info-mode'
+
+export async function shouldHideServerInfo(game: Pick<GameModel, 'gameServer'>): Promise<boolean> {
+  const mode = await configuration.get('games.hide_server_info_from_spectators')
+  switch (mode) {
+    case HideServerInfoMode.never:
+      return false
+    case HideServerInfoMode.always:
+      return true
+    case HideServerInfoMode.auto:
+      return game.gameServer?.provider !== GameServerProvider.servemeTf
+  }
+}

--- a/src/games/views/html/connect-info.tsx
+++ b/src/games/views/html/connect-info.tsx
@@ -1,11 +1,15 @@
 import { GameState, type GameModel } from '../../../database/models/game.model'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
+import { shouldHideServerInfo } from '../../should-hide-server-info'
 import { ConnectString } from './connect-string'
 import { JoinGameButton } from './join-game-button'
 import { JoinVoiceButton } from './join-voice-button'
 
 export function ConnectInfo(props: {
-  game: Pick<GameModel, 'number' | 'state' | 'slots' | 'connectString' | 'stvConnectString'>
+  game: Pick<
+    GameModel,
+    'number' | 'state' | 'slots' | 'connectString' | 'stvConnectString' | 'gameServer'
+  >
   actor: SteamId64 | undefined
 }) {
   const connectInfoVisible = [
@@ -34,7 +38,10 @@ export function ConnectInfo(props: {
 }
 
 async function UserConnectString(props: {
-  game: Pick<GameModel, 'state' | 'number' | 'slots' | 'connectString' | 'stvConnectString'>
+  game: Pick<
+    GameModel,
+    'state' | 'number' | 'slots' | 'connectString' | 'stvConnectString' | 'gameServer'
+  >
   actor: SteamId64 | undefined
 }) {
   let connectString: string | undefined
@@ -48,10 +55,15 @@ async function UserConnectString(props: {
       content = <i>configuring server...</i>
       break
     default:
-      connectString = actorInGame(props.game, props.actor)
-        ? (props.game.connectString ?? '')
-        : (props.game.stvConnectString ?? '')
-      content = connectString
+      if (actorInGame(props.game, props.actor)) {
+        connectString = props.game.connectString ?? ''
+        content = connectString
+      } else if (await shouldHideServerInfo(props.game)) {
+        content = <i>hidden</i>
+      } else {
+        connectString = props.game.stvConnectString ?? ''
+        content = connectString
+      }
   }
 
   return (

--- a/src/games/views/html/game-summary.tsx
+++ b/src/games/views/html/game-summary.tsx
@@ -10,7 +10,14 @@ import { DemoLink } from './demo-link'
 export function GameSummary(props: {
   game: Pick<
     GameModel,
-    'events' | 'number' | 'map' | 'state' | 'connectString' | 'stvConnectString' | 'slots'
+    | 'events'
+    | 'number'
+    | 'map'
+    | 'state'
+    | 'connectString'
+    | 'stvConnectString'
+    | 'slots'
+    | 'gameServer'
   >
   actor?: SteamId64 | undefined
 }) {

--- a/src/games/views/html/join-game-button.test.tsx
+++ b/src/games/views/html/join-game-button.test.tsx
@@ -8,6 +8,12 @@ import type { GameSlotId } from '../../../shared/types/game-slot-id'
 import { Tf2ClassName } from '../../../shared/types/tf2-class-name'
 import { Tf2Team } from '../../../shared/types/tf2-team'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
+import { configuration } from '../../../configuration'
+import { HideServerInfoMode } from '../../../shared/types/hide-server-info-mode'
+
+vi.mock('../../../configuration', () => ({
+  configuration: { get: vi.fn() },
+}))
 
 const actor = '76561198000000001' as SteamId64
 
@@ -29,6 +35,10 @@ const baseGame = {
 }
 
 describe('JoinGameButton', () => {
+  beforeEach(() => {
+    vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.never)
+  })
+
   describe('when game is not yet ready (created/configuring)', () => {
     it('shows a waiting loader for created state', async () => {
       const html = await JoinGameButton({ game: { ...baseGame, state: GameState.created }, actor })
@@ -67,6 +77,21 @@ describe('JoinGameButton', () => {
       const root = parse(html)
       const link = root.querySelector('.join-game-button')
       expect(link?.getAttribute('href')).toBe('steam://connect/192.168.1.1:27020')
+    })
+
+    it('hides the spectator button when server info is hidden', async () => {
+      vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.always)
+      const html = await JoinGameButton({ game: baseGame, actor: undefined })
+      const root = parse(html)
+      expect(root.querySelector('.join-game-button')).toBeNull()
+    })
+
+    it('still links a participant to the game connect string when server info is hidden', async () => {
+      vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.always)
+      const html = await JoinGameButton({ game: baseGame, actor })
+      const root = parse(html)
+      const link = root.querySelector('.join-game-button')
+      expect(link?.getAttribute('href')).toBe('steam://connect/192.168.1.1:27015/abc')
     })
 
     it('links to the game connect string when actor slot is waitingForSubstitute', async () => {

--- a/src/games/views/html/join-game-button.tsx
+++ b/src/games/views/html/join-game-button.tsx
@@ -7,9 +7,13 @@ import { GameState, type GameModel } from '../../../database/models/game.model'
 import { IconEye, IconLoader3, IconPlayerPlayFilled } from '../../../html/components/icons'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
 import { connectStringToLink } from '../../connect-string-to-link'
+import { shouldHideServerInfo } from '../../should-hide-server-info'
 
 export async function JoinGameButton(props: {
-  game: Pick<GameModel, 'number' | 'state' | 'slots' | 'connectString' | 'stvConnectString'>
+  game: Pick<
+    GameModel,
+    'number' | 'state' | 'slots' | 'connectString' | 'stvConnectString' | 'gameServer'
+  >
   actor: SteamId64 | undefined
 }) {
   return (
@@ -20,7 +24,10 @@ export async function JoinGameButton(props: {
 }
 
 async function JoinGameButtonContent(props: {
-  game: Pick<GameModel, 'number' | 'state' | 'slots' | 'connectString' | 'stvConnectString'>
+  game: Pick<
+    GameModel,
+    'number' | 'state' | 'slots' | 'connectString' | 'stvConnectString' | 'gameServer'
+  >
   actor: SteamId64 | undefined
 }) {
   let btnContent: JSX.Element
@@ -34,6 +41,9 @@ async function JoinGameButtonContent(props: {
     )
   } else {
     const slot = getPlayerSlot(props.game, props.actor)
+    if (!slot && (await shouldHideServerInfo(props.game))) {
+      return <></>
+    }
     const connectString = (slot ? props.game.connectString : props.game.stvConnectString) ?? ''
     connectLink = connectStringToLink(connectString)
     btnContent = slot ? <JoinAsPlayer slot={slot} /> : <JoinAsSpectator />

--- a/src/routes/admin/game-servers/index.ts
+++ b/src/routes/admin/game-servers/index.ts
@@ -1,18 +1,44 @@
 import { PlayerRole } from '../../../database/models/player.model'
 import { GameServersPage } from '../../../admin/game-servers/views/html/game-servers.page'
+import { HideServerInfoSelect } from '../../../admin/game-servers/views/html/hide-server-info-setting'
+import { configuration } from '../../../configuration'
+import { HideServerInfoMode } from '../../../shared/types/hide-server-info-mode'
 import { routes } from '../../../utils/routes'
+import { z } from 'zod'
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export default routes(async app => {
-  app.get(
-    '/',
-    {
-      config: {
-        authorize: [PlayerRole.admin],
+  app
+    .get(
+      '/',
+      {
+        config: {
+          authorize: [PlayerRole.admin],
+        },
       },
-    },
-    async (_request, reply) => {
-      await reply.status(200).html(GameServersPage())
-    },
-  )
+      async (_request, reply) => {
+        await reply.status(200).html(GameServersPage())
+      },
+    )
+    .put(
+      '/hide-server-info',
+      {
+        config: {
+          authorize: [PlayerRole.admin],
+        },
+        schema: {
+          body: z.object({
+            hideServerInfoMode: z.enum(HideServerInfoMode),
+          }),
+        },
+      },
+      async (request, reply) => {
+        await configuration.set(
+          'games.hide_server_info_from_spectators',
+          request.body.hideServerInfoMode,
+          request.user!.player.steamId,
+        )
+        return reply.status(200).html(HideServerInfoSelect({ saveResult: { success: true } }))
+      },
+    )
 })

--- a/src/shared/types/hide-server-info-mode.ts
+++ b/src/shared/types/hide-server-info-mode.ts
@@ -1,0 +1,5 @@
+export enum HideServerInfoMode {
+  never = 'never',
+  auto = 'auto',
+  always = 'always',
+}

--- a/tests/20-game/01-configure-game-server.spec.ts
+++ b/tests/20-game/01-configure-game-server.spec.ts
@@ -2,30 +2,36 @@ import { launchGame, expect } from '../fixtures/launch-game'
 import { secondsToMilliseconds } from 'date-fns'
 import { GamePage } from '../pages/game.page'
 
-launchGame('configure game server @6v6 @9v9', async ({ players, gameNumber, page, gameServer }) => {
-  await Promise.all(
-    players.map(async player => {
-      const page = await player.gamePage(gameNumber)
-      await expect(page.gameEvent('Game server assigned')).toBeVisible()
+launchGame(
+  'configure game server @6v6 @9v9',
+  async ({ players, gameNumber, page, gameServer, users }) => {
+    const admin = await users.getAdmin().adminPage()
+    await admin.configureHideServerInfo('never')
 
-      const connectString = page.connectString()
-      await expect(connectString).toHaveText(/^connect .+;\s?password (.+)$/, {
-        timeout: secondsToMilliseconds(30),
-      })
+    await Promise.all(
+      players.map(async player => {
+        const page = await player.gamePage(gameNumber)
+        await expect(page.gameEvent('Game server assigned')).toBeVisible()
 
-      const [, password] =
-        /^connect .+;\s?password (.+)$/.exec(await connectString.innerText()) ?? []
-      expect(gameServer.cvar('sv_password').value).toEqual(password)
+        const connectString = page.connectString()
+        await expect(connectString).toHaveText(/^connect .+;\s?password (.+)$/, {
+          timeout: secondsToMilliseconds(30),
+        })
 
-      await expect(page.gameEvent('Game server initialized')).toBeVisible()
-      await expect(page.joinGameButton()).toBeVisible()
+        const [, password] =
+          /^connect .+;\s?password (.+)$/.exec(await connectString.innerText()) ?? []
+        expect(gameServer.cvar('sv_password').value).toEqual(password)
 
-      await expect(gameServer).toHaveCommand(`sm_game_player_add ${player.steamId}`)
-    }),
-  )
+        await expect(page.gameEvent('Game server initialized')).toBeVisible()
+        await expect(page.joinGameButton()).toBeVisible()
 
-  const gamePage = new GamePage(page, gameNumber)
-  await gamePage.goto()
-  await expect(gamePage.connectString()).toHaveText(/^connect ([a-z0-9\s.:]+)(;\s?password tv)?$/)
-  await expect(gamePage.watchStvButton()).toBeVisible()
-})
+        await expect(gameServer).toHaveCommand(`sm_game_player_add ${player.steamId}`)
+      }),
+    )
+
+    const gamePage = new GamePage(page, gameNumber)
+    await gamePage.goto()
+    await expect(gamePage.connectString()).toHaveText(/^connect ([a-z0-9\s.:]+)(;\s?password tv)?$/)
+    await expect(gamePage.watchStvButton()).toBeVisible()
+  },
+)

--- a/tests/pages/admin.page.ts
+++ b/tests/pages/admin.page.ts
@@ -97,6 +97,17 @@ export class AdminPage {
     }
   }
 
+  async configureHideServerInfo(mode: 'never' | 'auto' | 'always') {
+    await this.page.goto('/admin/game-servers')
+    await Promise.all([
+      this.page.waitForResponse(
+        resp =>
+          resp.url().includes('/admin/game-servers/hide-server-info') && resp.status() === 200,
+      ),
+      this.page.getByLabel('Hide server info from spectators').selectOption(mode),
+    ])
+  }
+
   async configurePlayerSkillThreshold(threshold: number | null) {
     await this.page.goto('/admin/player-restrictions')
     await this.page


### PR DESCRIPTION
## Why

An instance operator reported game servers being DDoS'd and asked to hide server IPs from everyone except match participants. The SourceTV connect string shown to non-participants exposes the same IP as the game server (STV runs on the same host), so it's the leak being scraped for attacks.

## What

Adds a global admin setting **"Hide server info from spectators"** (Admin → Game servers) with three modes:

- **never** — show connect info to everyone (previous behavior)
- **auto** *(default)* — hide it only for non-serveme.tf servers; serveme.tf has built-in DDoS protection so those stay visible
- **always** — hide it for all servers

When hidden, non-participants see `hidden` instead of the STV connect string and the "watch stv" button is dropped. Match participants always keep their real connect string.

### Note on the tradeoff

SourceTV runs on the same IP as the game server, so hiding the IP from non-participants necessarily disables public STV spectating for the affected servers while a game is live. There's no way to keep public STV while hiding the address.