### PR TITLE
test: cover spectator connect info visibility under default config

### DIFF
--- a/tests/20-game/01-configure-game-server.spec.ts
+++ b/tests/20-game/01-configure-game-server.spec.ts
@@ -2,36 +2,31 @@ import { launchGame, expect } from '../fixtures/launch-game'
 import { secondsToMilliseconds } from 'date-fns'
 import { GamePage } from '../pages/game.page'
 
-launchGame(
-  'configure game server @6v6 @9v9',
-  async ({ players, gameNumber, page, gameServer, users }) => {
-    const admin = await users.getAdmin().adminPage()
-    await admin.configureHideServerInfo('never')
+launchGame('configure game server @6v6 @9v9', async ({ players, gameNumber, page, gameServer }) => {
+  await Promise.all(
+    players.map(async player => {
+      const page = await player.gamePage(gameNumber)
+      await expect(page.gameEvent('Game server assigned')).toBeVisible()
 
-    await Promise.all(
-      players.map(async player => {
-        const page = await player.gamePage(gameNumber)
-        await expect(page.gameEvent('Game server assigned')).toBeVisible()
+      const connectString = page.connectString()
+      await expect(connectString).toHaveText(/^connect .+;\s?password (.+)$/, {
+        timeout: secondsToMilliseconds(30),
+      })
 
-        const connectString = page.connectString()
-        await expect(connectString).toHaveText(/^connect .+;\s?password (.+)$/, {
-          timeout: secondsToMilliseconds(30),
-        })
+      const [, password] =
+        /^connect .+;\s?password (.+)$/.exec(await connectString.innerText()) ?? []
+      expect(gameServer.cvar('sv_password').value).toEqual(password)
 
-        const [, password] =
-          /^connect .+;\s?password (.+)$/.exec(await connectString.innerText()) ?? []
-        expect(gameServer.cvar('sv_password').value).toEqual(password)
+      await expect(page.gameEvent('Game server initialized')).toBeVisible()
+      await expect(page.joinGameButton()).toBeVisible()
 
-        await expect(page.gameEvent('Game server initialized')).toBeVisible()
-        await expect(page.joinGameButton()).toBeVisible()
+      await expect(gameServer).toHaveCommand(`sm_game_player_add ${player.steamId}`)
+    }),
+  )
 
-        await expect(gameServer).toHaveCommand(`sm_game_player_add ${player.steamId}`)
-      }),
-    )
-
-    const gamePage = new GamePage(page, gameNumber)
-    await gamePage.goto()
-    await expect(gamePage.connectString()).toHaveText(/^connect ([a-z0-9\s.:]+)(;\s?password tv)?$/)
-    await expect(gamePage.watchStvButton()).toBeVisible()
-  },
-)
+  // default "auto" hides connect info from spectators on non-serveme.tf servers
+  const gamePage = new GamePage(page, gameNumber)
+  await gamePage.goto()
+  await expect(gamePage.connectString()).toHaveText('hidden')
+  await expect(gamePage.watchStvButton()).not.toBeVisible()
+})

--- a/tests/20-game/19-show-server-info-to-spectators.spec.ts
+++ b/tests/20-game/19-show-server-info-to-spectators.spec.ts
@@ -1,0 +1,24 @@
+import { launchGame as test, expect } from '../fixtures/launch-game'
+import { GamePage } from '../pages/game.page'
+
+test.use({ waitForStage: 'launching' })
+
+test.beforeAll(async ({ users }) => {
+  const admin = await users.getAdmin().adminPage()
+  await admin.configureHideServerInfo('never')
+})
+
+test.afterAll(async ({ users }) => {
+  const admin = await users.getAdmin().adminPage()
+  await admin.configureHideServerInfo('auto')
+})
+
+test('shows the stv connect string to spectators when enabled @6v6 @9v9', async ({
+  gameNumber,
+  page,
+}) => {
+  const gamePage = new GamePage(page, gameNumber)
+  await gamePage.goto()
+  await expect(gamePage.connectString()).toHaveText(/^connect ([a-z0-9\s.:]+)(;\s?password tv)?$/)
+  await expect(gamePage.watchStvButton()).toBeVisible()
+})


### PR DESCRIPTION
Follow-up cleanup for #697.

## What

- **configure-game-server e2e test** now uses the default `hide_server_info_from_spectators = auto` setting instead of forcing `never`, and asserts that a spectator sees `hidden` connect info / no "watch stv" button on the static test server.
- **New e2e test** for the `never` mode, which shows the SourceTV connect string to everyone — verifies the spectator sees the STV connect string and the "watch stv" button. It restores the default afterward.