### PR TITLE
fix: keep game connect info visible to admins when hidden from spectators

### DIFF
--- a/src/games/views/html/connect-info.test.tsx
+++ b/src/games/views/html/connect-info.test.tsx
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { parse } from 'node-html-parser'
+import { ConnectInfo } from './connect-info'
+import { GameState } from '../../../database/models/game.model'
+import type { GameNumber } from '../../../database/models/game.model'
+import { PlayerConnectionStatus, SlotStatus } from '../../../database/models/game-slot.model'
+import type { GameSlotId } from '../../../shared/types/game-slot-id'
+import { Tf2ClassName } from '../../../shared/types/tf2-class-name'
+import { Tf2Team } from '../../../shared/types/tf2-team'
+import type { SteamId64 } from '../../../shared/types/steam-id-64'
+import { configuration } from '../../../configuration'
+import { HideServerInfoMode } from '../../../shared/types/hide-server-info-mode'
+import { players } from '../../../players'
+
+vi.mock('../../../configuration', () => ({
+  configuration: { get: vi.fn() },
+}))
+
+vi.mock('../../../players', () => ({
+  players: { isAdmin: vi.fn() },
+}))
+
+const participant = '76561198000000001' as SteamId64
+const spectator = '76561198000000002' as SteamId64
+const admin = '76561198000000003' as SteamId64
+
+const activeSlot = {
+  id: 'red-soldier-0' as GameSlotId,
+  player: participant,
+  team: Tf2Team.red,
+  gameClass: Tf2ClassName.soldier,
+  status: SlotStatus.active,
+  connectionStatus: PlayerConnectionStatus.connected,
+}
+
+const baseGame = {
+  number: 1 as GameNumber,
+  state: GameState.started,
+  slots: [activeSlot],
+  connectString: 'connect 192.168.1.1:27015; password abc',
+  stvConnectString: 'connect 192.168.1.1:27020',
+}
+
+function connectStringText(html: string) {
+  return parse(html).querySelector('.connect-string .content')?.text.trim()
+}
+
+describe('ConnectInfo', () => {
+  beforeEach(() => {
+    vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.never)
+    vi.mocked(players.isAdmin).mockResolvedValue(false)
+  })
+
+  it('shows the game connect string to a participant', async () => {
+    const html = await ConnectInfo({ game: baseGame, actor: participant })
+    expect(connectStringText(html)).toBe('connect 192.168.1.1:27015; password abc')
+  })
+
+  it('shows the stv connect string to a spectator when server info is not hidden', async () => {
+    const html = await ConnectInfo({ game: baseGame, actor: spectator })
+    expect(connectStringText(html)).toBe('connect 192.168.1.1:27020')
+  })
+
+  it('hides the connect string from a spectator when server info is hidden', async () => {
+    vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.always)
+    const html = await ConnectInfo({ game: baseGame, actor: spectator })
+    expect(connectStringText(html)).toBe('hidden')
+  })
+
+  it('hides the connect string from anonymous visitors when server info is hidden', async () => {
+    vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.always)
+    const html = await ConnectInfo({ game: baseGame, actor: undefined })
+    expect(connectStringText(html)).toBe('hidden')
+  })
+
+  it('still shows the stv connect string to an admin when server info is hidden', async () => {
+    vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.always)
+    vi.mocked(players.isAdmin).mockResolvedValue(true)
+    const html = await ConnectInfo({ game: baseGame, actor: admin })
+    expect(connectStringText(html)).toBe('connect 192.168.1.1:27020')
+  })
+
+  it('still shows the game connect string to a participant when server info is hidden', async () => {
+    vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.always)
+    const html = await ConnectInfo({ game: baseGame, actor: participant })
+    expect(connectStringText(html)).toBe('connect 192.168.1.1:27015; password abc')
+  })
+})

--- a/src/games/views/html/connect-info.tsx
+++ b/src/games/views/html/connect-info.tsx
@@ -1,4 +1,5 @@
 import { GameState, type GameModel } from '../../../database/models/game.model'
+import { players } from '../../../players'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
 import { shouldHideServerInfo } from '../../should-hide-server-info'
 import { ConnectString } from './connect-string'
@@ -58,7 +59,10 @@ async function UserConnectString(props: {
       if (actorInGame(props.game, props.actor)) {
         connectString = props.game.connectString ?? ''
         content = connectString
-      } else if (await shouldHideServerInfo(props.game)) {
+      } else if (
+        (await shouldHideServerInfo(props.game)) &&
+        !(await players.isAdmin(props.actor))
+      ) {
         content = <i>hidden</i>
       } else {
         connectString = props.game.stvConnectString ?? ''

--- a/src/games/views/html/join-game-button.test.tsx
+++ b/src/games/views/html/join-game-button.test.tsx
@@ -10,12 +10,18 @@ import { Tf2Team } from '../../../shared/types/tf2-team'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
 import { configuration } from '../../../configuration'
 import { HideServerInfoMode } from '../../../shared/types/hide-server-info-mode'
+import { players } from '../../../players'
 
 vi.mock('../../../configuration', () => ({
   configuration: { get: vi.fn() },
 }))
 
+vi.mock('../../../players', () => ({
+  players: { isAdmin: vi.fn() },
+}))
+
 const actor = '76561198000000001' as SteamId64
+const admin = '76561198000000002' as SteamId64
 
 const activeSlot = {
   id: 'red-soldier-0' as GameSlotId,
@@ -37,6 +43,7 @@ const baseGame = {
 describe('JoinGameButton', () => {
   beforeEach(() => {
     vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.never)
+    vi.mocked(players.isAdmin).mockResolvedValue(false)
   })
 
   describe('when game is not yet ready (created/configuring)', () => {
@@ -84,6 +91,16 @@ describe('JoinGameButton', () => {
       const html = await JoinGameButton({ game: baseGame, actor: undefined })
       const root = parse(html)
       expect(root.querySelector('.join-game-button')).toBeNull()
+    })
+
+    it('still shows the spectator button to an admin when server info is hidden', async () => {
+      vi.mocked(configuration.get).mockResolvedValue(HideServerInfoMode.always)
+      vi.mocked(players.isAdmin).mockResolvedValue(true)
+      const game = { ...baseGame, slots: [] }
+      const html = await JoinGameButton({ game, actor: admin })
+      const root = parse(html)
+      const link = root.querySelector('.join-game-button')
+      expect(link?.getAttribute('href')).toBe('steam://connect/192.168.1.1:27020')
     })
 
     it('still links a participant to the game connect string when server info is hidden', async () => {

--- a/src/games/views/html/join-game-button.tsx
+++ b/src/games/views/html/join-game-button.tsx
@@ -5,6 +5,7 @@ import {
 } from '../../../database/models/game-slot.model'
 import { GameState, type GameModel } from '../../../database/models/game.model'
 import { IconEye, IconLoader3, IconPlayerPlayFilled } from '../../../html/components/icons'
+import { players } from '../../../players'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
 import { connectStringToLink } from '../../connect-string-to-link'
 import { shouldHideServerInfo } from '../../should-hide-server-info'
@@ -41,7 +42,11 @@ async function JoinGameButtonContent(props: {
     )
   } else {
     const slot = getPlayerSlot(props.game, props.actor)
-    if (!slot && (await shouldHideServerInfo(props.game))) {
+    if (
+      !slot &&
+      (await shouldHideServerInfo(props.game)) &&
+      !(await players.isAdmin(props.actor))
+    ) {
       return <></>
     }
     const connectString = (slot ? props.game.connectString : props.game.stvConnectString) ?? ''

--- a/src/players/index.ts
+++ b/src/players/index.ts
@@ -5,6 +5,7 @@ import { findByName } from './find-by-name'
 import { getBanExpiryDate } from './get-ban-expiry-date'
 import { hasActiveBan } from './has-active-ban'
 import { hasActiveChatMute } from './has-active-chat-mute'
+import { isAdmin } from './is-admin'
 import { revokeBan } from './revoke-ban'
 import { revokeChatMute } from './revoke-chat-mute'
 import { setSkill } from './set-skill'
@@ -20,6 +21,7 @@ export const players = {
   getBanExpiryDate,
   hasActiveBan,
   hasActiveChatMute,
+  isAdmin,
   revokeBan,
   revokeChatMute,
   setSkill,

--- a/src/players/is-admin.ts
+++ b/src/players/is-admin.ts
@@ -1,0 +1,12 @@
+import { PlayerRole } from '../database/models/player.model'
+import type { SteamId64 } from '../shared/types/steam-id-64'
+import { bySteamId } from './by-steam-id'
+
+export async function isAdmin(steamId: SteamId64 | undefined): Promise<boolean> {
+  if (!steamId) {
+    return false
+  }
+
+  const player = await bySteamId(steamId, ['roles'])
+  return player.roles.includes(PlayerRole.admin)
+}


### PR DESCRIPTION
## Why

[#697](https://github.com/tf2pickup-org/tf2pickup/pull/697) hides the SourceTV connect string from non-participants to mitigate DDoS (`games.hide_server_info_from_spectators`: `never`/`auto`/`always`). But it treated **admins as plain spectators** — an admin who isn't playing in the game saw `hidden` and lost the "watch stv" button, even though they're trusted and already have the full rcon connect string in the admin toolbox.

The intent (and request) is: connect info should be available to match participants **or admins**, and otherwise hidden per config.

## What

- Add a reusable `players.isAdmin(steamId)` helper (`src/players/is-admin.ts`).
- Let admins bypass the `shouldHideServerInfo` gate in:
  - `connect-info.tsx` — admins see the STV connect string instead of `hidden`.
  - `join-game-button.tsx` — admins keep the "watch stv" button.

Resulting visibility:

| Viewer | Connect info |
| --- | --- |
| Match participant | real game connect string (always) |
| Admin (not playing) | STV connect string (always) |
| Spectator / anonymous | STV string, unless hidden by config → `hidden` |

Match participants and the spectator/config behavior from #697 are unchanged.

## Tests

- New `connect-info.test.tsx` covering participant / spectator / anonymous / admin under hidden and visible config.
- Extended `join-game-button.test.tsx` with the admin-still-sees-spectator-button case.
- `pnpm test` (326 passing) and `pnpm lint` green.

> Note: an e2e assertion for admin visibility lives alongside the spectator-visibility work in #698 (it depends on that branch's test refactor), so it's intentionally not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)