### PR TITLE
fix: tolerate null tags in Twitch streams response

### DIFF
--- a/src/twitch-tv/schemas/get-streams-response.schema.ts
+++ b/src/twitch-tv/schemas/get-streams-response.schema.ts
@@ -11,7 +11,7 @@ export const getStreamsResponseSchema = z.object({
       game_name: z.string(),
       type: z.enum(['live']),
       title: z.string(),
-      tags: z.array(z.string()),
+      tags: z.array(z.string()).nullable(),
       viewer_count: z.number(),
       started_at: z.string(),
       language: z.string(),


### PR DESCRIPTION
## Why

The scheduled `refreshStreams` task was throwing a `ZodError` in production (4 times in the last 7 days, source: `src/twitch-tv/get-streams.ts:61`).

The Twitch Helix `/streams` API intermittently returns `tags: null`, but our response schema declared `tags` as a non-nullable array. A single `null` aborted parsing of the entire response, so no streams were refreshed that cycle.

This makes `tags` nullable to match Twitch's actual behavior. The field (and `tag_ids`) is only validated, never read downstream, so no call sites change.