### PR TITLE
fix(players): make steam id confirmation input visible

### DIFF
--- a/src/admin/delete-player/views/html/delete-player.page.tsx
+++ b/src/admin/delete-player/views/html/delete-player.page.tsx
@@ -16,7 +16,7 @@ export function DeletePlayerPage(props: {
   return (
     <Admin activePage="delete-player">
       <div class="admin-panel-set">
-        <div class="bg-abru-dark-6 border-l-4 border-red-500 p-4 text-sm">
+        <div class="bg-abru-dark-6 mb-4 border-l-4 border-red-500 p-4 text-sm">
           <p class="font-bold text-red-400">Warning — this action is irreversible.</p>
           <p class="text-abru-light-50 mt-1">
             Deleting a player permanently removes their profile. The profile page will no longer be
@@ -111,7 +111,7 @@ export function DeletePlayerCard(props: { player: DeletePlayerSummary }) {
               type="text"
               name="confirmation"
               autocomplete="off"
-              class="mt-1 w-full"
+              class="bg-abru-dark-6! mt-1 w-full"
               required
             />
           </label>


### PR DESCRIPTION
## Problem

On the delete-player admin page, the "type the nickname or Steam ID to confirm deletion" input was invisible. Its background came from the global `input[type='text']` rule (`--color-abru-light-5`), which is the exact same color as the card it sits in (`bg-abru-light-5`), so it blended in completely.

## Fix

Give the confirmation input a darker, contrasting background (`bg-abru-dark-6`, the same token already used by the warning box on the page). The trailing `!` is required because the element selector `input[type='text']` outranks a plain utility class on specificity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)