### PR TITLE
feat: report anonymous instance telemetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ All env vars are Zod-validated in `src/environment.ts`. See `sample.env` for ava
 
 OpenTelemetry (`src/otel.ts`) ships metrics (`tf2pickup.*`), logs, and traces to SigNoz at `https://logs.tf2pickup.org` (`SIGNOZ_API_KEY` in `.env`). To query it from the CLI — investigate errors/latency, search logs, or build dashboards/alerts — use the `signoz-query` skill (`.claude/skills/signoz-query/SKILL.md`).
 
+There are three instrumentation channels — **OTel/SigNoz** (operational metrics/logs/traces for instances we host), **Umami** (per-instance, in-browser product analytics, via `data-umami-event` tags), and **tf2pickup telemetry** (anonymous cross-instance feature-adoption snapshot built in `src/telemetry/build-snapshot.ts`). See [docs/observability.md](docs/observability.md) for what belongs in each and a decision framework.
+
 ## Conventions
 
 - **One export per file** — the exported function name must match the file name (e.g., `foo-bar.ts` → `export function fooBar()`)
@@ -87,6 +89,7 @@ OpenTelemetry (`src/otel.ts`) ships metrics (`tf2pickup.*`), logs, and traces to
 - **ESM only** — `"type": "module"` in package.json
 - **pnpm** as package manager
 - **Adapt external code** — when integrating external/third-party code, adapt it to tf2pickup's coding style and idioms rather than vendoring it wholesale.
+- **Instrument new features when applicable** — consider whether a new feature warrants telemetry or metrics, and route it to the right channel per [docs/observability.md](docs/observability.md): a config/feature flag → add an entry to `src/telemetry/build-snapshot.ts` (anonymous cross-instance adoption); a user-facing interaction → a `data-umami-event` tag; operational health/outcomes → OTel metrics/logs. Skip it when none of these fit.
 
 ## Development Environment
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,115 @@
+# Observability & Telemetry
+
+tf2pickup uses three separate systems to understand how the software runs and is used. They answer
+different questions, collect different data, and have different privacy and reliability properties.
+This document is the reference for deciding **where a new signal belongs** so we don't double
+instrument or leak data into the wrong place.
+
+## The three systems at a glance
+
+| System                  | One-line identity                                     | Scope                                   | Origin                     | Unit                    | Privacy                            |
+| ----------------------- | ----------------------------------------------------- | --------------------------------------- | -------------------------- | ----------------------- | ---------------------------------- |
+| **tf2pickup telemetry** | What is configured and adopted, across every instance | All instances, incl. ones we don't host | Stored server config/state | Per instance            | Anonymous (sha256 of url), non-PII |
+| **Umami**               | What users click/do in the browser, per instance      | One instance's end users                | Browser interaction        | Per visitor/session     | Pseudonymous within one instance   |
+| **OTel / SigNoz**       | Is the running system healthy, and why                | Only instances we host                  | Server runtime             | Per request/span/metric | Internal infra                     |
+
+A good illustration of the boundary: server-side lifecycle/outcome events (game ended, substitute
+filled, abandonment) are deliberately kept **out** of Umami and sent to SigNoz — they must be
+reliable and they describe backend state, not browser behaviour.
+
+## tf2pickup telemetry
+
+Anonymous, cross-instance, server-side configuration snapshots. Lives in a
+[dedicated service](https://github.com/tf2pickup-org/telemetry); instances report a small non-PII
+snapshot on a schedule (opt-out via `TELEMETRY_DISABLED`).
+
+**Goes here** — instance-level, non-PII, low-frequency, answers "how is the software used in the
+wild":
+
+- Feature-flag states (`games.skill_suggestions`, voice server type, ETF2L requirement, …) — the
+  on/off rate of any experimental flag
+- Queue config (6v6/9v9/bball/ultiduo), app version, runtime version bucket
+- Integrations enabled (discord, serveme, tf2-quick-server, twitch, logs.tf, umami)
+- Usage counters (skill suggestions acted on, admin skill changes, games launched, static servers)
+- Scale buckets (registered players, map-pool size) and customization signals (docs edited,
+  cooldown levels, default skill, extra commands)
+- Maps played / map-pool composition
+
+**Does NOT go here:** anything per-player or per-game, URLs/names/IPs/Steam IDs, anything
+operational (errors/latency), anything high-frequency. If it can't be anonymized to an instance
+hash, it doesn't belong — the entire value of this channel is being safe-by-construction to collect
+from strangers' deployments.
+
+## Umami
+
+Per-instance, in-browser product analytics. Each instance points at its own Umami via
+`UMAMI_SCRIPT_SRC` / `UMAMI_WEBSITE_ID` (optional, off by default). Tracked client-side with
+`data-umami-event` tags.
+
+**Goes here** — client-side interaction, funnels, engagement, best-effort:
+
+- Pageviews / route navigation
+- CTA clicks: join queue, ready-up / not-ready, join game, join voice, copy connect string, map
+  votes, chat use
+- Funnels: queue → ready → game; `ready-up-shown` → ready/timeout drop-off
+- Engagement: logout, external profile links, stream/twitch views
+- Session recorder, web-vitals / performance
+
+**Does NOT go here:** anything you must not lose (ad-blockers, opt-out, and client failures drop
+events); server-side outcomes; cross-instance aggregation; PII beyond the deliberate per-instance
+`identify(steamId)`.
+
+## OTel / SigNoz
+
+Server-side observability for instances we host, shipped via OpenTelemetry to
+[SigNoz](https://logs.tf2pickup.org). Must be reliable.
+
+**Goes here** — server runtime, only for our own infra:
+
+- Metrics (`tf2pickup.*`): active games, queue occupancy, request/job latency, DB query times,
+  external-API latency (Steam, serveme, logs.tf), error rates
+- Logs: structured app logs, warnings/errors, security anomalies
+- Traces: request spans, game-launch pipeline, server allocation, end-to-end latency
+- Reliable server-side lifecycle/outcome events: game ended, substitute requested/filled,
+  abandonment, allocation failures, skill recalcs
+- SLOs / alerting / capacity
+
+**Does NOT go here:** other people's instances (we only see our own infra); browser UX clicks;
+config of instances we don't host.
+
+## Decision framework
+
+Ask these in order when a new signal appears:
+
+1. **Whose state/behaviour is it?** Every self-hosted instance incl. not ours → telemetry. One
+   instance's end users in the browser → umami. Our own infrastructure → otel.
+2. **Where does it originate?** Browser interaction → umami. Stored config/state → telemetry.
+   Server runtime (request/job/error) → otel.
+3. **What's the unit of analysis?** Per instance (adoption %) → telemetry. Per visitor/session
+   (funnel) → umami. Per request/span/time-series (health) → otel.
+4. **Must it be reliable/complete?** If losing it is unacceptable (outcomes, alerting, anything
+   you'd page on) → otel, **never umami**. If best-effort aggregate is fine → umami or telemetry.
+5. **Privacy ceiling.** Must be anonymous/non-PII (other people's instances) → telemetry only.
+   Pseudonymous within one instance is OK → umami. Internal infra → otel.
+6. **Cardinality / cost.** One low-frequency snapshot per instance → telemetry. Per-interaction
+   (sampling OK) → umami. High-volume with retention/sampling controls → otel.
+7. **What decision does it drive?** "Keep/promote/kill a feature ecosystem-wide?" → telemetry.
+   "Is the UX working / where do users drop?" → umami. "Is the system healthy / why slow?" → otel.
+
+### Handling overlap
+
+When a signal is tempting in two places, **route by the primary question — don't double
+instrument.** The same concept can legitimately split across all three by facet. "Skill
+suggestions" is the canonical example:
+
+- **Adoption** (is the flag on, how many admins act on it, across all instances) → telemetry
+- **In-browser interaction** (admin clicks the suggestion in the editor) → umami
+- **Operational** (did applying it succeed, latency, errors, on our instances) → otel
+
+### Anti-patterns
+
+- Relying on **umami** for anything you must not lose, or for cross-instance coverage (most
+  instances won't run it).
+- Pushing **per-request / high-cardinality** data into telemetry or umami.
+- Expecting **otel** to tell you anything about instances we don't host.
+- Putting anything **player-identifiable** into telemetry.

--- a/sample.env
+++ b/sample.env
@@ -63,7 +63,8 @@ THUMBNAIL_SERVICE_URL=https://mapthumbnails.tf2pickup.org
 #ATLAS_URL=https://atlas.tf2pickup.org
 ATLAS_SECRET=
 
-# Anonymous feature-adoption telemetry (enabled by default).
+# Anonymous feature-adoption telemetry (enabled by default in production only;
+# never reported when NODE_ENV is not "production" or when running in CI).
 # Reports a non-PII snapshot of how this instance is configured (which features
 # are on/off, which integrations are enabled, queue type, version) to help
 # prioritise development. No player data, server names, URLs or tokens are sent.

--- a/sample.env
+++ b/sample.env
@@ -63,6 +63,14 @@ THUMBNAIL_SERVICE_URL=https://mapthumbnails.tf2pickup.org
 #ATLAS_URL=https://atlas.tf2pickup.org
 ATLAS_SECRET=
 
+# Anonymous feature-adoption telemetry (enabled by default).
+# Reports a non-PII snapshot of how this instance is configured (which features
+# are on/off, which integrations are enabled, queue type, version) to help
+# prioritise development. No player data, server names, URLs or tokens are sent.
+# Set TELEMETRY_DISABLED=true to opt out.
+#TELEMETRY_URL=https://telemetry.tf2pickup.org
+TELEMETRY_DISABLED=false
+
 # serveme.tf integration (optional)
 # Valid endpoints are:
 # serveme.tf

--- a/src/database/collections.ts
+++ b/src/database/collections.ts
@@ -30,6 +30,7 @@ import type { PendingImportModel } from './models/pending-import.model'
 import type { LogsTfLogModel } from './models/logs-tf-log.model'
 import type { DeferredKickModel } from './models/deferred-kick.model'
 import type { GameRoundProgressModel } from './models/game-round-progress.model'
+import type { TelemetryStatModel } from './models/telemetry-stat.model'
 import { ensureIndexes } from './ensure-indexes'
 
 export const collections = {
@@ -66,6 +67,7 @@ export const collections = {
   staticGameServers: database.collection<StaticGameServerModel>('staticgameservers'),
   streams: database.collection<StreamModel>('streams'),
   tasks: database.collection<TaskModel>('tasks'),
+  telemetryStats: database.collection<TelemetryStatModel>('telemetrystats'),
 }
 
 await ensureIndexes()

--- a/src/database/ensure-indexes.ts
+++ b/src/database/ensure-indexes.ts
@@ -48,6 +48,7 @@ const definitions: Partial<Record<keyof typeof collections, IndexDefinition[]>> 
   keys: [{ spec: { name: 1 }, options: { unique: true } }],
   secrets: [{ spec: { name: 1 }, options: { unique: true } }],
   maps: [{ spec: { name: 1 }, options: { unique: true } }],
+  telemetryStats: [{ spec: { day: 1 }, options: { unique: true } }],
   chatMessages: [{ spec: { at: -1 } }],
   queueMapOptions: [{ spec: { name: 1 }, options: { unique: true } }],
   discordSubstituteNotifications: [

--- a/src/database/models/telemetry-stat.model.ts
+++ b/src/database/models/telemetry-stat.model.ts
@@ -1,0 +1,8 @@
+export interface TelemetryStatModel {
+  /** UTC day, formatted as YYYY-MM-DD */
+  day: string
+  /** admin skill saves that followed at least one live skill suggestion */
+  skillSuggestionsApplied: number
+  /** all admin skill saves made via the admin toolbox */
+  adminSkillChanges: number
+}

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -7,6 +7,10 @@ dotenv.config()
 
 const environmentSchema = z.object({
   NODE_ENV: z.string().default('development'),
+  CI: z
+    .string()
+    .default('false')
+    .transform(value => ['true', '1', 'yes', 'on'].includes(value.trim().toLowerCase())),
   LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).default('info'),
   APP_HOST: z.string().default('localhost'),
   APP_PORT: z.coerce.number().default(3000),
@@ -33,9 +37,9 @@ const environmentSchema = z.object({
 
   TELEMETRY_URL: z.url().default('https://telemetry.tf2pickup.org'),
   TELEMETRY_DISABLED: z
-    .enum(['true', 'false'])
+    .string()
     .default('false')
-    .transform(value => value === 'true'),
+    .transform(value => ['true', '1', 'yes', 'on'].includes(value.trim().toLowerCase())),
 
   SERVEME_TF_API_ENDPOINT: z.string().default(KnownEndpoint.europe),
   SERVEME_TF_API_KEY: z.string().optional(),

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -31,6 +31,12 @@ const environmentSchema = z.object({
   ATLAS_URL: z.url().default('https://atlas.tf2pickup.org'),
   ATLAS_SECRET: z.string().optional(),
 
+  TELEMETRY_URL: z.url().default('https://telemetry.tf2pickup.org'),
+  TELEMETRY_DISABLED: z
+    .enum(['true', 'false'])
+    .default('false')
+    .transform(value => value === 'true'),
+
   SERVEME_TF_API_ENDPOINT: z.string().default(KnownEndpoint.europe),
   SERVEME_TF_API_KEY: z.string().optional(),
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ app.setValidatorCompiler(validatorCompiler)
 
 logger.info(`starting tf2pickup.org ${version}`)
 
-if (process.env['CI'] !== 'true') {
+if (!environment.CI) {
   await app.register(await import('@fastify/rate-limit'), {
     keyGenerator: req => realIp(req),
   })

--- a/src/routes/players/:steamId/edit/skill/index.ts
+++ b/src/routes/players/:steamId/edit/skill/index.ts
@@ -6,6 +6,8 @@ import { players } from '../../../../../players'
 import { steamId64 } from '../../../../../shared/schemas/steam-id-64'
 import { routes } from '../../../../../utils/routes'
 import { AdminToolbox } from '../../../../../players/views/html/admin-toolbox'
+import { recordSkillSuggestionUsage } from '../../../../../telemetry/record-skill-suggestion-usage'
+import { safe } from '../../../../../utils/safe'
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export default routes(async app => {
@@ -57,7 +59,14 @@ export default routes(async app => {
     },
     async (request, reply) => {
       const { steamId } = request.params
-      const player = await players.bySteamId(steamId, ['steamId'])
+      const player = await players.bySteamId(steamId, [
+        'steamId',
+        'skill',
+        'elo',
+        'stats',
+        'skillHistory',
+      ])
+      const oldSkill = player.skill ?? {}
       const skill = Object.entries(request.body)
         .filter(([key]) => key.startsWith('skill.'))
         .reduce<Partial<Record<Tf2ClassName, number>>>(
@@ -69,6 +78,7 @@ export default routes(async app => {
         skill,
         actor: request.user!.player.steamId,
       })
+      safe(() => recordSkillSuggestionUsage({ player, oldSkill, newSkill: skill }))()
       request.flash('success', `Player skill updated`)
       await reply.redirect(`/players/${steamId}`)
     },

--- a/src/telemetry/build-snapshot.test.ts
+++ b/src/telemetry/build-snapshot.test.ts
@@ -140,4 +140,19 @@ describe('buildSnapshot', () => {
     expect(snapshot.maps).toEqual({ process: 120, gullywash: 80 })
     expect(snapshot.mapPool).toEqual(['cp_process_f12', 'cp_gullywash_f9'])
   })
+
+  it('ships display metadata for every reported key', async () => {
+    const snapshot = await buildSnapshot()
+    expect(snapshot.meta.features).toContainEqual({
+      key: 'games.skill_suggestions',
+      label: 'Skill suggestions (experimental)',
+      group: 'Games',
+    })
+    expect(snapshot.meta.integrations).toContainEqual({ key: 'discord', label: 'Discord' })
+    expect(snapshot.meta.usage).toContainEqual({
+      key: 'skillSuggestionsApplied30d',
+      label: 'Skill suggestions applied (30d)',
+    })
+    expect(snapshot.meta.features.map(entry => entry.key)).toEqual(Object.keys(snapshot.features))
+  })
 })

--- a/src/telemetry/build-snapshot.test.ts
+++ b/src/telemetry/build-snapshot.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildSnapshot } from './build-snapshot'
+import { configuration } from '../configuration'
+
+vi.mock('../environment', () => ({
+  environment: {
+    QUEUE_CONFIG: '6v6',
+    DISCORD_BOT_TOKEN: 'token',
+    SERVEME_TF_API_KEY: undefined,
+    TF2_QUICK_SERVER_CLIENT_ID: 'id',
+    TF2_QUICK_SERVER_CLIENT_SECRET: 'secret',
+    TWITCH_CLIENT_ID: undefined,
+    TWITCH_CLIENT_SECRET: undefined,
+    LOGS_TF_API_KEY: 'logs',
+    UMAMI_WEBSITE_ID: undefined,
+  },
+}))
+
+vi.mock('../version', () => ({ version: '1.2.3' }))
+
+vi.mock('./instance-id', () => ({ instanceId: 'deadbeef' }))
+
+vi.mock('../configuration', () => ({
+  configuration: { get: vi.fn(), getDefault: vi.fn() },
+}))
+
+vi.mock('../database/collections', () => ({
+  collections: {
+    announcements: { countDocuments: vi.fn().mockResolvedValue(1) },
+    players: { countDocuments: vi.fn().mockResolvedValue(120) },
+    staticGameServers: { countDocuments: vi.fn().mockResolvedValue(3) },
+    games: { countDocuments: vi.fn().mockResolvedValue(5000) },
+  },
+}))
+
+vi.mock('../maps/pool', () => ({
+  mapPool: {
+    get: vi.fn().mockResolvedValue([{ name: 'cp_process_f12' }, { name: 'cp_gullywash_f9' }]),
+  },
+}))
+
+vi.mock('../statistics/get-played-maps-count', () => ({
+  getPlayedMapsCount: vi.fn().mockResolvedValue([
+    { mapName: 'process', count: 120 },
+    { mapName: 'gullywash', count: 80 },
+    { mapName: undefined, count: 5 },
+  ]),
+}))
+
+vi.mock('./get-usage-counters', () => ({
+  getUsageCounters: vi
+    .fn()
+    .mockResolvedValue({ skillSuggestionsApplied30d: 12, adminSkillChanges30d: 30 }),
+}))
+
+vi.mock('./is-documents-customized', () => ({
+  isDocumentsCustomized: vi.fn().mockResolvedValue(true),
+}))
+
+const values: Record<string, unknown> = {
+  'games.skill_suggestions': true,
+  'games.skill_step': 1,
+  'games.logs_tf_upload_method': 'backend',
+  'games.hide_server_info_from_spectators': 'auto',
+  'games.voice_server_type': 'mumble',
+  'games.auto_force_end_threshold': 4,
+  'players.etf2l_account_required': false,
+  'players.minimum_in_game_hours': 0,
+  'queue.player_skill_threshold': null,
+  'queue.require_player_verification': false,
+  'queue.map_cooldown': 2,
+  'serveme_tf.preferred_region': 'eu',
+  'games.cooldown_levels': [{ level: 0, banLengthMs: 1 }],
+  'games.default_player_skill': { soldier: 5 },
+  'games.execute_extra_commands': [],
+}
+
+const defaults: Record<string, unknown> = {
+  'games.cooldown_levels': [{ level: 0, banLengthMs: 1 }],
+  'games.default_player_skill': { soldier: 1 },
+}
+
+vi.mocked(configuration.get).mockImplementation((key: string) =>
+  Promise.resolve(values[key] as never),
+)
+vi.mocked(configuration.getDefault).mockImplementation((key: string) => defaults[key] as never)
+
+afterEach(() => vi.clearAllMocks())
+
+describe('buildSnapshot', () => {
+  it('includes anonymous identity and version', async () => {
+    const snapshot = await buildSnapshot()
+    expect(snapshot.instanceId).toBe('deadbeef')
+    expect(snapshot.version).toBe('1.2.3')
+    expect(snapshot.queueConfig).toBe('6v6')
+  })
+
+  it('reports allow-listed configuration values', async () => {
+    const snapshot = await buildSnapshot()
+    expect(snapshot.features['games.skill_suggestions']).toBe(true)
+    expect(snapshot.features['games.voice_server_type']).toBe('mumble')
+    expect(snapshot.features['queue.player_skill_threshold']).toBeNull()
+    expect(snapshot.features['serveme_tf.preferred_region']).toBe('eu')
+  })
+
+  it('derives integration flags from env presence', async () => {
+    const snapshot = await buildSnapshot()
+    expect(snapshot.integrations).toEqual({
+      discord: true,
+      serveme: false,
+      tf2QuickServer: true,
+      twitch: false,
+      logsTf: true,
+      umami: false,
+    })
+  })
+
+  it('derives state and customization signals', async () => {
+    const snapshot = await buildSnapshot()
+    expect(snapshot.features['announcements.active']).toBe(true)
+    expect(snapshot.features['players.registered_bucket']).toBe('50-199')
+    expect(snapshot.features['documents.customized']).toBe(true)
+    expect(snapshot.features['games.cooldown_levels.customized']).toBe(false)
+    expect(snapshot.features['games.default_player_skill.customized']).toBe(true)
+    expect(snapshot.features['games.execute_extra_commands.set']).toBe(false)
+  })
+
+  it('reports usage counters', async () => {
+    const snapshot = await buildSnapshot()
+    expect(snapshot.usage).toEqual({
+      skillSuggestionsApplied30d: 12,
+      adminSkillChanges30d: 30,
+      gamesLaunchedLifetime: 5000,
+      staticGameServers: 3,
+    })
+  })
+
+  it('reports played maps and the configured pool, dropping blank map names', async () => {
+    const snapshot = await buildSnapshot()
+    expect(snapshot.maps).toEqual({ process: 120, gullywash: 80 })
+    expect(snapshot.mapPool).toEqual(['cp_process_f12', 'cp_gullywash_f9'])
+  })
+})

--- a/src/telemetry/build-snapshot.test.ts
+++ b/src/telemetry/build-snapshot.test.ts
@@ -27,9 +27,9 @@ vi.mock('../configuration', () => ({
 vi.mock('../database/collections', () => ({
   collections: {
     announcements: { countDocuments: vi.fn().mockResolvedValue(1) },
-    players: { countDocuments: vi.fn().mockResolvedValue(120) },
+    players: { estimatedDocumentCount: vi.fn().mockResolvedValue(120) },
     staticGameServers: { countDocuments: vi.fn().mockResolvedValue(3) },
-    games: { countDocuments: vi.fn().mockResolvedValue(5000) },
+    games: { estimatedDocumentCount: vi.fn().mockResolvedValue(5000) },
   },
 }))
 
@@ -145,7 +145,7 @@ describe('buildSnapshot', () => {
     const snapshot = await buildSnapshot()
     expect(snapshot.meta.features).toContainEqual({
       key: 'games.skill_suggestions',
-      label: 'Skill suggestions (experimental)',
+      label: 'Skill suggestions',
       group: 'Games',
     })
     expect(snapshot.meta.integrations).toContainEqual({ key: 'discord', label: 'Discord' })

--- a/src/telemetry/build-snapshot.ts
+++ b/src/telemetry/build-snapshot.ts
@@ -1,0 +1,139 @@
+import { isEqual } from 'es-toolkit'
+import { configuration } from '../configuration'
+import { collections } from '../database/collections'
+import { environment } from '../environment'
+import { mapPool } from '../maps/pool'
+import { getPlayedMapsCount } from '../statistics/get-played-maps-count'
+import { version } from '../version'
+import { getUsageCounters } from './get-usage-counters'
+import { instanceId } from './instance-id'
+import { isDocumentsCustomized } from './is-documents-customized'
+
+const maxMapsReported = 25
+const maxMapPoolReported = 60
+
+function registeredPlayersBucket(count: number): string {
+  if (count < 50) return '<50'
+  if (count < 200) return '50-199'
+  if (count < 500) return '200-499'
+  return '500+'
+}
+
+/**
+ * Builds the anonymous telemetry snapshot for this instance: allow-listed,
+ * non-PII configuration values, derived state, usage counters and the maps in
+ * play. Never includes player data, server names, URLs, tokens or other
+ * identifying fields.
+ */
+export async function buildSnapshot() {
+  const [
+    skillSuggestions,
+    skillStep,
+    logsTfUploadMethod,
+    hideServerInfo,
+    voiceServerType,
+    autoForceEndThreshold,
+    etf2lAccountRequired,
+    minimumInGameHours,
+    playerSkillThreshold,
+    requirePlayerVerification,
+    mapCooldown,
+    servemePreferredRegion,
+    cooldownLevels,
+    defaultPlayerSkill,
+    extraCommands,
+  ] = await Promise.all([
+    configuration.get('games.skill_suggestions'),
+    configuration.get('games.skill_step'),
+    configuration.get('games.logs_tf_upload_method'),
+    configuration.get('games.hide_server_info_from_spectators'),
+    configuration.get('games.voice_server_type'),
+    configuration.get('games.auto_force_end_threshold'),
+    configuration.get('players.etf2l_account_required'),
+    configuration.get('players.minimum_in_game_hours'),
+    configuration.get('queue.player_skill_threshold'),
+    configuration.get('queue.require_player_verification'),
+    configuration.get('queue.map_cooldown'),
+    configuration.get('serveme_tf.preferred_region'),
+    configuration.get('games.cooldown_levels'),
+    configuration.get('games.default_player_skill'),
+    configuration.get('games.execute_extra_commands'),
+  ])
+
+  const [
+    activeAnnouncements,
+    registeredPlayers,
+    staticGameServers,
+    gamesLaunchedLifetime,
+    documentsCustomized,
+    usage,
+    playedMaps,
+    pool,
+  ] = await Promise.all([
+    collections.announcements.countDocuments({ enabled: true }),
+    collections.players.countDocuments(),
+    collections.staticGameServers.countDocuments(),
+    collections.games.countDocuments(),
+    isDocumentsCustomized(),
+    getUsageCounters(),
+    getPlayedMapsCount(),
+    mapPool.get(),
+  ])
+
+  const maps = Object.fromEntries(
+    playedMaps
+      .filter(({ mapName }) => Boolean(mapName))
+      .slice(0, maxMapsReported)
+      .map(({ mapName, count }) => [mapName, count]),
+  )
+
+  return {
+    instanceId,
+    version,
+    queueConfig: environment.QUEUE_CONFIG,
+    features: {
+      'games.skill_suggestions': skillSuggestions,
+      'games.skill_step': skillStep,
+      'games.logs_tf_upload_method': logsTfUploadMethod,
+      'games.hide_server_info_from_spectators': hideServerInfo,
+      'games.voice_server_type': voiceServerType,
+      'games.auto_force_end_threshold': autoForceEndThreshold,
+      'players.etf2l_account_required': etf2lAccountRequired,
+      'players.minimum_in_game_hours': minimumInGameHours,
+      'queue.player_skill_threshold': playerSkillThreshold,
+      'queue.require_player_verification': requirePlayerVerification,
+      'queue.map_cooldown': mapCooldown,
+      'serveme_tf.preferred_region': servemePreferredRegion,
+      'announcements.active': activeAnnouncements > 0,
+      'players.registered_bucket': registeredPlayersBucket(registeredPlayers),
+      'documents.customized': documentsCustomized,
+      'games.cooldown_levels.customized': !isEqual(
+        cooldownLevels,
+        configuration.getDefault('games.cooldown_levels'),
+      ),
+      'games.default_player_skill.customized': !isEqual(
+        defaultPlayerSkill,
+        configuration.getDefault('games.default_player_skill'),
+      ),
+      'games.execute_extra_commands.set': extraCommands.length > 0,
+    },
+    integrations: {
+      discord: Boolean(environment.DISCORD_BOT_TOKEN),
+      serveme: Boolean(environment.SERVEME_TF_API_KEY),
+      tf2QuickServer: Boolean(
+        environment.TF2_QUICK_SERVER_CLIENT_ID && environment.TF2_QUICK_SERVER_CLIENT_SECRET,
+      ),
+      twitch: Boolean(environment.TWITCH_CLIENT_ID && environment.TWITCH_CLIENT_SECRET),
+      logsTf: Boolean(environment.LOGS_TF_API_KEY),
+      umami: Boolean(environment.UMAMI_WEBSITE_ID),
+    },
+    usage: {
+      skillSuggestionsApplied30d: usage.skillSuggestionsApplied30d,
+      adminSkillChanges30d: usage.adminSkillChanges30d,
+      gamesLaunchedLifetime,
+      staticGameServers,
+    },
+    maps,
+    mapPool: pool.map(entry => entry.name).slice(0, maxMapPoolReported),
+  }
+}

--- a/src/telemetry/build-snapshot.ts
+++ b/src/telemetry/build-snapshot.ts
@@ -71,9 +71,9 @@ export async function buildSnapshot() {
     pool,
   ] = await Promise.all([
     collections.announcements.countDocuments({ enabled: true }),
-    collections.players.countDocuments(),
-    collections.staticGameServers.countDocuments(),
-    collections.games.countDocuments(),
+    collections.players.estimatedDocumentCount(),
+    collections.staticGameServers.countDocuments({ isOnline: true }),
+    collections.games.estimatedDocumentCount(),
     isDocumentsCustomized(),
     getUsageCounters(),
     getPlayedMapsCount(),
@@ -91,7 +91,7 @@ export async function buildSnapshot() {
     {
       key: 'games.skill_suggestions',
       value: skillSuggestions,
-      label: 'Skill suggestions (experimental)',
+      label: 'Skill suggestions',
       group: 'Games',
     },
     { key: 'games.skill_step', value: skillStep, label: 'Skill adjustment step', group: 'Games' },

--- a/src/telemetry/build-snapshot.ts
+++ b/src/telemetry/build-snapshot.ts
@@ -87,53 +87,158 @@ export async function buildSnapshot() {
       .map(({ mapName, count }) => [mapName, count]),
   )
 
+  const featureEntries = [
+    {
+      key: 'games.skill_suggestions',
+      value: skillSuggestions,
+      label: 'Skill suggestions (experimental)',
+      group: 'Games',
+    },
+    { key: 'games.skill_step', value: skillStep, label: 'Skill adjustment step', group: 'Games' },
+    {
+      key: 'games.logs_tf_upload_method',
+      value: logsTfUploadMethod,
+      label: 'logs.tf upload method',
+      group: 'Games',
+    },
+    {
+      key: 'games.hide_server_info_from_spectators',
+      value: hideServerInfo,
+      label: 'Hide server info from spectators',
+      group: 'Games',
+    },
+    {
+      key: 'games.voice_server_type',
+      value: voiceServerType,
+      label: 'Voice server',
+      group: 'Games',
+    },
+    {
+      key: 'games.auto_force_end_threshold',
+      value: autoForceEndThreshold,
+      label: 'Auto force-end threshold',
+      group: 'Games',
+    },
+    {
+      key: 'players.etf2l_account_required',
+      value: etf2lAccountRequired,
+      label: 'ETF2L account required',
+      group: 'Players',
+    },
+    {
+      key: 'players.minimum_in_game_hours',
+      value: minimumInGameHours,
+      label: 'Minimum in-game hours',
+      group: 'Players',
+    },
+    {
+      key: 'queue.player_skill_threshold',
+      value: playerSkillThreshold,
+      label: 'Queue skill threshold',
+      group: 'Queue',
+    },
+    {
+      key: 'queue.require_player_verification',
+      value: requirePlayerVerification,
+      label: 'Require player verification',
+      group: 'Queue',
+    },
+    { key: 'queue.map_cooldown', value: mapCooldown, label: 'Map cooldown', group: 'Queue' },
+    {
+      key: 'serveme_tf.preferred_region',
+      value: servemePreferredRegion,
+      label: 'serveme.tf preferred region',
+      group: 'Integrations',
+    },
+    {
+      key: 'announcements.active',
+      value: activeAnnouncements > 0,
+      label: 'Active announcement',
+      group: 'State',
+    },
+    {
+      key: 'players.registered_bucket',
+      value: registeredPlayersBucket(registeredPlayers),
+      label: 'Registered players',
+      group: 'State',
+    },
+    {
+      key: 'documents.customized',
+      value: documentsCustomized,
+      label: 'Custom rules / privacy policy',
+      group: 'Customization',
+    },
+    {
+      key: 'games.cooldown_levels.customized',
+      value: !isEqual(cooldownLevels, configuration.getDefault('games.cooldown_levels')),
+      label: 'Custom cooldown levels',
+      group: 'Customization',
+    },
+    {
+      key: 'games.default_player_skill.customized',
+      value: !isEqual(defaultPlayerSkill, configuration.getDefault('games.default_player_skill')),
+      label: 'Custom default skill',
+      group: 'Customization',
+    },
+    {
+      key: 'games.execute_extra_commands.set',
+      value: extraCommands.length > 0,
+      label: 'Extra rcon commands',
+      group: 'Customization',
+    },
+  ]
+
+  const integrationEntries = [
+    { key: 'discord', value: Boolean(environment.DISCORD_BOT_TOKEN), label: 'Discord' },
+    { key: 'serveme', value: Boolean(environment.SERVEME_TF_API_KEY), label: 'serveme.tf' },
+    {
+      key: 'tf2QuickServer',
+      value: Boolean(
+        environment.TF2_QUICK_SERVER_CLIENT_ID && environment.TF2_QUICK_SERVER_CLIENT_SECRET,
+      ),
+      label: 'TF2 Quick Server',
+    },
+    {
+      key: 'twitch',
+      value: Boolean(environment.TWITCH_CLIENT_ID && environment.TWITCH_CLIENT_SECRET),
+      label: 'Twitch',
+    },
+    { key: 'logsTf', value: Boolean(environment.LOGS_TF_API_KEY), label: 'logs.tf' },
+    { key: 'umami', value: Boolean(environment.UMAMI_WEBSITE_ID), label: 'Umami analytics' },
+  ]
+
+  const usageEntries = [
+    {
+      key: 'skillSuggestionsApplied30d',
+      value: usage.skillSuggestionsApplied30d,
+      label: 'Skill suggestions applied (30d)',
+    },
+    {
+      key: 'adminSkillChanges30d',
+      value: usage.adminSkillChanges30d,
+      label: 'Admin skill changes (30d)',
+    },
+    {
+      key: 'gamesLaunchedLifetime',
+      value: gamesLaunchedLifetime,
+      label: 'Games launched (lifetime)',
+    },
+    { key: 'staticGameServers', value: staticGameServers, label: 'Static game servers' },
+  ]
+
   return {
     instanceId,
     version,
     queueConfig: environment.QUEUE_CONFIG,
-    features: {
-      'games.skill_suggestions': skillSuggestions,
-      'games.skill_step': skillStep,
-      'games.logs_tf_upload_method': logsTfUploadMethod,
-      'games.hide_server_info_from_spectators': hideServerInfo,
-      'games.voice_server_type': voiceServerType,
-      'games.auto_force_end_threshold': autoForceEndThreshold,
-      'players.etf2l_account_required': etf2lAccountRequired,
-      'players.minimum_in_game_hours': minimumInGameHours,
-      'queue.player_skill_threshold': playerSkillThreshold,
-      'queue.require_player_verification': requirePlayerVerification,
-      'queue.map_cooldown': mapCooldown,
-      'serveme_tf.preferred_region': servemePreferredRegion,
-      'announcements.active': activeAnnouncements > 0,
-      'players.registered_bucket': registeredPlayersBucket(registeredPlayers),
-      'documents.customized': documentsCustomized,
-      'games.cooldown_levels.customized': !isEqual(
-        cooldownLevels,
-        configuration.getDefault('games.cooldown_levels'),
-      ),
-      'games.default_player_skill.customized': !isEqual(
-        defaultPlayerSkill,
-        configuration.getDefault('games.default_player_skill'),
-      ),
-      'games.execute_extra_commands.set': extraCommands.length > 0,
-    },
-    integrations: {
-      discord: Boolean(environment.DISCORD_BOT_TOKEN),
-      serveme: Boolean(environment.SERVEME_TF_API_KEY),
-      tf2QuickServer: Boolean(
-        environment.TF2_QUICK_SERVER_CLIENT_ID && environment.TF2_QUICK_SERVER_CLIENT_SECRET,
-      ),
-      twitch: Boolean(environment.TWITCH_CLIENT_ID && environment.TWITCH_CLIENT_SECRET),
-      logsTf: Boolean(environment.LOGS_TF_API_KEY),
-      umami: Boolean(environment.UMAMI_WEBSITE_ID),
-    },
-    usage: {
-      skillSuggestionsApplied30d: usage.skillSuggestionsApplied30d,
-      adminSkillChanges30d: usage.adminSkillChanges30d,
-      gamesLaunchedLifetime,
-      staticGameServers,
-    },
+    features: Object.fromEntries(featureEntries.map(({ key, value }) => [key, value])),
+    integrations: Object.fromEntries(integrationEntries.map(({ key, value }) => [key, value])),
+    usage: Object.fromEntries(usageEntries.map(({ key, value }) => [key, value])),
     maps,
     mapPool: pool.map(entry => entry.name).slice(0, maxMapPoolReported),
+    meta: {
+      features: featureEntries.map(({ key, label, group }) => ({ key, label, group })),
+      integrations: integrationEntries.map(({ key, label }) => ({ key, label })),
+      usage: usageEntries.map(({ key, label }) => ({ key, label })),
+    },
   }
 }

--- a/src/telemetry/get-usage-counters.ts
+++ b/src/telemetry/get-usage-counters.ts
@@ -1,0 +1,25 @@
+import { subDays } from 'date-fns'
+import { collections } from '../database/collections'
+import { utcDayKey } from './utc-day-key'
+
+/** Skill-suggestion usage accumulated over the trailing 30 days. */
+export async function getUsageCounters() {
+  const since = utcDayKey(subDays(new Date(), 30))
+  const [totals] = await collections.telemetryStats
+    .aggregate<{ applied: number; changes: number }>([
+      { $match: { day: { $gte: since } } },
+      {
+        $group: {
+          _id: null,
+          applied: { $sum: '$skillSuggestionsApplied' },
+          changes: { $sum: '$adminSkillChanges' },
+        },
+      },
+    ])
+    .toArray()
+
+  return {
+    skillSuggestionsApplied30d: totals?.applied ?? 0,
+    adminSkillChanges30d: totals?.changes ?? 0,
+  }
+}

--- a/src/telemetry/get-usage-counters.ts
+++ b/src/telemetry/get-usage-counters.ts
@@ -2,7 +2,6 @@ import { subDays } from 'date-fns'
 import { collections } from '../database/collections'
 import { utcDayKey } from './utc-day-key'
 
-/** Skill-suggestion usage accumulated over the trailing 30 days. */
 export async function getUsageCounters() {
   const since = utcDayKey(subDays(new Date(), 30))
   const [totals] = await collections.telemetryStats

--- a/src/telemetry/instance-id.ts
+++ b/src/telemetry/instance-id.ts
@@ -1,0 +1,9 @@
+import { createHash } from 'node:crypto'
+import { environment } from '../environment'
+
+/**
+ * Stable, anonymous identifier for this instance. Derived from the website URL
+ * so it survives restarts and redeploys without storing anything, while not
+ * exposing the URL itself to the telemetry service.
+ */
+export const instanceId = createHash('sha256').update(environment.WEBSITE_URL).digest('hex')

--- a/src/telemetry/is-documents-customized.ts
+++ b/src/telemetry/is-documents-customized.ts
@@ -1,0 +1,30 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { collections } from '../database/collections'
+
+const seededDocuments = [
+  { name: 'rules', file: 'rules.md' },
+  { name: 'privacy policy', file: 'privacy-policy.md' },
+]
+
+/** True when any seeded document (rules / privacy policy) differs from its shipped default. */
+export async function isDocumentsCustomized(): Promise<boolean> {
+  const docs = await collections.documents
+    .find({ name: { $in: seededDocuments.map(doc => doc.name) } })
+    .toArray()
+
+  for (const { name, file } of seededDocuments) {
+    const stored = docs.find(doc => doc.name === name)?.body
+    if (stored === undefined) {
+      continue
+    }
+    const shipped = (
+      await readFile(resolve(import.meta.dirname, '..', 'documents', 'default', file))
+    ).toString()
+    if (stored !== shipped) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/src/telemetry/plugins/telemetry.ts
+++ b/src/telemetry/plugins/telemetry.ts
@@ -1,0 +1,18 @@
+import { milliseconds } from 'date-fns'
+import fp from 'fastify-plugin'
+import { environment } from '../../environment'
+import { safe } from '../../utils/safe'
+import { sendTelemetry } from '../send-telemetry'
+
+export default fp(
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async () => {
+    if (environment.TELEMETRY_DISABLED) {
+      return
+    }
+
+    setInterval(safe(sendTelemetry), milliseconds({ days: 1 })).unref()
+    safe(sendTelemetry)()
+  },
+  { name: 'telemetry' },
+)

--- a/src/telemetry/plugins/telemetry.ts
+++ b/src/telemetry/plugins/telemetry.ts
@@ -1,6 +1,7 @@
 import { milliseconds } from 'date-fns'
 import fp from 'fastify-plugin'
 import { environment } from '../../environment'
+import { logger } from '../../logger'
 import { safe } from '../../utils/safe'
 import { sendTelemetry } from '../send-telemetry'
 
@@ -10,6 +11,8 @@ export default fp(
     if (environment.TELEMETRY_DISABLED) {
       return
     }
+
+    logger.info('anonymous telemetry enabled; opt out with TELEMETRY_DISABLED=true')
 
     setInterval(safe(sendTelemetry), milliseconds({ days: 1 })).unref()
     safe(sendTelemetry)()

--- a/src/telemetry/plugins/telemetry.ts
+++ b/src/telemetry/plugins/telemetry.ts
@@ -8,7 +8,7 @@ import { sendTelemetry } from '../send-telemetry'
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
   async () => {
-    if (environment.TELEMETRY_DISABLED) {
+    if (environment.NODE_ENV !== 'production' || environment.CI || environment.TELEMETRY_DISABLED) {
       return
     }
 

--- a/src/telemetry/record-skill-suggestion-usage.test.ts
+++ b/src/telemetry/record-skill-suggestion-usage.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { recordSkillSuggestionUsage } from './record-skill-suggestion-usage'
+import { configuration } from '../configuration'
+import { collections } from '../database/collections'
+import { makeSkillSuggestions } from '../players/make-skill-suggestions'
+import type { Tf2ClassName } from '../shared/types/tf2-class-name'
+
+vi.mock('../configuration', () => ({ configuration: { get: vi.fn() } }))
+
+vi.mock('../database/collections', () => ({
+  collections: { telemetryStats: { updateOne: vi.fn() } },
+}))
+
+vi.mock('../players/make-skill-suggestions', () => ({ makeSkillSuggestions: vi.fn() }))
+
+const player = { elo: {}, stats: { gamesByClass: {} }, skillHistory: [] }
+
+function configReturns(enabled: boolean) {
+  vi.mocked(configuration.get).mockImplementation((key: string) =>
+    Promise.resolve((key === 'games.skill_suggestions' ? enabled : { soldier: 1 }) as never),
+  )
+}
+
+function suggest(entries: [Tf2ClassName, 'up' | 'down'][]) {
+  vi.mocked(makeSkillSuggestions).mockReturnValue(new Map(entries))
+}
+
+afterEach(() => vi.clearAllMocks())
+
+describe('recordSkillSuggestionUsage', () => {
+  it('records nothing when suggestions are disabled', async () => {
+    configReturns(false)
+    await recordSkillSuggestionUsage({ player, oldSkill: {}, newSkill: { soldier: 5 } })
+    expect(collections.telemetryStats.updateOne).not.toHaveBeenCalled()
+  })
+
+  it('counts a save that follows an "up" suggestion as applied', async () => {
+    configReturns(true)
+    suggest([['soldier' as Tf2ClassName, 'up']])
+    await recordSkillSuggestionUsage({
+      player,
+      oldSkill: { soldier: 3 },
+      newSkill: { soldier: 5 },
+    })
+    const inc = vi.mocked(collections.telemetryStats.updateOne).mock.calls[0]![1] as {
+      $inc: Record<string, number>
+    }
+    expect(inc.$inc).toEqual({ adminSkillChanges: 1, skillSuggestionsApplied: 1 })
+  })
+
+  it('does not count a save that moves against the suggestion', async () => {
+    configReturns(true)
+    suggest([['soldier' as Tf2ClassName, 'up']])
+    await recordSkillSuggestionUsage({
+      player,
+      oldSkill: { soldier: 5 },
+      newSkill: { soldier: 3 },
+    })
+    const inc = vi.mocked(collections.telemetryStats.updateOne).mock.calls[0]![1] as {
+      $inc: Record<string, number>
+    }
+    expect(inc.$inc).toEqual({ adminSkillChanges: 1, skillSuggestionsApplied: 0 })
+  })
+
+  it('counts the save but not an application when there are no suggestions', async () => {
+    configReturns(true)
+    suggest([])
+    await recordSkillSuggestionUsage({ player, oldSkill: {}, newSkill: { soldier: 9 } })
+    const inc = vi.mocked(collections.telemetryStats.updateOne).mock.calls[0]![1] as {
+      $inc: Record<string, number>
+    }
+    expect(inc.$inc).toEqual({ adminSkillChanges: 1, skillSuggestionsApplied: 0 })
+  })
+})

--- a/src/telemetry/record-skill-suggestion-usage.ts
+++ b/src/telemetry/record-skill-suggestion-usage.ts
@@ -1,0 +1,42 @@
+import { configuration } from '../configuration'
+import { collections } from '../database/collections'
+import type { PlayerModel, PlayerSkill } from '../database/models/player.model'
+import { makeSkillSuggestions } from '../players/make-skill-suggestions'
+import { utcDayKey } from './utc-day-key'
+
+interface RecordSkillSuggestionUsageParams {
+  player: Pick<PlayerModel, 'elo' | 'stats' | 'skillHistory'>
+  oldSkill: PlayerSkill
+  newSkill: PlayerSkill
+}
+
+/**
+ * Records an admin skill save for telemetry: counts every save, and counts it
+ * as a "suggestion applied" when at least one class was moved in the direction
+ * the skill suggestion recommended. Only counts while the feature is enabled —
+ * if suggestions are off the admin can't have acted on one.
+ */
+export async function recordSkillSuggestionUsage({
+  player,
+  oldSkill,
+  newSkill,
+}: RecordSkillSuggestionUsageParams) {
+  if (!(await configuration.get('games.skill_suggestions'))) {
+    return
+  }
+
+  const defaultSkill = await configuration.get('games.default_player_skill')
+  const suggestions = makeSkillSuggestions({ player })
+
+  const followed = [...suggestions.entries()].some(([gameClass, direction]) => {
+    const before = oldSkill[gameClass] ?? defaultSkill[gameClass] ?? 0
+    const after = newSkill[gameClass] ?? defaultSkill[gameClass] ?? 0
+    return direction === 'up' ? after > before : after < before
+  })
+
+  await collections.telemetryStats.updateOne(
+    { day: utcDayKey(new Date()) },
+    { $inc: { adminSkillChanges: 1, skillSuggestionsApplied: followed ? 1 : 0 } },
+    { upsert: true },
+  )
+}

--- a/src/telemetry/send-telemetry.test.ts
+++ b/src/telemetry/send-telemetry.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sendTelemetry } from './send-telemetry'
+import { environment } from '../environment'
+import { logger } from '../logger'
+
+vi.mock('../environment', () => ({
+  environment: {
+    TELEMETRY_URL: 'https://telemetry.tf2pickup.org',
+    TELEMETRY_DISABLED: false,
+  },
+}))
+
+vi.mock('../logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('./build-snapshot', () => ({
+  buildSnapshot: vi.fn().mockResolvedValue({ instanceId: 'deadbeef', queueConfig: '6v6' }),
+}))
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockResolvedValue({ ok: true, status: 204 })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('when telemetry is disabled', () => {
+  beforeEach(() => {
+    environment.TELEMETRY_DISABLED = true
+  })
+
+  afterEach(() => {
+    environment.TELEMETRY_DISABLED = false
+  })
+
+  it('should not send anything', async () => {
+    await sendTelemetry()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('when telemetry is enabled', () => {
+  it('should send the snapshot unauthenticated', async () => {
+    await sendTelemetry()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url.toString()).toBe('https://telemetry.tf2pickup.org/api/telemetry')
+    expect(init.method).toBe('PUT')
+    expect(init.headers).toEqual({ 'Content-Type': 'application/json' })
+    expect(init.headers).not.toHaveProperty('Authorization')
+    expect(JSON.parse(init.body)).toEqual({ instanceId: 'deadbeef', queueConfig: '6v6' })
+  })
+
+  describe('and the report is rejected', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValue({ ok: false, status: 429 })
+    })
+
+    it('should log a warning and not throw', async () => {
+      await expect(sendTelemetry()).resolves.toBeUndefined()
+      expect(logger.warn).toHaveBeenCalledWith({ status: 429 }, 'telemetry rejected')
+    })
+  })
+})

--- a/src/telemetry/send-telemetry.ts
+++ b/src/telemetry/send-telemetry.ts
@@ -1,0 +1,27 @@
+import { secondsToMilliseconds } from 'date-fns'
+import { environment } from '../environment'
+import { logger } from '../logger'
+import { buildSnapshot } from './build-snapshot'
+
+/**
+ * Reports this instance's anonymous feature-adoption snapshot to the telemetry
+ * service. Enabled by default; operators can opt out with TELEMETRY_DISABLED.
+ */
+export async function sendTelemetry() {
+  if (environment.TELEMETRY_DISABLED) {
+    return
+  }
+
+  const response = await fetch(new URL('/api/telemetry', environment.TELEMETRY_URL), {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(await buildSnapshot()),
+    signal: AbortSignal.timeout(secondsToMilliseconds(10)),
+  })
+
+  if (!response.ok) {
+    logger.warn({ status: response.status }, 'telemetry rejected')
+  }
+}

--- a/src/telemetry/utc-day-key.ts
+++ b/src/telemetry/utc-day-key.ts
@@ -1,0 +1,4 @@
+/** UTC day, formatted as YYYY-MM-DD */
+export function utcDayKey(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}


### PR DESCRIPTION
## Why

We have no visibility into how self-hosted instances actually use tf2pickup — which features get adopted (e.g. the experimental `games.skill_suggestions`), how pickups are configured, what's used and what isn't. OTEL metrics only cover instances I host, and [atlas](https://atlas.tf2pickup.org) is opt-in (tokens handed out per instance), so neither answers "how is the software used in the wild".

This adds a lightweight, **anonymous, opt-out** telemetry reporter that periodically sends a small non-PII configuration + usage snapshot to a dedicated service (telemetry.tf2pickup.org).

## What it sends

- An `instanceId` that is a salted **sha256 of the instance URL** — the URL itself is never sent
- Allow-listed config values (feature flags on/off, queue config, version), enabled integrations
- Usage counters: how many admins actually act on skill suggestions, games launched, static servers
- Maps played + configured map pool

It never sends player data, server names, URLs, tokens, Steam IDs or Discord guilds. It is **default-on but opt-out** via `TELEMETRY_DISABLED=true`, and automated skill changes (future-skill / bulk import) are deliberately excluded from the usage counters — only admin actions are counted.

The receiving service lives in a separate repo.