### PR TITLE
fix(analytics): expand umami tracking coverage

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -81,3 +81,7 @@ TWITCH_CLIENT_SECRET=
 # https://umami.is/docs/self-host
 UMAMI_SCRIPT_SRC=
 UMAMI_WEBSITE_ID=
+# session recorder script (optional) — loaded when set
+UMAMI_RECORDER_SCRIPT_SRC=
+# add data-performance="true" to the umami script (true/false)
+UMAMI_TRACK_PERFORMANCE=false

--- a/src/admin/announcements/views/html/announcements.page.tsx
+++ b/src/admin/announcements/views/html/announcements.page.tsx
@@ -71,6 +71,7 @@ export function AnnouncementEntry(props: { announcement: WithId<AnnouncementMode
         <div class="flex gap-2">
           <button
             class="text-accent-500 flex items-center gap-1 hover:underline"
+            data-umami-event="toggle-announcement"
             hx-post={`/admin/announcements/${id}/toggle`}
             hx-target="closest div.rounded-sm"
             hx-swap="outerHTML"
@@ -79,6 +80,7 @@ export function AnnouncementEntry(props: { announcement: WithId<AnnouncementMode
           </button>
           <button
             class="flex items-center gap-1 text-white hover:underline"
+            data-umami-event="edit-announcement"
             hx-get={`/admin/announcements/${id}/edit`}
             hx-target="closest div.rounded-sm"
             hx-swap="outerHTML"
@@ -87,6 +89,7 @@ export function AnnouncementEntry(props: { announcement: WithId<AnnouncementMode
           </button>
           <button
             class="text-alert flex items-center gap-1 hover:underline"
+            data-umami-event="delete-announcement"
             hx-delete={`/admin/announcements/${id}`}
             hx-confirm="Are you sure you want to delete this announcement?"
             hx-target="closest div.rounded-sm"

--- a/src/admin/delete-player/views/html/delete-player.page.tsx
+++ b/src/admin/delete-player/views/html/delete-player.page.tsx
@@ -121,6 +121,8 @@ export function DeletePlayerCard(props: { player: DeletePlayerSummary }) {
               class="button"
               data-variant="accent"
               data-size="dense"
+              data-umami-event="delete-player"
+              data-umami-event-player={props.player.steamId}
               hx-delete={`/admin/delete-player/${props.player.steamId}`}
               hx-target={`#delete-player-card-${props.player.steamId}`}
               hx-swap="outerHTML"

--- a/src/admin/map-pool/views/html/map-pool.page.tsx
+++ b/src/admin/map-pool/views/html/map-pool.page.tsx
@@ -27,6 +27,7 @@ export async function MapPoolPage() {
 
           <button
             class="mt-2 flex flex-row items-center gap-2 text-white hover:underline"
+            data-umami-event="add-map-pool-entry"
             hx-post="/admin/map-pool/create"
             hx-trigger="click"
             hx-target="#mapPoolList"

--- a/src/admin/scramble-maps/views/html/scramble-maps.page.tsx
+++ b/src/admin/scramble-maps/views/html/scramble-maps.page.tsx
@@ -12,6 +12,7 @@ export async function ScrambleMaps() {
             class="button"
             data-variant="accent"
             data-size="dense"
+            data-umami-event="scramble-maps"
             hx-put="/admin/scramble-maps/scramble"
             hx-target="#adminPanelMapVoteOptions"
             hx-swap="outerHTML"

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -43,6 +43,8 @@ const environmentSchema = z.object({
 
   UMAMI_SCRIPT_SRC: z.string().optional(),
   UMAMI_WEBSITE_ID: z.string().optional(),
+  UMAMI_RECORDER_SCRIPT_SRC: z.string().optional(),
+  UMAMI_TRACK_PERFORMANCE: z.enum(['true', 'false']).default('false'),
 })
 
 export const environment = environmentSchema.parse(process.env)

--- a/src/games/views/html/choose-game-server-dialog.tsx
+++ b/src/games/views/html/choose-game-server-dialog.tsx
@@ -18,7 +18,12 @@ export async function ChooseGameServerDialog(props: { gameNumber: GameNumber }) 
         <StaticGameServerList name="gameServer" />
         {servemeTf.isEnabled && <ServemeTfServerList />}
         {tf2QuickServer.isEnabled && <Tf2QuickServerList gameNumber={props.gameNumber} />}
-        <button class="button mt-8 self-center" data-variant="accent">
+        <button
+          class="button mt-8 self-center"
+          data-variant="accent"
+          data-umami-event="reassign-game-server"
+          data-umami-event-game-number={props.gameNumber}
+        >
           Select
         </button>
       </form>

--- a/src/html/@client/ready-up-dialog.ts
+++ b/src/html/@client/ready-up-dialog.ts
@@ -21,6 +21,7 @@ function showReadyUpDialog() {
 
   if (!dialog.open) {
     dialog.showModal()
+    window.umami?.track('ready-up-shown')
   }
 
   setButtonsDisabled(dialog, false)

--- a/src/html/@client/types.d.ts
+++ b/src/html/@client/types.d.ts
@@ -1,3 +1,7 @@
 interface Window {
   htmx: typeof import('htmx.org').default
+  umami?: {
+    track: (eventName: string, eventData?: Record<string, unknown>) => void
+    identify: (data: Record<string, unknown>) => void
+  }
 }

--- a/src/html/components/profile.tsx
+++ b/src/html/components/profile.tsx
@@ -58,6 +58,7 @@ export async function Profile(player: PickDeep<PlayerModel, 'steamId' | 'name' |
               href="/auth/sign-out"
               class="profile-menu-item"
               data-variant="accent"
+              data-umami-event="logout"
               hx-boost="false"
             >
               <IconLogout />

--- a/src/html/layout.tsx
+++ b/src/html/layout.tsx
@@ -78,7 +78,7 @@ export async function Layout(
             data-performance={environment.UMAMI_TRACK_PERFORMANCE === 'true' ? 'true' : undefined}
           ></script>
         )}
-        {umamiEnabled && environment.UMAMI_RECORDER_SCRIPT_SRC && (
+        {umamiEnabled && !!environment.UMAMI_RECORDER_SCRIPT_SRC && (
           <script
             defer
             src={environment.UMAMI_RECORDER_SCRIPT_SRC}

--- a/src/html/layout.tsx
+++ b/src/html/layout.tsx
@@ -75,6 +75,14 @@ export async function Layout(
             defer
             src={environment.UMAMI_SCRIPT_SRC}
             data-website-id={environment.UMAMI_WEBSITE_ID}
+            data-performance={environment.UMAMI_TRACK_PERFORMANCE === 'true' ? 'true' : undefined}
+          ></script>
+        )}
+        {umamiEnabled && environment.UMAMI_RECORDER_SCRIPT_SRC && (
+          <script
+            defer
+            src={environment.UMAMI_RECORDER_SCRIPT_SRC}
+            data-website-id={environment.UMAMI_WEBSITE_ID}
           ></script>
         )}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,9 @@ await app.register(await import('@fastify/helmet'), {
               ...(environment.UMAMI_SCRIPT_SRC
                 ? [new URL(environment.UMAMI_SCRIPT_SRC).origin]
                 : []),
+              ...(environment.UMAMI_RECORDER_SCRIPT_SRC
+                ? [new URL(environment.UMAMI_RECORDER_SCRIPT_SRC).origin]
+                : []),
             ],
             'script-src-attr': ["'unsafe-inline'"],
             'img-src': [
@@ -52,6 +55,9 @@ await app.register(await import('@fastify/helmet'), {
               "'self'",
               ...(environment.UMAMI_SCRIPT_SRC
                 ? [new URL(environment.UMAMI_SCRIPT_SRC).origin]
+                : []),
+              ...(environment.UMAMI_RECORDER_SCRIPT_SRC
+                ? [new URL(environment.UMAMI_RECORDER_SCRIPT_SRC).origin]
                 : []),
             ],
           },

--- a/src/players/views/html/admin-toolbox.tsx
+++ b/src/players/views/html/admin-toolbox.tsx
@@ -101,7 +101,14 @@ export async function AdminToolbox(props: {
                 ))}
 
                 <div class="skill-buttons">
-                  <button type="submit" class="button" data-variant="accent" title="Save">
+                  <button
+                    type="submit"
+                    class="button"
+                    data-variant="accent"
+                    title="Save"
+                    data-umami-event="save-player-skill"
+                    data-umami-event-player={player.steamId}
+                  >
                     <IconDeviceFloppy size={20} />
                     <span>Save</span>
                   </button>
@@ -110,6 +117,8 @@ export async function AdminToolbox(props: {
                     type="button"
                     class="button"
                     title="Reset"
+                    data-umami-event="reset-player-skill"
+                    data-umami-event-player={player.steamId}
                     hx-delete={`/players/${player.steamId}/edit/skill`}
                     hx-confirm="Are you sure you want to reset this player's skill?"
                     hx-trigger="click"

--- a/src/players/views/html/edit-player.page.tsx
+++ b/src/players/views/html/edit-player.page.tsx
@@ -100,7 +100,14 @@ export async function EditPlayerProfilePage(props: { steamId: SteamId64 }) {
             </div>
 
             <div class="self-end">
-              <button type="submit" class="button" data-variant="accent" data-size="dense">
+              <button
+                type="submit"
+                class="button"
+                data-variant="accent"
+                data-size="dense"
+                data-umami-event="save-player-profile"
+                data-umami-event-player={player.steamId}
+              >
                 <IconDeviceFloppy size={20} />
                 <span>Save</span>
               </button>
@@ -213,7 +220,14 @@ export async function EditPlayerRolesPage(props: { steamId: SteamId64 }) {
             </p>
           </div>
 
-          <button type="submit" class="button" data-variant="accent" data-size="dense">
+          <button
+            type="submit"
+            class="button"
+            data-variant="accent"
+            data-size="dense"
+            data-umami-event="save-player-roles"
+            data-umami-event-player={player.steamId}
+          >
             <IconDeviceFloppy size={20} />
             <span>Save</span>
           </button>
@@ -384,6 +398,8 @@ export async function BanDetails(props: {
             <button
               class="button"
               data-variant="darker"
+              data-umami-event="revoke-ban"
+              data-umami-event-player={props.player.steamId}
               hx-put={`/players/${props.player.steamId}/edit/bans/${props.ban.start.getTime().toString()}/revoke`}
               hx-trigger="click"
               hx-target={`#player-ban-${props.ban.start.getTime().toString()}`}
@@ -443,6 +459,8 @@ export async function ChatMuteDetails(props: {
             <button
               class="button"
               data-variant="darker"
+              data-umami-event="revoke-chat-mute"
+              data-umami-event-player={props.player.steamId}
               hx-put={`/players/${props.player.steamId}/edit/chat-mutes/${props.chatMute.start.getTime().toString()}/revoke`}
               hx-trigger="click"
               hx-target={`#player-chat-mute-${props.chatMute.start.getTime().toString()}`}

--- a/src/players/views/html/player-verified-checkbox.tsx
+++ b/src/players/views/html/player-verified-checkbox.tsx
@@ -19,6 +19,8 @@ export function PlayerVerifiedCheckbox(props: {
         value="true"
         checked={player.verified}
         hx-put={`/players/${player.steamId}/verify`}
+        data-umami-event="verify-player"
+        data-umami-event-player={player.steamId}
         hx-trigger="change"
         hx-target="#player-verified-checkbox"
         hx-swap="outerHTML transition:false"

--- a/src/players/views/html/player.page.tsx
+++ b/src/players/views/html/player.page.tsx
@@ -208,6 +208,8 @@ function PlayerPresentation(props: {
           rel="noreferrer"
           class={['player-presentation-link', queue.config.classes.length > 4 && 'compact']}
           title="Steam"
+          data-umami-event="open-external-profile"
+          data-umami-event-target="steam"
         >
           <IconBrandSteam />
           <span>steam</span>
@@ -219,6 +221,8 @@ function PlayerPresentation(props: {
           rel="noreferrer"
           class={['player-presentation-link', queue.config.classes.length > 4 && 'compact']}
           title="Logs"
+          data-umami-event="open-external-profile"
+          data-umami-event-target="logs"
         >
           <IconAlignBoxBottomRight />
           <span>logs</span>
@@ -231,6 +235,8 @@ function PlayerPresentation(props: {
             rel="noreferrer"
             class={['player-presentation-link', queue.config.classes.length > 4 && 'compact']}
             title="ETF2L"
+            data-umami-event="open-external-profile"
+            data-umami-event-target="etf2l"
           >
             <IconStars />
             <span>etf2l</span>
@@ -246,6 +252,8 @@ function PlayerPresentation(props: {
             rel="noreferrer"
             class={['player-presentation-link', queue.config.classes.length > 4 && 'compact']}
             title="Twitch"
+            data-umami-event="open-external-profile"
+            data-umami-event-target="twitch"
           >
             <IconBrandTwitch />
             <span>twitch</span>

--- a/src/queue-auto/views/html/queue.page.tsx
+++ b/src/queue-auto/views/html/queue.page.tsx
@@ -150,6 +150,7 @@ export async function ClearQueueButton(props: { actor?: User | undefined }) {
     <button
       class="button"
       data-variant="accent"
+      data-umami-event="clear-queue"
       hx-delete="/queue/players"
       hx-confirm="Are you sure you want to kick everyone from the queue?"
     >

--- a/src/queue-auto/views/html/stream-list.tsx
+++ b/src/queue-auto/views/html/stream-list.tsx
@@ -40,6 +40,8 @@ function FeaturedStream(props: StreamModel) {
       href={`https://www.twitch.tv/${props.userName}`}
       target="_blank"
       rel="noreferrer"
+      data-umami-event="watch-stream"
+      data-umami-event-streamer={props.userName}
     >
       <img src={thumbnail} alt="stream thumbnail" class="rounded-xs" width="177" height="100" />
       <div class="text-abru-light-75 flex flex-col justify-center font-medium">
@@ -65,6 +67,8 @@ function CompactStream(props: StreamModel) {
       href={`https://www.twitch.tv/${props.userName}`}
       target="_blank"
       rel="noreferrer"
+      data-umami-event="watch-stream"
+      data-umami-event-streamer={props.userName}
     >
       <span class="text-abru-light-75 truncate text-lg font-medium" safe>
         {props.userName}


### PR DESCRIPTION
Umami tagging had drifted as new features shipped; this restores coverage and adds two opt-in integration toggles.

### Why
- **Coverage gaps** — many interactive actions added since tags were last touched had no `data-umami-event`, so they were invisible in analytics. Adds tags for admin player/game/announcement/map actions and engagement clicks (logout, external profile links, stream views).
- **Ready-up funnel** — `ready-up-shown` (fired on dialog open) lets the queue→ready→game conversion and the timeout drop-off be derived from the already-tracked `ready-up`/`not-ready` clicks, tied to the player's browser session. No new infra.
- **Recorder / performance** — `UMAMI_RECORDER_SCRIPT_SRC` loads the session recorder when set; `UMAMI_TRACK_PERFORMANCE` adds `data-performance` to the umami script. Both optional; recorder origin is allowlisted in the production CSP.

Lifecycle/outcome events (game ended, substitute filled, abandonment) were intentionally left out — those are server-side and belong in SigNoz/OTel rather than skewing Umami visitor stats.