### PR TITLE
fix(logging): right-size noisy warn/error logs and guard match end/restart

### DIFF
--- a/src/auth/plugins/steam.ts
+++ b/src/auth/plugins/steam.ts
@@ -45,9 +45,11 @@ const verifySteamCallback = (url: string): Promise<string> =>
   new Promise((resolve, reject) => {
     openId.verifyAssertion(url, (err, result) => {
       if (err) {
-        // OpenID assertion failures (replayed nonce, bad signature) come from
-        // stale/duplicated callback requests, not server faults — log at debug.
-        reject(withLogLevel(new Error(err.message), 'debug'))
+        const error = new Error(err.message)
+        // A replayed nonce just means a stale/duplicated callback request (e.g.
+        // the user refreshed the return URL), not a server fault — log at debug.
+        // Other assertion failures are rarer and kept at the default level.
+        reject(err.message === 'Invalid or replayed nonce' ? withLogLevel(error, 'debug') : error)
         return
       }
 

--- a/src/auth/plugins/steam.ts
+++ b/src/auth/plugins/steam.ts
@@ -8,6 +8,7 @@ import { players } from '../../players'
 import type { User } from '../types/user'
 import { SteamApiError } from '../../steam/errors/steam-api.error'
 import { PrivateSteamProfilePage } from '../views/html/private-steam-profile.page'
+import { withLogLevel } from '../../utils/with-log-level'
 
 declare module '@fastify/secure-session' {
   interface SessionData {
@@ -44,7 +45,9 @@ const verifySteamCallback = (url: string): Promise<string> =>
   new Promise((resolve, reject) => {
     openId.verifyAssertion(url, (err, result) => {
       if (err) {
-        reject(new Error(err.message))
+        // OpenID assertion failures (replayed nonce, bad signature) come from
+        // stale/duplicated callback requests, not server faults — log at debug.
+        reject(withLogLevel(new Error(err.message), 'debug'))
         return
       }
 

--- a/src/games/plugins/match-event-handler.ts
+++ b/src/games/plugins/match-event-handler.ts
@@ -48,6 +48,16 @@ export default fp(
     events.on(
       'match:restarted',
       safe(async ({ gameNumber }) => {
+        // Gameservers re-fire match:restarted (mp_restartgame, map reloads); only
+        // the started -> launching transition is meaningful. Ignore the rest
+        // instead of failing to find a started game.
+        const game = await collections.games.findOne(
+          { number: gameNumber },
+          { projection: { state: 1 } },
+        )
+        if (game?.state !== GameState.started) {
+          return
+        }
         await update(
           { number: gameNumber, state: GameState.started },
           {
@@ -71,6 +81,16 @@ export default fp(
     events.on(
       'match:ended',
       safe(async ({ gameNumber }) => {
+        // Gameservers re-fire match:ended after the game already left the started
+        // state (ended, force-ended, restarted). Ignore the rest instead of
+        // failing to find a started game.
+        const existing = await collections.games.findOne(
+          { number: gameNumber },
+          { projection: { state: 1 } },
+        )
+        if (existing?.state !== GameState.started) {
+          return
+        }
         await collections.gamesSubstituteRequests.deleteMany({ gameNumber })
         const game = await update(
           { number: gameNumber, state: GameState.started },

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { secrets } from './secrets'
 import { environment } from './environment'
 import { version } from './version'
 import { realIp } from './utils/real-ip'
+import { logError } from './utils/log-error'
 import { ErrorPage } from './error-pages/views/html/error.page'
 import { secondsInWeek } from 'date-fns/constants'
 import autoload from '@fastify/autoload'
@@ -110,16 +111,7 @@ app.setErrorHandler((error, request, reply) => {
     message = error.message
   }
 
-  // Only server faults (5xx) are genuine errors. Client errors (4xx) are routine
-  // — unknown players, aborted games, queue races, validation — so don't log
-  // them at error level. 404s and 429s are noisy enough to belong at info.
-  if (statusCode >= 500) {
-    logger.error(error)
-  } else if (statusCode === 404 || statusCode === 429) {
-    logger.info(error)
-  } else {
-    logger.warn(error)
-  }
+  logError(error)
 
   const accept = request.accepts()
   switch (accept.type(['json', 'html'])) {

--- a/src/mumble/setup-game-channels.ts
+++ b/src/mumble/setup-game-channels.ts
@@ -1,4 +1,5 @@
 import type { GameModel } from '../database/models/game.model'
+import { CommandTimedOutError } from '@tf2pickup-org/mumble-client'
 import { assertClientIsConnected } from './assert-client-is-connected'
 import { client } from './client'
 import { moveToTargetChannel } from './move-to-target-channel'
@@ -6,6 +7,7 @@ import { Tf2Team } from '../shared/types/tf2-team'
 import { games } from '../games'
 import { collections } from '../database/collections'
 import { mumbleDirectUrl } from './mumble-direct-url'
+import { withLogLevel } from '../utils/with-log-level'
 
 // subchannels for each game
 const subChannelNames = [Tf2Team.blu.toUpperCase(), Tf2Team.red.toUpperCase()]
@@ -14,10 +16,19 @@ export async function setupGameChannels(game: GameModel) {
   assertClientIsConnected(client)
   await moveToTargetChannel(client)
   const channelName = `${game.number}`
-  const channel = await client.user.channel.createSubChannel(channelName)
-  await Promise.all(
-    subChannelNames.map(async subChannelName => await channel.createSubChannel(subChannelName)),
-  )
+  try {
+    const channel = await client.user.channel.createSubChannel(channelName)
+    await Promise.all(
+      subChannelNames.map(async subChannelName => await channel.createSubChannel(subChannelName)),
+    )
+  } catch (error) {
+    // Mumble command timeouts are transient (server busy / packet loss); channel
+    // setup retries on the next game, so this isn't a server fault.
+    if (error instanceof CommandTimedOutError) {
+      throw withLogLevel(error, 'warn')
+    }
+    throw error
+  }
 
   // update game
   await games.update(game.number, {

--- a/src/players/sync-avatars.test.ts
+++ b/src/players/sync-avatars.test.ts
@@ -27,7 +27,7 @@ vi.mock('../database/collections', () => ({
 }))
 
 vi.mock('../logger', () => ({
-  logger: { warn: vi.fn(), debug: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }))
 
 import { collections } from '../database/collections'

--- a/src/players/sync-avatars.ts
+++ b/src/players/sync-avatars.ts
@@ -40,7 +40,7 @@ export async function syncAvatars() {
     if (error instanceof Error && error.message === 'No players found') {
       summaries = []
     } else {
-      logger.warn({ error }, 'failed to fetch Steam summaries while syncing avatars')
+      logger.info({ error }, 'failed to fetch Steam summaries while syncing avatars')
       return
     }
   }

--- a/src/players/upsert.ts
+++ b/src/players/upsert.ts
@@ -11,6 +11,7 @@ import { Etf2lApiError } from '../etf2l/errors/etf2l-api.error'
 import { errors } from '../errors'
 import { environment } from '../environment'
 import { events } from '../events'
+import { withLogLevel } from '../utils/with-log-level'
 
 interface UpsertPlayerParams {
   steamID: string
@@ -70,9 +71,12 @@ async function verifyInGameHours(steamId: SteamId64) {
   const reportedHours = await getTf2InGameHours(steamId)
   logger.debug({ steamId, reportedHours, requiredHours }, 'in-game hours verification')
   if (reportedHours < requiredHours) {
-    logger.warn({ steamId, reportedHours, requiredHours }, 'insufficient TF2 in-game hours')
-    throw errors.forbidden(
-      `insufficient TF2 in-game hours (reported: ${reportedHours}, required: ${requiredHours})`,
+    logger.info({ steamId, reportedHours, requiredHours }, 'insufficient TF2 in-game hours')
+    throw withLogLevel(
+      errors.forbidden(
+        `insufficient TF2 in-game hours (reported: ${reportedHours}, required: ${requiredHours})`,
+      ),
+      'info',
     )
   }
 }
@@ -99,8 +103,8 @@ async function verifyEtf2l(player: CreatePlayerParams): Promise<CreatePlayerPara
     }
   } catch (error) {
     if (error instanceof Etf2lApiError && error.response.status === 404 /* Not Found */) {
-      logger.warn({ player }, 'ETF2L.org account not found')
-      throw errors.forbidden(`ETF2L.org account is required`)
+      logger.info({ player }, 'ETF2L.org account not found')
+      throw withLogLevel(errors.forbidden(`ETF2L.org account is required`), 'info')
     } else {
       throw error
     }

--- a/src/queue-auto/join.ts
+++ b/src/queue-auto/join.ts
@@ -9,6 +9,7 @@ import { players } from '../players'
 import { preReady } from '../pre-ready'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getState } from '../queue/get-state'
+import { withLogLevel } from '../utils/with-log-level'
 import { meetsSkillThreshold } from './meets-skill-threshold'
 import { withQueueLock } from '../queue/with-queue-lock'
 import type { QueueSlotId } from '../queue/types/queue-slot-id'
@@ -52,7 +53,7 @@ export async function join(slotId: QueueSlotId, steamId: SteamId64): Promise<Que
   return await withQueueLock('join', async () => {
     const state = await getState()
     if (![QueueState.waiting, QueueState.ready].includes(state)) {
-      throw errors.badRequest('invalid queue state')
+      throw withLogLevel(errors.badRequest('invalid queue state'), 'debug')
     }
 
     const targetSlot = await collections.queueSlots.findOneAndUpdate(
@@ -73,7 +74,7 @@ export async function join(slotId: QueueSlotId, steamId: SteamId64): Promise<Que
     )
 
     if (!targetSlot) {
-      throw errors.badRequest('slot occupied')
+      throw withLogLevel(errors.badRequest('slot occupied'), 'debug')
     }
 
     const oldSlot = await collections.queueSlots.findOneAndUpdate(

--- a/src/queue-auto/kick.ts
+++ b/src/queue-auto/kick.ts
@@ -9,13 +9,14 @@ import { getState } from '../queue/get-state'
 import { withQueueLock } from '../queue/with-queue-lock'
 import { preReady } from '../pre-ready'
 import { errors } from '../errors'
+import { withLogLevel } from '../utils/with-log-level'
 
 export async function kick(...steamIds: SteamId64[]): Promise<QueueSlotModel[]> {
   return await withQueueLock('kick', async () => {
     logger.trace({ steamIds }, 'queue.kick()')
     const state = await getState()
     if (state === QueueState.launching) {
-      throw errors.badRequest('invalid queue state')
+      throw withLogLevel(errors.badRequest('invalid queue state'), 'debug')
     }
 
     const slots: QueueSlotModel[] = []

--- a/src/queue-auto/leave.ts
+++ b/src/queue-auto/leave.ts
@@ -9,13 +9,14 @@ import { getState } from '../queue/get-state'
 import { withQueueLock } from '../queue/with-queue-lock'
 import { preReady } from '../pre-ready'
 import { errors } from '../errors'
+import { withLogLevel } from '../utils/with-log-level'
 
 export async function leave(steamId: SteamId64): Promise<QueueSlotModel> {
   return await withQueueLock('leave', async () => {
     logger.trace({ steamId }, 'queue.leave()')
     const state = await getState()
     if (state === QueueState.launching) {
-      throw errors.badRequest('invalid queue state')
+      throw withLogLevel(errors.badRequest('invalid queue state'), 'debug')
     }
 
     const slot = await collections.queueSlots.findOneAndUpdate(
@@ -31,7 +32,7 @@ export async function leave(steamId: SteamId64): Promise<QueueSlotModel> {
     )
 
     if (!slot) {
-      throw errors.badRequest('player not in the queue')
+      throw withLogLevel(errors.badRequest('player not in the queue'), 'debug')
     }
     events.emit('queue/slots:updated', { slots: [slot] })
 

--- a/src/queue-auto/plugins/gateway-listeners.ts
+++ b/src/queue-auto/plugins/gateway-listeners.ts
@@ -6,7 +6,7 @@ import { leave } from '../leave'
 import { readyUp } from '../ready-up'
 import { ReadyUpDialog } from '../views/html/ready-up-dialog'
 import { voteMap } from '../vote-map'
-import { logger } from '../../logger'
+import { logError } from '../../utils/log-error'
 import type { SteamId64 } from '../../shared/types/steam-id-64'
 import { markAsFriend } from '../mark-as-friend'
 import { getState } from '../../queue/get-state'
@@ -55,23 +55,10 @@ export default fp(
             })
           },
         ).catch(async (error: unknown) => {
-          // Mirror the HTTP error handler (src/main.ts): only server faults (5xx)
-          // are genuine errors. Client errors (4xx) — queue races ('slot occupied'),
-          // invalid state, unauthorized — are routine, so don't log them at error level.
-          if (
-            error instanceof Error &&
-            'statusCode' in error &&
-            typeof error.statusCode === 'number' &&
-            error.statusCode < 500
-          ) {
-            if (error.statusCode === 404 || error.statusCode === 429) {
-              logger.info(error)
-            } else {
-              logger.warn(error)
-            }
-          } else {
-            logger.error(error)
-          }
+          // Same levelling as the HTTP error handler (src/main.ts): client errors
+          // (4xx) — queue races ('slot occupied'), invalid state, unauthorized —
+          // are routine and not logged at error level. See logError.
+          logError(error)
           if (error instanceof Error) {
             const msg = await FlashMessage({
               message: `Error: ${error.message}`,

--- a/src/queue-auto/vote-map.ts
+++ b/src/queue-auto/vote-map.ts
@@ -5,6 +5,7 @@ import { logger } from '../logger'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import { getMapVoteResults } from './get-map-vote-results'
 import { withQueueLock } from '../queue/with-queue-lock'
+import { withLogLevel } from '../utils/with-log-level'
 
 export async function voteMap(steamId: SteamId64, map: string): Promise<Record<string, number>> {
   return await withQueueLock('vote-map', async () => {
@@ -16,7 +17,7 @@ export async function voteMap(steamId: SteamId64, map: string): Promise<Record<s
 
     const slotCount = await collections.queueSlots.countDocuments({ 'player.steamId': steamId })
     if (slotCount === 0) {
-      throw errors.badRequest('player not in the queue')
+      throw withLogLevel(errors.badRequest('player not in the queue'), 'debug')
     }
 
     const { deletedCount } = await collections.queueMapVotes.deleteOne({ player: steamId, map })

--- a/src/twitch-tv/get-streams.ts
+++ b/src/twitch-tv/get-streams.ts
@@ -2,20 +2,28 @@ import { chunk } from 'es-toolkit'
 import { environment } from '../environment'
 import { getAppAccessToken } from './get-app-access-token'
 import { getStreamsResponseSchema } from './schemas/get-streams-response.schema'
+import { withLogLevel } from '../utils/with-log-level'
 import type { Stream } from './types/stream'
 
 const twitchTvApiUrl = 'https://api.twitch.tv/helix'
 
-const withTwitchTvAuth = async (input: string | URL | Request, init?: RequestInit) =>
-  fetch(input, {
-    ...init,
-    headers: {
-      // eslint-disable-next-line @typescript-eslint/no-misused-spread
-      ...init?.headers,
-      Authorization: `Bearer ${await getAppAccessToken()}`,
-      'Client-ID': environment.TWITCH_CLIENT_ID!,
-    },
-  })
+const withTwitchTvAuth = async (input: string | URL | Request, init?: RequestInit) => {
+  try {
+    return await fetch(input, {
+      ...init,
+      headers: {
+        // eslint-disable-next-line @typescript-eslint/no-misused-spread
+        ...init?.headers,
+        Authorization: `Bearer ${await getAppAccessToken()}`,
+        'Client-ID': environment.TWITCH_CLIENT_ID!,
+      },
+    })
+  } catch (error) {
+    // Twitch is a non-critical external dependency; transient DNS/network
+    // failures (EAI_AGAIN, timeouts) are routine and retried every minute.
+    throw withLogLevel(error, 'warn')
+  }
+}
 
 export async function getStreams(params: {
   userIds: string[]

--- a/src/utils/log-error.test.ts
+++ b/src/utils/log-error.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { logError } from './log-error'
+import { withLogLevel } from './with-log-level'
+import { logger } from '../logger'
+
+vi.mock('../logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+describe('logError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('logs an explicit tag at the requested level', () => {
+    const error = withLogLevel(new Error('slot occupied'), 'debug')
+    logError(error)
+    expect(logger.debug).toHaveBeenCalledWith(error)
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('logs a 404/429 at info', () => {
+    const error = Object.assign(new Error('not found'), { statusCode: 404 })
+    logError(error)
+    expect(logger.info).toHaveBeenCalledWith(error)
+  })
+
+  it('logs other 4xx at warn', () => {
+    const error = Object.assign(new Error('bad request'), { statusCode: 400 })
+    logError(error)
+    expect(logger.warn).toHaveBeenCalledWith(error)
+  })
+
+  it('logs 5xx at error', () => {
+    const error = Object.assign(new Error('boom'), { statusCode: 500 })
+    logError(error)
+    expect(logger.error).toHaveBeenCalledWith(error)
+  })
+
+  it('logs untyped errors at error', () => {
+    const error = new Error('boom')
+    logError(error)
+    expect(logger.error).toHaveBeenCalledWith(error)
+  })
+
+  it('prefers the explicit tag over the status code', () => {
+    const error = withLogLevel(Object.assign(new Error('boom'), { statusCode: 500 }), 'info')
+    logError(error)
+    expect(logger.info).toHaveBeenCalledWith(error)
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/log-error.ts
+++ b/src/utils/log-error.ts
@@ -1,0 +1,45 @@
+import { logger } from '../logger'
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+// Mirror of the key set by withLogLevel; kept in sync via the global registry.
+const logLevelKey = Symbol.for('tf2pickup.log-level')
+
+/**
+ * Log an error at the appropriate level. An explicit tag from `withLogLevel`
+ * always wins. Otherwise client errors (4xx) are routine — unknown players,
+ * aborted games, queue races, validation — and logged at warn, with 404s/429s
+ * demoted further to info; server faults (5xx) and untyped errors are errors.
+ */
+export function logError(error: unknown): void {
+  switch (resolveLevel(error)) {
+    case 'debug':
+      logger.debug(error)
+      break
+    case 'info':
+      logger.info(error)
+      break
+    case 'warn':
+      logger.warn(error)
+      break
+    case 'error':
+      logger.error(error)
+      break
+  }
+}
+
+function resolveLevel(error: unknown): LogLevel {
+  if (typeof error === 'object' && error !== null) {
+    const tagged = (error as Record<symbol, unknown>)[logLevelKey]
+    if (tagged === 'debug' || tagged === 'info' || tagged === 'warn' || tagged === 'error') {
+      return tagged
+    }
+    if ('statusCode' in error) {
+      const { statusCode } = error
+      if (typeof statusCode === 'number' && statusCode < 500) {
+        return statusCode === 404 || statusCode === 429 ? 'info' : 'warn'
+      }
+    }
+  }
+  return 'error'
+}

--- a/src/utils/safe.ts
+++ b/src/utils/safe.ts
@@ -1,13 +1,14 @@
-import { logger } from '../logger'
+import { logError } from './log-error'
 
 /**
- * Wrap a function in a try/catch block and log any errors.
+ * Wrap a function in a try/catch block and log any errors at their appropriate
+ * level (see `logError`: 4xx client errors are routine, 5xx are real faults).
  * @param fn The function to wrap.
  */
 export function safe<Args extends unknown[]>(fn: (...args: Args) => Promise<void>) {
   return (...args: Args) => {
     fn(...args).catch((error: unknown) => {
-      logger.error(error)
+      logError(error)
     })
   }
 }

--- a/src/utils/with-log-level.ts
+++ b/src/utils/with-log-level.ts
@@ -1,0 +1,21 @@
+type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+// Symbol.for keeps the key stable across modules without a shared import, so
+// log-error.ts can read what was tagged here.
+const logLevelKey = Symbol.for('tf2pickup.log-level')
+
+/**
+ * Tag an error with the level it should be logged at, overriding the default
+ * status-code heuristic in `logError`. Returns the same error for chaining,
+ * e.g. `throw withLogLevel(errors.badRequest('slot occupied'), 'debug')`.
+ */
+export function withLogLevel<E>(error: E, level: LogLevel): E {
+  if (typeof error === 'object' && error !== null) {
+    Object.defineProperty(error, logLevelKey, {
+      value: level,
+      enumerable: false,
+      configurable: true,
+    })
+  }
+  return error
+}


### PR DESCRIPTION
## What

Investigated yesterday/today's production warn/error logs (via SigNoz). Almost all of the volume turned out to be **routine client-side conditions logged one level too high** — no active incidents. This re-levels them and removes the single biggest error source at its root.

## Changes

**Structural:** new shared helper `withLogLevel(error, level)` + `logError(error)`. The HTTP error handler (`main.ts`), the websocket handler (`gateway-listeners.ts`) and the `safe()` wrapper now all log errors with the same heuristic — **4xx = routine (warn, or info for 404/429), 5xx = real fault (error)** — with explicit per-error overrides via `withLogLevel`. This also collapses two copies of the status-code heuristic into one place.

**Guard (root-cause fix):** `match:ended` / `match:restarted` now pre-check game state like `match:started` already does. Gameservers re-fire these events after a game already left the `started` state, which was throwing `game ({"number":N,"state":"started"}) not found` — by far the largest error source (~50/48h).

**Re-levelled (matches the requested list):**

| Message | Was | Now |
|---|---|---|
| `failed to fetch Steam summaries while syncing avatars` | warn | info |
| `slot occupied` / `player not in the queue` / `invalid queue state` | warn | debug |
| Twitch `fetch failed` (EAI_AGAIN / timeout) | error | warn |
| Mumble `createChannel has timed out` | error | warn |
| `channel does not exist` | error | warn (now via `safe()` → 4xx) |
| Steam OpenID `Invalid or replayed nonce` | error | debug |
| ETF2L account required/not found, insufficient TF2 hours | warn | info |

## Testing

- `pnpm lint` ✅
- `pnpm test` ✅ (342 passing, incl. new `log-error.test.ts`)
- `tsc -p tsconfig.build.json` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)