### PR TITLE
perf(queue): debounce online player list broadcasts

### DIFF
--- a/src/queue-auto/plugins/sync-clients.ts
+++ b/src/queue-auto/plugins/sync-clients.ts
@@ -98,9 +98,6 @@ export default fp(
       await syncQueuePage(socket)
     })
 
-    // Connect/disconnect events can arrive in bursts (deploys, reconnect storms,
-    // a game ending). Debounce so a burst collapses into a single re-render and
-    // broadcast instead of one full list render + broadcast per event.
     const updateOnlinePlayers = debounce(
       safe(async () => {
         const [opl, opc] = await Promise.all([OnlinePlayerList(), OnlinePlayerCount()])

--- a/src/queue-auto/plugins/sync-clients.ts
+++ b/src/queue-auto/plugins/sync-clients.ts
@@ -1,4 +1,5 @@
 import fp from 'fastify-plugin'
+import { debounce } from 'es-toolkit'
 import { events } from '../../events'
 import { OnlinePlayerList } from '../views/html/online-player-list'
 import { safe } from '../../utils/safe'
@@ -97,14 +98,19 @@ export default fp(
       await syncQueuePage(socket)
     })
 
-    async function updateOnlinePlayers() {
-      const opl = await OnlinePlayerList()
-      const opc = await OnlinePlayerCount()
-      app.gateway.to({ url: '/' }).send(() => [opl, opc])
-    }
+    // Connect/disconnect events can arrive in bursts (deploys, reconnect storms,
+    // a game ending). Debounce so a burst collapses into a single re-render and
+    // broadcast instead of one full list render + broadcast per event.
+    const updateOnlinePlayers = debounce(
+      safe(async () => {
+        const [opl, opc] = await Promise.all([OnlinePlayerList(), OnlinePlayerCount()])
+        app.gateway.to({ url: '/' }).send(() => [opl, opc])
+      }),
+      300,
+    )
 
-    events.on('player:connected', safe(updateOnlinePlayers))
-    events.on('player:disconnected', safe(updateOnlinePlayers))
+    events.on('player:connected', updateOnlinePlayers)
+    events.on('player:disconnected', updateOnlinePlayers)
 
     events.on(
       'player/activeGame:updated',


### PR DESCRIPTION
## What

The online player list is server-pushed over WebSocket: every `player:connected` / `player:disconnected` event ran a full `OnlinePlayerList()` re-render (two DB queries — online players + admin lookup), a `OnlinePlayerCount()` render, and a broadcast to **every** client on `/`.

During reconnect storms (deploys, server restarts, a game ending and sockets cycling), that's N full-list renders + N broadcasts-to-all for N events — a thundering herd.

## Change

- **Debounce** `updateOnlinePlayers` (300ms trailing) so a burst of connect/disconnect events collapses into a single render + broadcast.
- **Parallelize** the `OnlinePlayerList()` / `OnlinePlayerCount()` renders with `Promise.all` (they were sequential).
- Uses es-toolkit's `debounce` + the existing `safe()` wrapper, matching the pattern already used in sibling plugins (`send-join-prompts.ts`, `auto-cleanup-friendships.ts`).

## Trade-off

A new arrival/departure shows up after up to ~300ms of quiet — imperceptible for a presence list.

## Testing

- `pnpm lint` passes
- `pnpm test` (src) green, including `sync-clients.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)