### PR TITLE
perf(players): speed up player page LCP and dedupe profile query

### DIFF
--- a/src/html/layout.tsx
+++ b/src/html/layout.tsx
@@ -62,6 +62,7 @@ export async function Layout(
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="htmx-config" content='{"historyCacheSize":"0","globalViewTransitions":true}' />
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+        <link rel="preconnect" href="https://avatars.steamstatic.com" />
         <link
           rel="preload"
           href="/fonts/Satoshi-Variable.woff2"

--- a/src/players/views/html/player.page.tsx
+++ b/src/players/views/html/player.page.tsx
@@ -24,29 +24,31 @@ import { makeTitle } from '../../../html/make-title'
 import { environment } from '../../../environment'
 import { AdminToolbox } from './admin-toolbox'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
-import { players } from '../..'
 import type { PickDeep } from 'type-fest'
 import type { GameModel } from '../../../database/models/game.model'
 import { requestContext } from '@fastify/request-context'
 
 const gamesPerPage = 5
 
-export async function PlayerPage(props: { steamId: SteamId64; page: number }) {
-  const player = await players.bySteamId(props.steamId, [
-    'steamId',
-    'name',
-    'joinedAt',
-    'roles',
-    'etf2lProfile',
-    'twitchTvProfile',
-    'avatar.large',
-    'stats',
-    'skill',
-    'skillHistory',
-    'verified',
-    'bans',
-    'elo',
-  ])
+export type PlayerPageData = PickDeep<
+  PlayerModel,
+  | 'steamId'
+  | 'name'
+  | 'joinedAt'
+  | 'roles'
+  | 'etf2lProfile'
+  | 'twitchTvProfile'
+  | 'avatar.large'
+  | 'stats'
+  | 'skill'
+  | 'skillHistory'
+  | 'verified'
+  | 'bans'
+  | 'elo'
+>
+
+export async function PlayerPage(props: { player: PlayerPageData; page: number }) {
+  const { player } = props
   const user = requestContext.get('user')
 
   return (
@@ -157,6 +159,7 @@ function PlayerPresentation(props: {
         height="184"
         class="player-avatar"
         alt={`${props.player.name}'s avatar`}
+        fetchpriority="high"
       />
 
       <div class="flex flex-row items-center gap-[10px]">

--- a/src/routes/players/:steamId/index.tsx
+++ b/src/routes/players/:steamId/index.tsx
@@ -24,18 +24,34 @@ export default routes(async app => {
       },
       async (req, reply) => {
         const { steamId } = req.params
-        const player = await players.bySteamId(steamId, ['etf2lProfileLastSyncedAt'])
+        const page = Number(req.query.gamespage) || 1
+
+        const player = await players.bySteamId(steamId, [
+          'steamId',
+          'name',
+          'joinedAt',
+          'roles',
+          'etf2lProfile',
+          'twitchTvProfile',
+          'avatar.large',
+          'stats',
+          'skill',
+          'skillHistory',
+          'verified',
+          'bans',
+          'elo',
+          'etf2lProfileLastSyncedAt',
+        ])
 
         if (shouldSyncEtf2lProfile(player)) {
           await tasks.schedule('etf2l:syncPlayerProfile', 0, { player: steamId })
         }
 
-        const page = Number(req.query.gamespage) || 1
         await reply.html(
           req.isPartialFor('gameList') ? (
             <PlayerGameList steamId={steamId} page={page} />
           ) : (
-            <PlayerPage steamId={steamId} page={page} />
+            <PlayerPage player={player} page={page} />
           ),
         )
       },


### PR DESCRIPTION
Real-user metrics (umami) show player pages with 7–8 s LCP while the server renders them in <300 ms (OTel `responseTime` p99 = 283 ms). The bottleneck isn't rendering — the LCP element is the player avatar, loaded from Steam's CDN (`avatars.steamstatic.com`), a third host the browser must do a fresh DNS+TCP+TLS to with no resource hints.

- **Preconnect to the Steam avatar CDN** in the page `<head>` so the handshake starts during HTML parse instead of after the `<img>` is discovered. Also helps queue avatars on the home page.
- **`fetchpriority="high"` on the avatar** since it's the LCP element.
- **Fetch the player once per page load** instead of twice (the route did a `bySteamId` for the ETF2L sync check and `PlayerPage` did another for rendering).