### PR TITLE
fix(games): prevent htmx from swallowing the join voice link

### DIFF
--- a/src/games/views/html/join-voice-button.tsx
+++ b/src/games/views/html/join-voice-button.tsx
@@ -35,6 +35,7 @@ async function JoinVoiceButtonContent(props: {
     <a
       href={slot.voiceServerUrl}
       class="button"
+      hx-boost="false"
       data-umami-event="join-voice"
       data-umami-event-game-number={props.game.number}
       data-umami-event-game-state={props.game.state}


### PR DESCRIPTION
## Why

The "join voice" button worked on tf2pickup.pl but did nothing on tf2pickup.eu, logging only `htmx:invalidPath` in the console.

The body sets `hx-boost="true"`, so htmx intercepts anchor clicks whenever the link's hostname matches the site's (`isLocalLink`). On tf2pickup.eu the Mumble server shares the website hostname, so the `mumble://…` link qualified as a local link and got boosted. htmx then tried to AJAX-fetch it, but a `mumble:` URL has an opaque (`null`) origin, so `selfRequestsOnly` (htmx's default) aborted with `htmx:invalidPath` and the browser never handed the link to the Mumble client. On tf2pickup.pl the Mumble host is a different subdomain, so htmx ignored the link and it worked.

## Fix

Add `hx-boost="false"` to the voice link so htmx never intercepts it — consistent with how other special/external links (`/auth/steam`, etc.) are handled, and config-agnostic across instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)