### PR TITLE
feat(atlas): report 30-day active players

### DIFF
--- a/src/atlas/plugins/heartbeat.ts
+++ b/src/atlas/plugins/heartbeat.ts
@@ -6,6 +6,7 @@ import { events } from '../../events'
 import { safe } from '../../utils/safe'
 import { sendHeartbeat } from '../send-heartbeat'
 import { sendActivity } from '../send-activity'
+import { sendActivePlayers } from '../send-active-players'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -28,6 +29,10 @@ export default fp(
       minutesToMilliseconds(3),
     ).unref()
     safe(() => sendActivity())()
+
+    // report the 30-day active player set on boot, then refresh periodically
+    setInterval(safe(sendActivePlayers), minutesToMilliseconds(15)).unref()
+    safe(sendActivePlayers)()
   },
   { name: 'atlas heartbeat' },
 )

--- a/src/atlas/send-active-players.test.ts
+++ b/src/atlas/send-active-players.test.ts
@@ -1,0 +1,109 @@
+import { createHash } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sendActivePlayers } from './send-active-players'
+import { environment } from '../environment'
+import { getActivePlayers } from '../statistics/get-active-players'
+import { logger } from '../logger'
+import type { SteamId64 } from '../shared/types/steam-id-64'
+
+vi.mock('../environment', () => ({
+  environment: {
+    ATLAS_URL: 'https://atlas.tf2pickup.org',
+    ATLAS_SECRET: 'supersecret',
+    WEBSITE_URL: 'https://tf2pickup.pl',
+  },
+}))
+
+vi.mock('../logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('../statistics/get-active-players', () => ({
+  getActivePlayers: vi.fn(),
+}))
+
+const fetchMock = vi.fn()
+
+const sha256 = (value: string) => createHash('sha256').update(value).digest('hex')
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockResolvedValue({ ok: true, status: 204 })
+  vi.mocked(getActivePlayers).mockResolvedValue([
+    { steamId: '76561197960287930' as SteamId64, lastActiveAt: new Date('2026-06-21T10:00:00Z') },
+    { steamId: '76561197960287931' as SteamId64, lastActiveAt: new Date('2026-06-29T18:42:00Z') },
+  ])
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('when ATLAS_SECRET is not set', () => {
+  beforeEach(() => {
+    environment.ATLAS_SECRET = undefined
+  })
+
+  afterEach(() => {
+    environment.ATLAS_SECRET = 'supersecret'
+  })
+
+  it('should not send anything', async () => {
+    await sendActivePlayers()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('when ATLAS_SECRET is set', () => {
+  it('should report the players as hashed ids with their last-active time', async () => {
+    await sendActivePlayers()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url.toString()).toBe('https://atlas.tf2pickup.org/api/active-players')
+    expect(init.method).toBe('PUT')
+    expect(init.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer supersecret',
+    })
+    expect(JSON.parse(init.body)).toEqual({
+      url: 'https://tf2pickup.pl',
+      players: [
+        { id: sha256('76561197960287930'), lastActiveAt: '2026-06-21T10:00:00.000Z' },
+        { id: sha256('76561197960287931'), lastActiveAt: '2026-06-29T18:42:00.000Z' },
+      ],
+    })
+  })
+
+  it('should request players active within the last 30 days', async () => {
+    const now = new Date('2026-06-30T00:00:00Z')
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+
+    await sendActivePlayers()
+
+    expect(getActivePlayers).toHaveBeenCalledWith(new Date('2026-05-31T00:00:00Z'))
+    vi.useRealTimers()
+  })
+
+  it('should not send anything when there are no active players', async () => {
+    vi.mocked(getActivePlayers).mockResolvedValue([])
+    await sendActivePlayers()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  describe('and the request is rejected', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValue({ ok: false, status: 403 })
+    })
+
+    it('should log a warning and not throw', async () => {
+      await expect(sendActivePlayers()).resolves.toBeUndefined()
+      expect(logger.warn).toHaveBeenCalledWith({ status: 403 }, 'atlas active players rejected')
+    })
+  })
+})

--- a/src/atlas/send-active-players.ts
+++ b/src/atlas/send-active-players.ts
@@ -1,0 +1,55 @@
+import { createHash } from 'node:crypto'
+import { secondsToMilliseconds, subDays } from 'date-fns'
+import { environment } from '../environment'
+import { logger } from '../logger'
+import { getActivePlayers } from '../statistics/get-active-players'
+import type { SteamId64 } from '../shared/types/steam-id-64'
+
+const activeWindowDays = 30
+
+/**
+ * Hashes a steam id into the stable, instance-independent player id atlas uses
+ * to deduplicate active players across instances. The scheme must match every
+ * other instance (plain SHA-256, no per-instance salt), otherwise the same
+ * player would be counted more than once.
+ */
+function toPlayerId(steamId: SteamId64): string {
+  return createHash('sha256').update(steamId).digest('hex')
+}
+
+/**
+ * Reports the players active on this instance in the last 30 days to atlas, so
+ * it can show the number of distinct players across all pickups. The full set
+ * is sent every time; atlas keeps the most recent activity per player, so
+ * re-sending is idempotent.
+ */
+export async function sendActivePlayers() {
+  if (!environment.ATLAS_SECRET) {
+    return
+  }
+
+  const players = await getActivePlayers(subDays(new Date(), activeWindowDays))
+  if (players.length === 0) {
+    return
+  }
+
+  const response = await fetch(new URL('/api/active-players', environment.ATLAS_URL), {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${environment.ATLAS_SECRET}`,
+    },
+    body: JSON.stringify({
+      url: environment.WEBSITE_URL,
+      players: players.map(({ steamId, lastActiveAt }) => ({
+        id: toPlayerId(steamId),
+        lastActiveAt: lastActiveAt.toISOString(),
+      })),
+    }),
+    signal: AbortSignal.timeout(secondsToMilliseconds(30)),
+  })
+
+  if (!response.ok) {
+    logger.warn({ status: response.status }, 'atlas active players rejected')
+  }
+}

--- a/src/statistics/get-active-players.ts
+++ b/src/statistics/get-active-players.ts
@@ -1,0 +1,35 @@
+import { collections } from '../database/collections'
+import { deletedUserSteamId, type SteamId64 } from '../shared/types/steam-id-64'
+
+export interface ActivePlayer {
+  steamId: SteamId64
+  /** the most recent game this player was in (its creation time) */
+  lastActiveAt: Date
+}
+
+/**
+ * Distinct players that took part in a game on or after `since`, along with the
+ * time of their most recent game. Deleted players are excluded.
+ */
+export async function getActivePlayers(since: Date): Promise<ActivePlayer[]> {
+  return await collections.games
+    .aggregate<ActivePlayer>([
+      { $match: { 'events.0.at': { $gte: since } } },
+      { $unwind: '$slots' },
+      { $match: { 'slots.player': { $ne: deletedUserSteamId } } },
+      {
+        $group: {
+          _id: '$slots.player',
+          lastActiveAt: { $max: { $arrayElemAt: ['$events.at', 0] } },
+        },
+      },
+      {
+        $project: {
+          steamId: '$_id',
+          lastActiveAt: 1,
+          _id: 0,
+        },
+      },
+    ])
+    .toArray()
+}


### PR DESCRIPTION
## What

Reports the players active on this instance in the last 30 days to atlas, so the [atlas dashboard](https://github.com/tf2pickup-org/atlas/pull/3) can show the number of distinct active players across all pickups.

## How

- **`getActivePlayers(since)`** (`src/statistics/get-active-players.ts`) — aggregates games created since `since`, unwinds slots, and returns each distinct (non-deleted) player with the time of their most recent game.
- **`sendActivePlayers()`** (`src/atlas/send-active-players.ts`) — `PUT`s the set to `/api/active-players`. Each player is sent as a **SHA-256 hash of their steam id** (via the same `createHash('sha256')...digest('hex')` used for the telemetry instance id) plus `lastActiveAt`.
- Wired into the existing atlas heartbeat plugin: sent on boot, then refreshed every 15 minutes.

## Why the hash (and no salt)

Atlas deduplicates players by this id, so the same player active on two pickups is counted **once**. For that to work, every instance must hash steam ids **identically** — plain SHA-256, no per-instance salt. The hash also means atlas never receives raw steam ids, only opaque ids it counts.

## Companion PR

Requires the atlas side: tf2pickup-org/atlas#3 (adds the `/api/active-players` endpoint).

## Checks

- `send-active-players` unit tests pass (5 tests), mirroring `send-activity.test.ts`
- `tsc -p tsconfig.build.json` clean; eslint + prettier clean on changed files
- (The statistics aggregation has no unit test, matching the other `get-*` statistics helpers, which aren't unit-tested either)

🤖 Generated with [Claude Code](https://claude.com/claude-code)