### PR TITLE
fix(queue): warn Chrome users when the browser blocks the ready-up sound

### DIFF
--- a/src/html/@client/main.ts
+++ b/src/html/@client/main.ts
@@ -24,6 +24,7 @@ import './details-persist'
 import './ready-up-dialog'
 import './remove-closest'
 import './skill-input'
+import './sound-blocked-alert'
 import './tabs'
 import './toggle-disabled'
 

--- a/src/html/@client/sound-blocked-alert.ts
+++ b/src/html/@client/sound-blocked-alert.ts
@@ -19,8 +19,17 @@ let showTimer: number | undefined
 // before the context reports it is running.
 const showDelay = 500
 
+function hasBeenActivated() {
+  // navigator.userActivation is unavailable in some browsers (e.g. Safari)
+  const activation = navigator.userActivation as UserActivation | undefined
+  return activation?.hasBeenActive ?? false
+}
+
 function isAudioBlocked() {
-  return Howler.ctx.state === 'suspended'
+  // A suspended context is only truly blocked when the user has never interacted.
+  // Howler's idle autoSuspend also suspends it for players who already have, and
+  // resume() succeeds for them, so those must not count as blocked.
+  return Howler.ctx.state === 'suspended' && !hasBeenActivated()
 }
 
 function isInQueue() {

--- a/src/html/@client/sound-blocked-alert.ts
+++ b/src/html/@client/sound-blocked-alert.ts
@@ -1,0 +1,56 @@
+import htmx from './htmx'
+import { Howler } from 'howler'
+import { onLoadWithAttr } from './on-load-with-attr'
+
+const attrName = 'data-sound-blocked-alert'
+
+interface SocketWrapper {
+  send: (message: string) => void
+}
+
+let socket: SocketWrapper | undefined
+let banner: HTMLElement | undefined
+let lastReported: boolean | undefined
+let ctxListenerAttached = false
+
+function isAudioBlocked() {
+  return Howler.ctx.state === 'suspended'
+}
+
+function reportAudioStatus() {
+  if (!socket) return
+  const audioReady = !isAudioBlocked()
+  if (audioReady === lastReported) return
+  lastReported = audioReady
+  socket.send(JSON.stringify({ audioReady }))
+}
+
+function update() {
+  if (banner) {
+    banner.style.display = isAudioBlocked() ? '' : 'none'
+  }
+  reportAudioStatus()
+}
+
+function ensureCtxListener() {
+  if (ctxListenerAttached) return
+  Howler.ctx.addEventListener('statechange', update)
+  ctxListenerAttached = true
+}
+
+function init(element: HTMLElement) {
+  banner = element
+  element.querySelector('button')?.addEventListener('click', () => {
+    void Howler.ctx.resume()
+  })
+  ensureCtxListener()
+  update()
+}
+
+htmx.on('htmx:wsOpen', event => {
+  socket = (event as CustomEvent<{ socketWrapper: SocketWrapper }>).detail.socketWrapper
+  lastReported = undefined
+  reportAudioStatus()
+})
+
+onLoadWithAttr(attrName, init)

--- a/src/html/@client/sound-blocked-alert.ts
+++ b/src/html/@client/sound-blocked-alert.ts
@@ -56,23 +56,33 @@ function shouldShow() {
   return isAudioBlocked() && isInQueue() && !notificationBannerVisible()
 }
 
-function update() {
-  if (banner) {
-    if (shouldShow()) {
-      if (showTimer === undefined && banner.style.display === 'none') {
-        showTimer = window.setTimeout(() => {
-          showTimer = undefined
-          if (banner && shouldShow()) banner.style.display = ''
-        }, showDelay)
-      }
-    } else {
-      if (showTimer !== undefined) {
-        clearTimeout(showTimer)
-        showTimer = undefined
-      }
-      banner.style.display = 'none'
-    }
+function cancelScheduledShow() {
+  if (showTimer === undefined) return
+  clearTimeout(showTimer)
+  showTimer = undefined
+}
+
+function scheduleShow() {
+  // nothing to do if it's already visible or a show is already pending
+  if (banner?.style.display !== 'none' || showTimer !== undefined) return
+  showTimer = window.setTimeout(() => {
+    showTimer = undefined
+    if (banner && shouldShow()) banner.style.display = ''
+  }, showDelay)
+}
+
+function syncBanner() {
+  if (!banner) return
+  if (shouldShow()) {
+    scheduleShow()
+  } else {
+    cancelScheduledShow()
+    banner.style.display = 'none'
   }
+}
+
+function update() {
+  syncBanner()
   reportAudioStatus()
 }
 

--- a/src/html/@client/sound-blocked-alert.ts
+++ b/src/html/@client/sound-blocked-alert.ts
@@ -17,6 +17,10 @@ function isAudioBlocked() {
   return Howler.ctx.state === 'suspended'
 }
 
+function isInQueue() {
+  return document.querySelector<HTMLInputElement>('#isInQueue')?.value === 'true'
+}
+
 function reportAudioStatus() {
   if (!socket) return
   const audioReady = !isAudioBlocked()
@@ -27,7 +31,7 @@ function reportAudioStatus() {
 
 function update() {
   if (banner) {
-    banner.style.display = isAudioBlocked() ? '' : 'none'
+    banner.style.display = isAudioBlocked() && isInQueue() ? '' : 'none'
   }
   reportAudioStatus()
 }
@@ -52,5 +56,8 @@ htmx.on('htmx:wsOpen', event => {
   lastReported = undefined
   reportAudioStatus()
 })
+
+// queue membership is swapped into #isInQueue over the websocket
+htmx.on('htmx:wsAfterMessage', update)
 
 onLoadWithAttr(attrName, init)

--- a/src/html/@client/sound-blocked-alert.ts
+++ b/src/html/@client/sound-blocked-alert.ts
@@ -44,8 +44,16 @@ function reportAudioStatus() {
   socket.send(JSON.stringify({ audioReady }))
 }
 
+function notificationBannerVisible() {
+  // the notification-permission banners cover the same "you'll miss the game" concern,
+  // and their call to action already unlocks audio, so don't stack a second banner
+  return ['notifications-permission-default', 'notifications-permission-denied'].some(
+    id => document.getElementById(id)?.style.display === 'block',
+  )
+}
+
 function shouldShow() {
-  return isAudioBlocked() && isInQueue()
+  return isAudioBlocked() && isInQueue() && !notificationBannerVisible()
 }
 
 function update() {

--- a/src/html/@client/sound-blocked-alert.ts
+++ b/src/html/@client/sound-blocked-alert.ts
@@ -12,6 +12,12 @@ let socket: SocketWrapper | undefined
 let banner: HTMLElement | undefined
 let lastReported: boolean | undefined
 let ctxListenerAttached = false
+let showTimer: number | undefined
+
+// Delay showing the banner so that joining a queue — which is itself the user
+// gesture that resumes the audio context — doesn't flash it for a split second
+// before the context reports it is running.
+const showDelay = 500
 
 function isAudioBlocked() {
   return Howler.ctx.state === 'suspended'
@@ -29,9 +35,26 @@ function reportAudioStatus() {
   socket.send(JSON.stringify({ audioReady }))
 }
 
+function shouldShow() {
+  return isAudioBlocked() && isInQueue()
+}
+
 function update() {
   if (banner) {
-    banner.style.display = isAudioBlocked() && isInQueue() ? '' : 'none'
+    if (shouldShow()) {
+      if (showTimer === undefined && banner.style.display === 'none') {
+        showTimer = window.setTimeout(() => {
+          showTimer = undefined
+          if (banner && shouldShow()) banner.style.display = ''
+        }, showDelay)
+      }
+    } else {
+      if (showTimer !== undefined) {
+        clearTimeout(showTimer)
+        showTimer = undefined
+      }
+      banner.style.display = 'none'
+    }
   }
   reportAudioStatus()
 }

--- a/src/queue-auto/plugins/track-audio-blocked-players.ts
+++ b/src/queue-auto/plugins/track-audio-blocked-players.ts
@@ -16,9 +16,10 @@ export default fp(
       valueType: ValueType.INT,
     })
     gauge.addCallback(result => {
-      const blocked = [...app.websocketServer.clients].filter(
-        client => (client as AppWebSocket).audioReady === false,
-      ).length
+      const blocked = [...app.websocketServer.clients].filter(client => {
+        const socket = client as AppWebSocket
+        return !!socket.player && socket.audioReady === false
+      }).length
       result.observe(blocked)
     })
   },

--- a/src/queue-auto/plugins/track-audio-blocked-players.ts
+++ b/src/queue-auto/plugins/track-audio-blocked-players.ts
@@ -1,0 +1,26 @@
+import fp from 'fastify-plugin'
+import { ValueType } from '@opentelemetry/api'
+import { meter } from '../../otel'
+import type { AppWebSocket } from '../../websocket/types'
+
+export default fp(
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async app => {
+    app.gateway.on('queue:audiostatus', (socket, audioReady) => {
+      socket.audioReady = audioReady
+    })
+
+    const gauge = meter.createObservableGauge('tf2pickup.audio_blocked_players.count', {
+      description: 'Number of connected players whose browser is blocking the ready-up sound',
+      unit: '1',
+      valueType: ValueType.INT,
+    })
+    gauge.addCallback(result => {
+      const blocked = [...app.websocketServer.clients].filter(
+        client => (client as AppWebSocket).audioReady === false,
+      ).length
+      result.observe(blocked)
+    })
+  },
+  { name: 'track audio blocked players' },
+)

--- a/src/queue-auto/plugins/track-audio-blocked-players.ts
+++ b/src/queue-auto/plugins/track-audio-blocked-players.ts
@@ -2,6 +2,10 @@ import fp from 'fastify-plugin'
 import { ValueType } from '@opentelemetry/api'
 import { meter } from '../../otel'
 import type { AppWebSocket } from '../../websocket/types'
+import { events } from '../../events'
+import { collections } from '../../database/collections'
+import { QueueState } from '../../database/models/queue-state.model'
+import { safe } from '../../utils/safe'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -22,6 +26,38 @@ export default fp(
       }).length
       result.observe(blocked)
     })
+
+    // Records each ready-up prompt as it is dispatched, split by whether the player's
+    // browser could play the sound. Missed prompts are the ones tagged audioBlocked=true.
+    const readyUpNotifications = meter.createCounter('tf2pickup.ready_up.notified.count', {
+      description: 'Ready-up prompts delivered to players, split by whether the sound could play',
+      unit: '1',
+      valueType: ValueType.INT,
+    })
+    events.on(
+      'queue/state:updated',
+      safe(async ({ state }) => {
+        if (state !== QueueState.ready) {
+          return
+        }
+
+        const recipients = (
+          await collections.queueSlots
+            .find({ player: { $ne: null }, ready: { $eq: false } })
+            .toArray()
+        ).map(slot => slot.player!.steamId)
+        const clients = [...app.websocketServer.clients].map(client => client as AppWebSocket)
+
+        for (const steamId of recipients) {
+          const sockets = clients.filter(client => client.player?.steamId === steamId)
+          if (sockets.length === 0) {
+            continue
+          }
+          const audioBlocked = sockets.every(socket => socket.audioReady === false)
+          readyUpNotifications.add(1, { audioBlocked })
+        }
+      }),
+    )
   },
   { name: 'track audio blocked players' },
 )

--- a/src/queue-auto/views/html/queue.page.tsx
+++ b/src/queue-auto/views/html/queue.page.tsx
@@ -11,6 +11,7 @@ import { environment } from '../../../environment'
 import { RunningGameSnackbar } from './running-game-snackbar'
 import { MapVote } from './map-vote'
 import { OfflineAlert } from './offline-alert'
+import { SoundBlockedAlert } from './sound-blocked-alert'
 import { Footer } from '../../../html/components/footer'
 import type { QueueSlotModel } from '../../../database/models/queue-slot.model'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
@@ -51,6 +52,7 @@ export async function QueuePage() {
           <div class="order-1 grid grid-cols-1 gap-y-2 lg:col-span-4">
             <OfflineAlert />
             {!!user && <RequestNotificationPermissions />}
+            {!!user && <SoundBlockedAlert />}
             <BanAlerts actor={user?.player.steamId} />
             <SubstitutionRequests />
             <Announcements />

--- a/src/queue-auto/views/html/sound-blocked-alert.tsx
+++ b/src/queue-auto/views/html/sound-blocked-alert.tsx
@@ -1,0 +1,19 @@
+export function SoundBlockedAlert() {
+  return (
+    <div style="display: none;" data-sound-blocked-alert>
+      <div class="banner flex flex-col gap-y-2 md:flex-row" data-tone="alert" role="alert">
+        <p class="flex-1 text-center md:text-start">
+          Your browser is blocking the ready-up sound. Click to enable it so you don't miss a game.
+        </p>
+        <button
+          class="button"
+          data-size="dense"
+          data-variant="alert"
+          data-umami-event="enable-sound"
+        >
+          Enable sound
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/websocket/gateway.ts
+++ b/src/websocket/gateway.ts
@@ -20,6 +20,7 @@ export interface ClientToServerEvents {
   'queue:readyup': () => void
   'queue:markasfriend': (steamId: SteamId64 | null) => void
   'queue:togglepreready': () => void
+  'queue:audiostatus': (audioReady: boolean) => void
 }
 
 type GatewayEvents = ClientToServerEvents
@@ -68,6 +69,11 @@ const navigated = z.object({
   HEADERS: htmxHeaders.optional(),
 })
 
+const audioStatus = z.object({
+  audioReady: z.boolean(),
+  HEADERS: htmxHeaders.optional(),
+})
+
 const clientMessage = z.union([
   joinQueue,
   leaveQueue,
@@ -76,6 +82,7 @@ const clientMessage = z.union([
   markAsFriend,
   preReadyToggle,
   navigated,
+  audioStatus,
 ])
 
 type MessageFn = (
@@ -274,6 +281,8 @@ export class Gateway extends EventEmitter implements Broadcaster {
         this.emit('queue:markasfriend', socket, parsed.markasfriend)
       } else if ('prereadytoggle' in parsed) {
         this.emit('queue:togglepreready', socket)
+      } else if ('audioReady' in parsed) {
+        this.emit('queue:audiostatus', socket, parsed.audioReady)
       }
     } catch (error) {
       logger.error({ error }, `failed to parse message: ${message}`)

--- a/src/websocket/types.ts
+++ b/src/websocket/types.ts
@@ -5,6 +5,7 @@ export type AppWebSocket = WebSocket & {
   id: string
   isAlive: boolean
   currentUrl?: string
+  audioReady?: boolean
   player?: {
     steamId: SteamId64
   }


### PR DESCRIPTION
Some players (mostly on Chrome) reported not hearing the ready-up notification sound.

**Why it happens:** the sound plays through the Web Audio API (Howler). Chromium/WebKit suspend the `AudioContext` until the page receives a user gesture. A player can join a slot, close the tab, open a fresh tab on the queue, and stay online via the websocket (no gesture needed) — but the new document has had no interaction, so the context stays suspended and `play()` is silent. Firefox doesn't block Web Audio by default, which is why reports skew Chromium/Safari.

**This PR:**
- Adds a "sound blocked" banner on the queue page shown only when `Howler.ctx.state === 'suspended'`, prompting the player to enable sound. Any interaction (Howler auto-unlock) resumes the context and hides the banner.
- Reports audio-readiness to the server over the existing websocket and exposes an OTel gauge `tf2pickup.audio_blocked_players.count` so we can see how many connected players are actually affected.