### PR TITLE
fix: harden against recon/injection activity from security review

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,14 @@ import { ErrorPage } from './error-pages/views/html/error.page'
 import { secondsInWeek } from 'date-fns/constants'
 import autoload from '@fastify/autoload'
 
-const app = fastify({ loggerInstance, trustProxy: environment.TRUST_PROXY })
+const app = fastify({
+  loggerInstance,
+  trustProxy: environment.TRUST_PROXY,
+  // Bind the client IP into the per-request child logger so every request-scoped
+  // log line (notably fastify's "request completed") is attributable to an IP.
+  childLoggerFactory: (parent, bindings, childLoggerOpts, rawReq) =>
+    parent.child({ ...bindings, 'req.clientIp': realIp(rawReq) }, childLoggerOpts),
+})
 
 app.setSerializerCompiler(serializerCompiler)
 app.setValidatorCompiler(validatorCompiler)

--- a/src/mumble/client.ts
+++ b/src/mumble/client.ts
@@ -72,8 +72,12 @@ export async function tryConnect() {
       attempt += 1
 
       if (attempt > maxReconnectAttempts) {
-        logger.error(error, 'mumble socket error')
-        reportError(error)
+        if (attempt === maxReconnectAttempts + 1) {
+          logger.error(error, 'mumble socket error')
+          reportError(error)
+        } else {
+          logger.debug(error, 'mumble socket error')
+        }
         reconnecting = false
         return
       }

--- a/src/routes/games/index.test.ts
+++ b/src/routes/games/index.test.ts
@@ -1,0 +1,57 @@
+import fastify from 'fastify'
+import { validatorCompiler } from 'fastify-type-provider-zod'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { GameList, GameListPage } from '../../games/views/html/game-list.page'
+import gamesRoutes from './index'
+
+vi.mock('../../games/views/html/game-list.page', () => ({
+  GameList: vi.fn().mockReturnValue('<div>game list</div>'),
+  GameListPage: vi.fn().mockReturnValue('<html>game list page</html>'),
+}))
+
+describe('GET /games', () => {
+  const app = fastify()
+
+  beforeAll(async () => {
+    app.setValidatorCompiler(validatorCompiler)
+    await app.register((await import('@kitajs/fastify-html-plugin')).default)
+    app.decorateRequest('isPartialFor', () => false)
+    await app.register(gamesRoutes)
+    await app.ready()
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  beforeEach(() => {
+    vi.mocked(GameList).mockClear()
+    vi.mocked(GameListPage).mockClear()
+  })
+
+  it('renders the game list for a numeric page', async () => {
+    const response = await app.inject({ method: 'GET', url: '/', query: { page: '2' } })
+    expect(response.statusCode).toBe(200)
+    expect(GameListPage).toHaveBeenCalledWith({ page: 2 })
+  })
+
+  it.each(['1 UNION SELECT NULL--', "1' AND (SELECT 1 FROM pg_sleep(5))--", '../../../etc/passwd'])(
+    'rejects injection-style page=%s without rendering',
+    async page => {
+      const response = await app.inject({ method: 'GET', url: '/', query: { page } })
+      expect(response.statusCode).toBe(400)
+      expect(GameListPage).not.toHaveBeenCalled()
+      expect(GameList).not.toHaveBeenCalled()
+    },
+  )
+
+  it('strips unknown params such as goto instead of passing them on', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/',
+      query: { goto: '1 UNION SELECT username, password FROM users--' },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(GameListPage).toHaveBeenCalledWith({ page: 1 })
+  })
+})

--- a/src/utils/real-ip.ts
+++ b/src/utils/real-ip.ts
@@ -1,7 +1,8 @@
-import type { FastifyRequest } from 'fastify'
+import type { IncomingMessage } from 'node:http'
 
 // Replicates the behavior of @supercharge/request-ip (used by nestjs-real-ip's RealIP decorator).
 // Checks headers in priority order before falling back to the raw socket IP.
+// Accepts both FastifyRequest and the raw IncomingMessage (childLoggerFactory).
 const proxyHeaders = [
   'x-forwarded-for',
   'x-forwarded',
@@ -15,7 +16,7 @@ const proxyHeaders = [
   'x-cluster-client-ip',
 ] as const
 
-export function realIp(req: FastifyRequest): string {
+export function realIp(req: Pick<IncomingMessage, 'headers' | 'socket'> & { ip?: string }): string {
   for (const header of proxyHeaders) {
     const value = req.headers[header]
     if (typeof value === 'string' && value) {
@@ -24,5 +25,5 @@ export function realIp(req: FastifyRequest): string {
       if (first !== undefined) return first.trim()
     }
   }
-  return req.socket.remoteAddress ?? req.ip
+  return req.socket.remoteAddress ?? req.ip ?? ''
 }


### PR DESCRIPTION
Follow-ups from this week's telemetry security review (sqlmap campaign against `/games`, `.php`/`.env`/`wp-` scanning, `socket not writable` log-spew):

- **fix(mumble):** once reconnect attempts are exhausted, every 10s ping failure logged `mumble socket error` at ERROR and pinged Discord — ~3,600/wk on tf2pickup-fr (99.8% of all ERROR logs), drowning real incidents. The give-up is now logged once at ERROR; repeats go to debug. Non-socket mumble errors keep their level.
- **test(games):** regression test for the sqlmap campaign — injection-style `page` values must 400 without the view (and thus the DB layer) ever being invoked; unknown params like `goto` are stripped by the Zod schema.
- **feat(logs):** bind `req.clientIp` into the per-request child logger so fastify's `request completed` logs are attributable to an IP. This feeds the new SigNoz "Per-IP 404 flood" alert rule, which stays silent until this deploys.

Two SigNoz alert rules (injection/recon URL patterns per IP, per-IP 404 flood) were created alongside this PR; edge IP-blocking recommendations went to ops separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)