### PR TITLE
feat: add ultiduo queue config

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -35,7 +35,7 @@ STEAM_API_KEY=your_steam_api_key
 # Obtain yours here: https://logs.tf/uploader
 LOGS_TF_API_KEY=your_logs_tf_api_key
 
-# Which gamemode to run; possible values: 6v6, 9v9
+# Which gamemode to run; possible values: 6v6, 9v9, ultiduo
 QUEUE_CONFIG=6v6
 
 # A passphrase that is used to encrypt private keys that sign JWT tokens.

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -24,7 +24,7 @@ const environmentSchema = z.object({
   MONGODB_URI: z.url(),
   SUPER_USER: steamId64.optional(),
   STEAM_API_KEY: z.string(),
-  QUEUE_CONFIG: z.enum(['6v6', '9v9']).default('6v6'),
+  QUEUE_CONFIG: z.enum(['6v6', '9v9', 'ultiduo']).default('6v6'),
   KEY_STORE_PASSPHRASE: z.string(),
   LOG_RELAY_ADDRESS: z.string(),
   LOG_RELAY_PORT: z.coerce.number(),

--- a/src/games/views/html/game.page.tsx
+++ b/src/games/views/html/game.page.tsx
@@ -14,6 +14,7 @@ import { ChooseGameServerDialog } from './choose-game-server-dialog'
 import { AdminToolbox } from './admin-toolbox'
 import { findOne } from '../../find-one'
 import { requestContext } from '@fastify/request-context'
+import { environment } from '../../../environment'
 
 export async function GamePage(props: { number: GameNumber }) {
   const user = requestContext.get('user')
@@ -41,7 +42,7 @@ export async function GamePage(props: { number: GameNumber }) {
     >
       <NavigationBar />
       <Page>
-        <div class="game-page relative container mx-auto">
+        <div class={`game-page config-${environment.QUEUE_CONFIG} relative container mx-auto`}>
           <GameSummary game={game} actor={actor} />
           <GameSlotList game={game} actor={actor} />
           <GameEventList game={game} />

--- a/src/games/views/html/style.css
+++ b/src/games/views/html/style.css
@@ -31,6 +31,18 @@
       grid-template-columns: 2fr 3fr auto auto 3fr;
     }
 
+    &.config-ultiduo {
+      @media (width >= theme(--breakpoint-xl)) {
+        grid-template-areas:
+          'gameSummary scoreBlu     scoreBlu        scoreRed        scoreRed'
+          'gameSummary slotsBlu     gameClassIcons  gameClassIcons  slotsRed'
+          'gameSummary adminToolbox adminToolbox    adminToolbox    adminToolbox'
+          'gameSummary .            .               .               .'
+          'gameEvents  .            .               .               .';
+        grid-template-rows: auto auto auto 1fr auto;
+      }
+    }
+
     .score-header {
       display: grid;
       grid-column: 2 / span 2;
@@ -171,6 +183,36 @@
           'redMedic1'
           'redSniper1'
           'redSpy1';
+
+        @media (width >= theme(--breakpoint-lg)) {
+          border-radius: 0 0 8px 0;
+        }
+      }
+
+      &.config-ultiduo.team-blu {
+        grid-area: slotsBlu;
+        grid-template-areas:
+          'bluSoldier1'
+          'bluMedic1';
+
+        @media (width >= theme(--breakpoint-lg)) {
+          border-radius: 0 0 0 8px;
+
+          .slot {
+            flex-flow: row-reverse nowrap;
+
+            .player-link {
+              justify-content: flex-end;
+            }
+          }
+        }
+      }
+
+      &.config-ultiduo.team-red {
+        grid-area: slotsRed;
+        grid-template-areas:
+          'redSoldier1'
+          'redMedic1';
 
         @media (width >= theme(--breakpoint-lg)) {
           border-radius: 0 0 8px 0;

--- a/src/main.ts
+++ b/src/main.ts
@@ -163,7 +163,7 @@ await app.register(autoload, {
   dir: resolve(import.meta.dirname, 'routes'),
   dirNameRoutePrefix: true,
   scriptPattern: /(?:(?:^.?|\.[^d]|[^.]d|[^.][^d])\.ts|\.js|\.cjs|\.mjs|\.cts|\.mts|\.tsx?)$/,
-  matchFilter: path => !path.includes('/dto/'),
+  matchFilter: path => !path.includes('/dto/') && !path.includes('.test.'),
 })
 
 await app.listen({ host: environment.APP_HOST, port: environment.APP_PORT })

--- a/src/queue-auto/configs/index.ts
+++ b/src/queue-auto/configs/index.ts
@@ -1,9 +1,11 @@
 import { _6v6 } from './6v6'
 import { _9v9 } from './9v9'
+import { ultiduo } from './ultiduo'
 import type { QueueConfig } from '../../queue/types/queue-config'
 import { environment } from '../../environment'
 
 export const queueConfigs: Record<typeof environment.QUEUE_CONFIG, QueueConfig> = {
   '6v6': _6v6,
   '9v9': _9v9,
+  ultiduo,
 }

--- a/src/queue-auto/configs/ultiduo.ts
+++ b/src/queue-auto/configs/ultiduo.ts
@@ -1,0 +1,16 @@
+import { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import type { QueueConfig } from '../../queue/types/queue-config'
+
+export const ultiduo: QueueConfig = {
+  teamCount: 2,
+  classes: [
+    {
+      name: Tf2ClassName.soldier,
+      count: 1,
+    },
+    {
+      name: Tf2ClassName.medic,
+      count: 1,
+    },
+  ],
+}

--- a/src/queue-auto/views/html/queue.page.tsx
+++ b/src/queue-auto/views/html/queue.page.tsx
@@ -108,7 +108,12 @@ async function QueueState(props: { actor?: User | undefined; required: number })
 }
 
 async function Queue(props: { slots: QueueSlotModel[]; actor?: SteamId64 | undefined }) {
-  const gridCols = config.classes.length > 4 ? 'xl:grid-cols-3' : 'xl:grid-cols-4'
+  const gridCols =
+    config.classes.length > 4
+      ? 'xl:grid-cols-3'
+      : config.classes.length > 2
+        ? 'xl:grid-cols-4'
+        : 'xl:grid-cols-2'
   const actor = props.actor
     ? await players.bySteamId(props.actor, [
         'steamId',


### PR DESCRIPTION
Adds `ultiduo` as a third `QUEUE_CONFIG` option (2 teams, soldier + medic).

Most of the app already iterates `queue.config.classes` generically, so the config itself is small; the rest of the diff covers the places keyed on config name or class count:

- game page slot list CSS only had grid areas for 6v6/9v9 — without them the slots fall into implicit grid placement and the layout breaks
- with only 2 classes the queue page left half of its 4-column grid empty, so it now uses 2 columns; similarly the game page xl grid tied the slots column height to the game summary card, which looks broken with 2-slot teams — ultiduo gets its own grid with a filler row so slots size to content
- routes autoload didn't exclude `.test.` files (plugins/middleware filters do), so `pnpm dev` crashed since #728 added the first test file under `src/routes/`

Verified visually against a running instance (queue page, game page with an ultiduo game). Atlas accepts any string as queue config, so heartbeats are unaffected.

Known limitation, deliberately out of scope: the default map pool and whitelist are 6v6-centric (already the case for 9v9) — ultiduo instances must configure their own; a follow-up will address both.