### PR TITLE
feat: mark 1500 ELO as the balance target and open the ELO view to admins

### DIFF
--- a/src/players/views/html/@client/elo-history-chart.ts
+++ b/src/players/views/html/@client/elo-history-chart.ts
@@ -22,10 +22,38 @@ const colors: Record<string, string> = {
   spy: '#e91e63',
 }
 
+function targetEloLine(targetElo: number) {
+  return {
+    id: 'targetEloLine',
+    afterDatasetsDraw(chart: Chart) {
+      const yScale = chart.scales['y']
+      if (!yScale) return
+      const y = yScale.getPixelForValue(targetElo)
+      const { left, right } = chart.chartArea
+      const ctx = chart.ctx
+      ctx.save()
+      ctx.strokeStyle = 'rgba(255,255,255,0.4)'
+      ctx.setLineDash([6, 6])
+      ctx.lineWidth = 1
+      ctx.beginPath()
+      ctx.moveTo(left, y)
+      ctx.lineTo(right, y)
+      ctx.stroke()
+      ctx.setLineDash([])
+      ctx.fillStyle = 'rgba(255,255,255,0.65)'
+      ctx.font = '11px sans-serif'
+      ctx.textBaseline = 'bottom'
+      ctx.fillText(`${targetElo} target`, left + 4, y - 3)
+      ctx.restore()
+    },
+  }
+}
+
 function buildChartConfig(
   points: EloDataPoint[],
   gameClass: string,
   xMode: XAxisMode,
+  targetElo: number,
   skillPoints?: (number | null)[],
 ): ChartConfiguration<'line'> {
   const color = colors[gameClass] ?? '#F61059'
@@ -102,6 +130,8 @@ function buildChartConfig(
           grid: { color: 'rgba(217,217,217,0.15)' },
           ticks: { color: '#C7C4C7' },
           position: 'left',
+          suggestedMin: targetElo,
+          suggestedMax: targetElo,
         },
         ...(hasSkill
           ? {
@@ -122,7 +152,11 @@ function buildChartConfig(
   }
 }
 
-export function initEloHistoryChart(data: EloHistoryData, skillData?: SkillData) {
+export function initEloHistoryChart(
+  data: EloHistoryData,
+  skillData: SkillData | undefined,
+  targetElo: number,
+) {
   const canvas = document.getElementById('elo-history-canvas') as HTMLCanvasElement | null
   if (!canvas) return
 
@@ -148,7 +182,8 @@ export function initEloHistoryChart(data: EloHistoryData, skillData?: SkillData)
       return
     }
 
-    const config = buildChartConfig(points, activeClass, xMode, skillData?.[activeClass])
+    const config = buildChartConfig(points, activeClass, xMode, targetElo, skillData?.[activeClass])
+    config.plugins = [targetEloLine(targetElo)]
 
     if (chart) {
       chart.data = config.data

--- a/src/players/views/html/edit-player.page.tsx
+++ b/src/players/views/html/edit-player.page.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../html/components/admin-panel'
 import {
   IconAirTrafficControl,
+  IconAlertSquareRounded,
   IconArrowBackUp,
   IconBan,
   IconChartArrowsVertical,
@@ -242,6 +243,13 @@ export async function EditPlayerEloPage(props: { steamId: SteamId64 }) {
   return (
     <EditPlayer player={player} activePage="/elo">
       <div class="admin-panel-content">
+        <p class="bg-abru-dark-25 text-abru-light-75 mb-4 flex items-center gap-2 rounded-lg px-4 py-3 text-sm">
+          <IconAlertSquareRounded size={20} />
+          <span>
+            ELO should aim at {defaultElo} when the games are properly balanced — values drifting
+            away from it suggest unbalanced games.
+          </span>
+        </p>
         <table class="w-full text-sm text-white">
           <thead>
             <tr class="text-abru-light-75 border-abru-light-15 border-b text-left font-light">
@@ -329,6 +337,13 @@ function EditPlayer(props: {
               <IconMessageCircleOff />
               Chat mutes
             </AdminPanelLink>
+            <AdminPanelLink
+              href={`/players/${props.player.steamId}/edit/elo`}
+              active={props.activePage === '/elo'}
+            >
+              <IconChartArrowsVertical />
+              ELO
+            </AdminPanelLink>
 
             {user.player.roles.includes(PlayerRole.superUser) && (
               <>
@@ -339,13 +354,6 @@ function EditPlayer(props: {
                 >
                   <IconAirTrafficControl />
                   Roles
-                </AdminPanelLink>
-                <AdminPanelLink
-                  href={`/players/${props.player.steamId}/edit/elo`}
-                  active={props.activePage === '/elo'}
-                >
-                  <IconChartArrowsVertical />
-                  ELO
                 </AdminPanelLink>
               </>
             )}

--- a/src/players/views/html/elo-history-chart.tsx
+++ b/src/players/views/html/elo-history-chart.tsx
@@ -4,6 +4,7 @@ import { players } from '../../../players'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
 import { queue } from '../../../queue-auto'
 import { GameClassIcon } from '../../../html/components/game-class-icon'
+import { defaultElo } from '../../../games/calculate-elo-updates'
 import type { EloDataPoint, EloHistoryData, SkillData } from './@client/elo-history-chart'
 
 export async function EloHistoryChart(props: { steamId: SteamId64 }) {
@@ -75,7 +76,7 @@ export async function EloHistoryChart(props: { steamId: SteamId64 }) {
         import { initEloHistoryChart } from '${mainJs}';
         const data = ${JSON.stringify(data)};
         const skillData = ${JSON.stringify(skillData)};
-        initEloHistoryChart(data, skillData);
+        initEloHistoryChart(data, skillData, ${JSON.stringify(defaultElo)});
         `}
       </script>
     </div>

--- a/src/routes/players/:steamId/edit/elo/index.ts
+++ b/src/routes/players/:steamId/edit/elo/index.ts
@@ -10,7 +10,7 @@ export default routes(async app => {
     '/',
     {
       config: {
-        authorize: [PlayerRole.superUser],
+        authorize: [PlayerRole.admin],
       },
       schema: {
         params: z.object({


### PR DESCRIPTION
## Why

* Regular admins are the ones balancing games day-to-day, but the Edit Player → ELO view was gated behind the super-user role. It is now authorized with `PlayerRole.admin`, consistent with every other edit-player page (profile, bans, chat mutes), and the sidebar link moved out of the super-user section.
* 1500 is the ELO every player starts with, and with properly balanced games the population should gravitate back towards it. To make that explicit, the view now states it in a notice at the top, and the history chart draws a dashed "1500 target" line (always kept in the visible axis range) so drift away from the target is obvious at a glance.

## Screenshot

![Edit Player ELO view with the notice and the 1500 target line](https://gist.githubusercontent.com/garrappachc/87a3ef4e696e117619c85adc342bff42/raw/elo-view.png)