### PR TITLE
fix: verify log transmission before configuring the game server

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -245,6 +245,10 @@ class TypedEventEmitter extends EventEmitter {
   override on<K extends keyof Events>(event: K, listener: (params: Events[K]) => void): this {
     return super.on(event, listener)
   }
+
+  override off<K extends keyof Events>(event: K, listener: (params: Events[K]) => void): this {
+    return super.off(event, listener)
+  }
 }
 
 export const events = new TypedEventEmitter()

--- a/src/games/rcon/configure.ts
+++ b/src/games/rcon/configure.ts
@@ -19,6 +19,7 @@ import { extractConVarValue } from '../extract-con-var-value'
 import { generate } from 'generate-password'
 import { events } from '../../events'
 import { withRcon } from './with-rcon'
+import { verifyLogTransmission } from './verify-log-transmission'
 import { servemeTf } from '../../serveme-tf'
 import { tf2QuickServer } from '../../tf2-quick-server'
 import type { ReservationId } from '@tf2pickup-org/serveme-tf-client'
@@ -177,6 +178,9 @@ async function doConfigure(game: GameModel, options: { signal?: AbortSignal } = 
     for await (const line of compileConfig(game, password)) {
       logger.debug(line)
       await rcon.send(line)
+      if (line.startsWith('logaddress_add')) {
+        await verifyLogTransmission({ rcon, logSecret, gameNumber: game.number, signal })
+      }
       if (line.startsWith('changelevel')) {
         await delay(secondsToMilliseconds(10))
       }

--- a/src/games/rcon/verify-log-transmission.test.ts
+++ b/src/games/rcon/verify-log-transmission.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import { verifyLogTransmission } from './verify-log-transmission'
+import { events } from '../../events'
+import type { GameNumber } from '../../database/models/game.model'
+import type { RconCommand } from '../../shared/types/rcon-command'
+
+vi.mock('../../environment', () => ({
+  environment: {
+    LOG_RELAY_ADDRESS: 'FAKE_LOG_RELAY_ADDRESS',
+    LOG_RELAY_PORT: 9871,
+  },
+}))
+
+vi.mock('../../logger', () => ({
+  logger: {
+    trace: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+const gameNumber = 512 as GameNumber
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+it('should resolve when a log message with the matching logsecret arrives', async () => {
+  const rcon = {
+    send: vi.fn().mockImplementation(async (command: RconCommand) => {
+      if (command.startsWith('echo')) {
+        setImmediate(() => {
+          events.emit('gamelog:message', {
+            message: { payload: 'rcon from "127.0.0.1:51234": command "echo"', password: 'SECRET' },
+          })
+        })
+      }
+      return ''
+    }),
+  }
+
+  await verifyLogTransmission({ rcon, logSecret: 'SECRET', gameNumber })
+  expect(rcon.send).toHaveBeenCalledWith('log on')
+  expect(events.listenerCount('gamelog:message')).toBe(0)
+})
+
+it('should throw when no log message arrives', async () => {
+  vi.useFakeTimers()
+  const rcon = { send: vi.fn().mockResolvedValue('') }
+
+  const promise = verifyLogTransmission({ rcon, logSecret: 'SECRET', gameNumber })
+  const assertion = expect(promise).rejects.toThrow(/game server is not sending logs/)
+  await vi.advanceTimersByTimeAsync(5000)
+  await assertion
+  expect(events.listenerCount('gamelog:message')).toBe(0)
+})
+
+it('should ignore log messages with a different logsecret', async () => {
+  vi.useFakeTimers()
+  const rcon = {
+    send: vi.fn().mockImplementation(async (command: RconCommand) => {
+      if (command.startsWith('echo')) {
+        setImmediate(() => {
+          events.emit('gamelog:message', {
+            message: { payload: 'rcon from "127.0.0.1:51234": command "echo"', password: 'OTHER' },
+          })
+        })
+      }
+      return ''
+    }),
+  }
+
+  const promise = verifyLogTransmission({ rcon, logSecret: 'SECRET', gameNumber })
+  const assertion = expect(promise).rejects.toThrow(/game server is not sending logs/)
+  await vi.advanceTimersByTimeAsync(5000)
+  await assertion
+})
+
+it('should throw when the signal is aborted', async () => {
+  const rcon = { send: vi.fn().mockResolvedValue('') }
+  const controller = new AbortController()
+  controller.abort('FAKE_REASON')
+
+  await expect(
+    verifyLogTransmission({ rcon, logSecret: 'SECRET', gameNumber, signal: controller.signal }),
+  ).rejects.toThrow('FAKE_REASON')
+})

--- a/src/games/rcon/verify-log-transmission.ts
+++ b/src/games/rcon/verify-log-transmission.ts
@@ -1,0 +1,58 @@
+import { millisecondsToSeconds, secondsToMilliseconds } from 'date-fns'
+import { withTimeout } from 'es-toolkit'
+import type { GameNumber } from '../../database/models/game.model'
+import { environment } from '../../environment'
+import { events } from '../../events'
+import type { LogMessage } from '../../log-receiver/parse-log-message'
+import { logger } from '../../logger'
+import type { Rcon } from './with-rcon'
+
+const verifyTimeout = secondsToMilliseconds(5)
+const triggerInterval = secondsToMilliseconds(1)
+
+export async function verifyLogTransmission(args: {
+  rcon: Rcon
+  logSecret: string
+  gameNumber: GameNumber
+  signal?: AbortSignal | undefined
+}): Promise<void> {
+  const { rcon, logSecret, gameNumber, signal } = args
+  const logAddress = `${environment.LOG_RELAY_ADDRESS}:${environment.LOG_RELAY_PORT}`
+  logger.debug(`game #${gameNumber}: verifying log transmission to ${logAddress}...`)
+
+  let listener!: (params: { message: LogMessage }) => void
+  const received = new Promise<void>(resolve => {
+    listener = ({ message }) => {
+      if (message.password === logSecret) {
+        resolve()
+      }
+    }
+    events.on('gamelog:message', listener)
+  })
+
+  try {
+    await rcon.send('log on')
+    const attempts = Math.floor(verifyTimeout / triggerInterval)
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      if (signal?.aborted) {
+        throw new Error(`${signal.reason}`)
+      }
+      await rcon.send(`echo tf2pickup log check`)
+      try {
+        await withTimeout(() => received, triggerInterval)
+        logger.debug(`game #${gameNumber}: log transmission verified`)
+        return
+      } catch {
+        // `received` never rejects, so this can only be the TimeoutError
+      }
+    }
+
+    throw new Error(
+      `game server is not sending logs to ${logAddress}: no log message received within ` +
+        `${millisecondsToSeconds(verifyTimeout)} seconds of logaddress_add; make sure the game server can reach ` +
+        `${logAddress} over UDP (firewall) and that the LOG_RELAY_PORT port mapping is correct (docker)`,
+    )
+  } finally {
+    events.off('gamelog:message', listener)
+  }
+}

--- a/src/games/rcon/with-rcon.ts
+++ b/src/games/rcon/with-rcon.ts
@@ -5,7 +5,7 @@ import { logger } from '../../logger'
 import { errors } from '../../errors'
 import type { RconCommand } from '../../shared/types/rcon-command'
 
-interface Rcon {
+export interface Rcon {
   send: (command: RconCommand) => Promise<string>
 }
 

--- a/src/shared/types/rcon-command.ts
+++ b/src/shared/types/rcon-command.ts
@@ -4,8 +4,10 @@ export type RconCommand =
   | `sm_game_player_delall`
   | `sm_game_player_del ${string}`
   | `sm_game_player_whitelist ${0 | 1}`
+  | `echo ${string}`
   | `exec ${string}`
   | `kickall`
+  | `log on`
   | `sv_logsecret ${string}`
   | `logaddress_add ${string}`
   | `logaddress_del ${string}`

--- a/tests/game-server-simulator.ts
+++ b/tests/game-server-simulator.ts
@@ -190,6 +190,9 @@ export class GameServerSimulator {
 
               socket.write(response.toBuffer())
             }
+
+            // real srcds logs every rcon command (sv_rcon_log)
+            this.log(`rcon from "127.0.0.1:51234": command "${packet.body}"`)
             break
           }
 


### PR DESCRIPTION
## Why

When a game server is assigned but its UDP log traffic never reaches the log receiver (blocked firewall port, wrongly mapped `LOG_RELAY_PORT` in docker), the game used to proceed through configuration and break later in confusing ways (no match events, no player connection status).

Now, right after `logaddress_add` is sent, the server must prove logs actually flow: the check sends `log on` plus up to five `echo` triggers (real srcds logs every rcon command via `sv_rcon_log`) and waits for a log packet carrying the game's logsecret. If nothing arrives within 5 seconds, configure fails (with the standard 3 attempts).

Error visibility follows the existing configure-failure path: players see only the generic *Error configuring game server* game event, while the exact cause (address, port, firewall/docker hints) goes to the admin Discord channel, the game event record, and the logs.

The e2e game server simulator now mirrors the `sv_rcon_log` behavior so the check passes in tests.

## Notes

- Verified end-to-end locally: happy path (`20-game/01-configure-game-server.spec.ts` green) and failure path (app started with a black-hole `LOG_RELAY_ADDRESS` fails configure with the detailed admin error; game page leaks nothing).
- `instanceof TimeoutError` from es-toolkit is not used on purpose: since 1.49.0 `TimeoutError` extends the native `DOMException`, whose constructor breaks subclassing, so `instanceof` never matches (the check in `tests/fixtures/simulate-game-server.ts` is affected by this, too).