### PR TITLE
fix(queue): show ready-up dialog after page refresh

### DIFF
--- a/src/queue-auto/plugins/sync-clients.test.ts
+++ b/src/queue-auto/plugins/sync-clients.test.ts
@@ -8,12 +8,14 @@ const {
   mockQueueSlotsFind,
   mockQueueSlotsFindOne,
   mockNotFound,
+  mockGetState,
 } = vi.hoisted(() => ({
   mockPlayersFind: vi.fn(),
   mockPlayersCollectionFindOne: vi.fn(),
   mockQueueSlotsFind: vi.fn(),
   mockQueueSlotsFindOne: vi.fn(),
   mockNotFound: vi.fn((msg: string) => new Error(msg)),
+  mockGetState: vi.fn(),
 }))
 
 vi.mock('fastify-plugin', () => ({ default: <T>(fn: T): T => fn }))
@@ -21,6 +23,7 @@ vi.mock('../../events', () => ({ events: { on: vi.fn() } }))
 vi.mock('../../utils/safe', () => ({ safe: <T>(fn: T): T => fn }))
 vi.mock('../../players', () => ({ players: { bySteamId: vi.fn() } }))
 vi.mock('../../errors', () => ({ errors: { notFound: mockNotFound } }))
+vi.mock('../../queue/get-state', () => ({ getState: mockGetState }))
 vi.mock('../../database/collections', () => ({
   collections: {
     players: { find: mockPlayersFind, findOne: mockPlayersCollectionFindOne },
@@ -72,6 +75,8 @@ vi.mock('../views/html/is-in-queue', () => ({ IsInQueue: vi.fn().mockResolvedVal
 
 import { events } from '../../events'
 import { players } from '../../players'
+import { ReadyUpDialog } from '../views/html/ready-up-dialog'
+import { QueueState } from '../../database/models/queue-state.model'
 import plugin from './sync-clients'
 
 const steamId1 = '76561198000000001' as SteamId64
@@ -111,6 +116,7 @@ describe('sync-clients', () => {
     mockQueueSlotsFindOne.mockResolvedValue(null)
     mockPlayersCollectionFindOne.mockResolvedValue(null)
     mockPlayersFind.mockReturnValue({ toArray: vi.fn().mockResolvedValue([]) })
+    mockGetState.mockResolvedValue(QueueState.waiting)
     await (plugin as unknown as (app: FastifyInstance) => Promise<void>)(app)
   })
 
@@ -166,6 +172,53 @@ describe('sync-clients', () => {
         { steamId: { $in: [steamId1, steamId2] } },
         expect.objectContaining({ projection: expect.any(Object) }),
       )
+    })
+  })
+
+  describe('syncQueuePage', () => {
+    function getReadyHandler(): (socket: unknown) => Promise<void> {
+      const call = vi
+        .mocked(app.gateway.on)
+        .mock.calls.find(([e]: [unknown, unknown]) => e === 'ready')
+      if (!call) throw new Error('No gateway handler registered for event: ready')
+      return call[1] as (socket: unknown) => Promise<void>
+    }
+
+    function makeSocket() {
+      return { player: { steamId: steamId1 }, currentUrl: '/', send: vi.fn() }
+    }
+
+    it('shows the ready-up dialog when the queue is in ready state and the player has not readied up', async () => {
+      mockGetState.mockResolvedValue(QueueState.ready)
+      mockQueueSlotsFindOne.mockResolvedValue({ player: { steamId: steamId1 }, ready: false })
+      const socket = makeSocket()
+
+      await getReadyHandler()(socket)
+
+      expect(mockQueueSlotsFindOne).toHaveBeenCalledWith({
+        'player.steamId': steamId1,
+        ready: false,
+      })
+      expect(vi.mocked(ReadyUpDialog.show)).toHaveBeenCalledWith(steamId1)
+    })
+
+    it('does not show the ready-up dialog when the player has already readied up', async () => {
+      mockGetState.mockResolvedValue(QueueState.ready)
+      mockQueueSlotsFindOne.mockResolvedValue(null)
+      const socket = makeSocket()
+
+      await getReadyHandler()(socket)
+
+      expect(vi.mocked(ReadyUpDialog.show)).not.toHaveBeenCalled()
+    })
+
+    it('does not show the ready-up dialog when the queue is not in ready state', async () => {
+      mockGetState.mockResolvedValue(QueueState.waiting)
+      const socket = makeSocket()
+
+      await getReadyHandler()(socket)
+
+      expect(vi.mocked(ReadyUpDialog.show)).not.toHaveBeenCalled()
     })
   })
 

--- a/src/queue-auto/plugins/sync-clients.ts
+++ b/src/queue-auto/plugins/sync-clients.ts
@@ -23,6 +23,7 @@ import type { PlayerModel } from '../../database/models/player.model'
 import type { AppWebSocket } from '../../websocket/types'
 import { players } from '../../players'
 import { errors } from '../../errors'
+import { getState } from '../../queue/get-state'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -79,6 +80,16 @@ export default fp(
         socket.send(await RunningGameSnackbar({ gameNumber: player?.activeGame }))
         socket.send(await PreReadyUpButton({ actor: socket.player.steamId }))
         socket.send(await BanAlerts({ actor: socket.player.steamId }))
+
+        if ((await getState()) === QueueState.ready) {
+          const slot = await collections.queueSlots.findOne({
+            'player.steamId': socket.player.steamId,
+            ready: false,
+          })
+          if (slot) {
+            socket.send(await ReadyUpDialog.show(socket.player.steamId))
+          }
+        }
       }
     }
 

--- a/tests/10-queue/12-ready-up-dialog-after-refresh.spec.ts
+++ b/tests/10-queue/12-ready-up-dialog-after-refresh.spec.ts
@@ -1,0 +1,34 @@
+import { launchGame as test, expect } from '../fixtures/launch-game'
+import { minutesToMilliseconds, secondsToMilliseconds } from 'date-fns'
+
+test('ready-up dialog is shown again after page refresh @6v6', async ({
+  players,
+  desiredSlots,
+  users,
+}) => {
+  test.setTimeout(minutesToMilliseconds(2))
+
+  await Promise.all(
+    players.map(async player => {
+      const page = await player.queuePage()
+      await page.goto()
+      await page.slot(desiredSlots.get(player.playerName)!).join()
+    }),
+  )
+
+  const moonManPage = await users.byName('MoonMan').queuePage()
+  await expect(moonManPage.readyUpDialog().readyUpButton()).toBeVisible()
+
+  await moonManPage.page.reload()
+  await expect(moonManPage.readyUpDialog().readyUpButton()).toBeVisible({
+    timeout: secondsToMilliseconds(10),
+  })
+
+  // everybody leaves the queue
+  await Promise.all(
+    players.map(async player => {
+      const page = await player.queuePage()
+      await page.readyUpDialog().notReady()
+    }),
+  )
+})


### PR DESCRIPTION
When a player refreshes the page (or reconnects) during the ready-up phase, the ready-up dialog never reappeared — it was only pushed on the `queue/state:updated` transition, and the websocket page re-sync in `syncQueuePage` didn't cover it. A player who refreshed at the wrong moment would silently miss the ready-up and get kicked from the queue.

Now `syncQueuePage` checks on connect whether the queue is in the `ready` state and the player still has an unready slot, and if so re-sends `ReadyUpDialog.show()` (same fragment as the original trigger, so the sound/notification fire too).