### PR TITLE
ci: cache Playwright browsers and annotate failures inline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,8 +136,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Download artifact
         uses: actions/download-artifact@v8.0.1

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: process.env.CI ? 'blob' : 'html',
+  reporter: process.env.CI ? [['blob'], ['github']] : 'html',
   timeout: secondsToMilliseconds(45),
   reportSlowTests: {
     max: 5,


### PR DESCRIPTION
Inspired by https://endform.dev/blog/playwright-github-actions.

Every e2e matrix job (16 of them) was cold-downloading ~400 MB of Playwright browsers on every run. Browsers are now cached keyed on `pnpm-lock.yaml`, and only Chromium is installed since it's the only project in use — on cache hits only the (uncacheable) system libraries are installed.

Also adds the `github` reporter in CI alongside `blob`, so test failures show up as inline PR annotations per shard, without waiting for the merge-reports job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)