### PR TITLE
fix(games): detect mid-game match restarts and reset the score

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -83,9 +83,6 @@ export interface Events {
   'match:started': {
     gameNumber: GameNumber
   }
-  'match:restarted': {
-    gameNumber: GameNumber
-  }
   'match:roundWon': {
     gameNumber: GameNumber
     winner: Tf2Team

--- a/src/events.ts
+++ b/src/events.ts
@@ -71,6 +71,10 @@ export interface Events {
   'game:ended': {
     game: GameModel
   }
+  // a mid-game match restart was detected and the game's score was reset
+  'game:restarted': {
+    game: GameModel
+  }
 
   'gamelog:message': {
     message: LogMessage
@@ -121,6 +125,11 @@ export interface Events {
     gameNumber: GameNumber
     team: Tf2Team
     score: number
+  }
+  // the server reset its scoreboard — a tournament match (re)start, detected
+  // by Round_Start being logged twice in the same second
+  'match/score:reset': {
+    gameNumber: GameNumber
   }
   'match/controlPoint:captured': {
     gameNumber: GameNumber

--- a/src/games/game-log-sink.test.ts
+++ b/src/games/game-log-sink.test.ts
@@ -167,7 +167,7 @@ describe('clear()', () => {
     expect(collections.gameLogs.deleteOne).toHaveBeenCalledWith({ logSecret: 'my-secret' })
   })
 
-  it('should detach from the pending queue so subsequent pushes start a fresh chain', async () => {
+  it('should serialize deletion between pre- and post-clear writes', async () => {
     const results: number[] = []
     let resolveFirst!: () => void
     const promiseFirst = new Promise<void>(r => {
@@ -184,19 +184,20 @@ describe('clear()', () => {
         results.push(2)
         return null
       })
+    vi.mocked(collections.gameLogs.deleteOne).mockImplementationOnce(async () => {
+      results.push(0)
+      return { acknowledged: true, deletedCount: 1 }
+    })
 
     gameLogSink.push({ payload: 'first', password: 'clear-chain' })
-    await gameLogSink.clear('clear-chain')
-
-    // Fresh push after clear should not wait for the still-pending first message
+    const clear = gameLogSink.clear('clear-chain')
     gameLogSink.push({ payload: 'second', password: 'clear-chain' })
+
+    resolveFirst()
+    await clear
+
     await gameLogSink.waitForCompletion('clear-chain')
 
-    expect(results).toEqual([2])
-
-    // Resolve the original and confirm it still completes independently
-    resolveFirst()
-    await Promise.resolve()
-    expect(results).toEqual([2, 1])
+    expect(results).toEqual([1, 0, 2])
   })
 })

--- a/src/games/game-log-sink.ts
+++ b/src/games/game-log-sink.ts
@@ -11,7 +11,7 @@ class GameLogSink {
   constructor(private readonly collection: Collection<GameLogsModel>) {}
 
   push(message: LogMessage): void {
-    this.enqueue(message.password, async () => {
+    void this.enqueue(message.password, async () => {
       await this.safePushLogMessage(message)
     })
   }

--- a/src/games/game-log-sink.ts
+++ b/src/games/game-log-sink.ts
@@ -16,12 +16,13 @@ class GameLogSink {
     })
   }
 
-  private enqueue(logSecret: string, operation: () => Promise<void>): void {
+  private enqueue(logSecret: string, operation: () => Promise<void>): Promise<void> {
     const previous = this.queues.get(logSecret) ?? Promise.resolve()
     const current = previous.then(operation)
 
     // Store a caught version to prevent unhandled rejection and to not break the chain
     this.queues.set(logSecret, current.catch(noop))
+    return current
   }
 
   async waitForCompletion(logSecret: string): Promise<void> {
@@ -32,8 +33,9 @@ class GameLogSink {
   }
 
   async clear(logSecret: string): Promise<void> {
-    this.queues.delete(logSecret)
-    await this.collection.deleteOne({ logSecret })
+    await this.enqueue(logSecret, async () => {
+      await this.collection.deleteOne({ logSecret })
+    })
   }
 
   private async safePushLogMessage(message: LogMessage) {

--- a/src/games/plugins/game-log-collector.ts
+++ b/src/games/plugins/game-log-collector.ts
@@ -13,6 +13,13 @@ export default fp(
     events.on('match:restarted', async ({ gameNumber }) => {
       await pruneLogs(gameNumber)
     })
+    // drop pre-restart log lines so the log uploaded to logs.tf contains only
+    // the restarted match and its parsed score agrees with ours
+    events.on('game:restarted', async ({ game }) => {
+      if (game.logSecret) {
+        await gameLogSink.clear(game.logSecret)
+      }
+    })
   },
   { name: 'game log collector', encapsulate: true },
 )

--- a/src/games/plugins/game-log-collector.ts
+++ b/src/games/plugins/game-log-collector.ts
@@ -1,7 +1,5 @@
 import fp from 'fastify-plugin'
 import { events } from '../../events'
-import { findOne } from '../find-one'
-import type { GameNumber } from '../../database/models/game.model'
 import { gameLogSink } from '../game-log-sink'
 
 export default fp(
@@ -9,9 +7,6 @@ export default fp(
   async () => {
     events.on('gamelog:message', ({ message }) => {
       gameLogSink.push(message)
-    })
-    events.on('match:restarted', async ({ gameNumber }) => {
-      await pruneLogs(gameNumber)
     })
     // drop pre-restart log lines so the log uploaded to logs.tf contains only
     // the restarted match and its parsed score agrees with ours
@@ -23,12 +18,3 @@ export default fp(
   },
   { name: 'game log collector', encapsulate: true },
 )
-
-async function pruneLogs(number: GameNumber) {
-  const game = await findOne({ number }, ['logSecret'])
-  if (!game.logSecret) {
-    return
-  }
-
-  await gameLogSink.clear(game.logSecret)
-}

--- a/src/games/plugins/match-event-handler.test.ts
+++ b/src/games/plugins/match-event-handler.test.ts
@@ -51,10 +51,9 @@ describe('match-event-handler', () => {
     scoreResetHandler = call![1] as typeof scoreResetHandler
   })
 
-  it('zeroes the score and records the restart for a started game with a nonzero score', async () => {
+  it('zeroes the score and records the restart for a started game', async () => {
     vi.mocked(collections.games.findOne).mockResolvedValue({
       state: GameState.started,
-      score: { [Tf2Team.blu]: 0, [Tf2Team.red]: 1 },
     } as never)
     const updated = { number: gameNumber } as never
     vi.mocked(update).mockResolvedValue(updated)
@@ -71,18 +70,6 @@ describe('match-event-handler', () => {
       }),
     )
     expect(events.emit).toHaveBeenCalledWith('game:restarted', { game: updated })
-  })
-
-  it('ignores the reset when nothing was scored yet', async () => {
-    vi.mocked(collections.games.findOne).mockResolvedValue({
-      state: GameState.started,
-      score: { [Tf2Team.blu]: 0, [Tf2Team.red]: 0 },
-    } as never)
-
-    await scoreResetHandler({ gameNumber })
-
-    expect(update).not.toHaveBeenCalled()
-    expect(events.emit).not.toHaveBeenCalled()
   })
 
   it('ignores the reset when the game is not started', async () => {

--- a/src/games/plugins/match-event-handler.test.ts
+++ b/src/games/plugins/match-event-handler.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('fastify-plugin', () => ({
+  default: <T>(fn: T): T => fn,
+}))
+
+vi.mock('../../events', () => ({
+  events: {
+    on: vi.fn(),
+    emit: vi.fn(),
+  },
+}))
+
+vi.mock('../update', () => ({
+  update: vi.fn(),
+}))
+
+vi.mock('../../utils/safe', () => ({
+  safe: <T>(fn: T): T => fn,
+}))
+
+vi.mock('../../database/collections', () => ({
+  collections: {
+    games: {
+      findOne: vi.fn(),
+    },
+  },
+}))
+
+import { events } from '../../events'
+import { update } from '../update'
+import { collections } from '../../database/collections'
+import { GameState } from '../../database/models/game.model'
+import { GameEventType } from '../../database/models/game-event.model'
+import { Tf2Team } from '../../shared/types/tf2-team'
+import plugin from './match-event-handler'
+import type { GameNumber } from '../../database/models/game.model'
+
+const gameNumber = 7615 as GameNumber
+
+describe('match-event-handler', () => {
+  let scoreResetHandler: (params: { gameNumber: GameNumber }) => Promise<void>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    await (plugin as unknown as () => Promise<void>)()
+
+    const call = vi
+      .mocked(events.on)
+      .mock.calls.find(([event]: [string, ...unknown[]]) => event === 'match/score:reset')
+    scoreResetHandler = call![1] as typeof scoreResetHandler
+  })
+
+  it('zeroes the score and records the restart for a started game with a nonzero score', async () => {
+    vi.mocked(collections.games.findOne).mockResolvedValue({
+      state: GameState.started,
+      score: { [Tf2Team.blu]: 0, [Tf2Team.red]: 1 },
+    } as never)
+    const updated = { number: gameNumber } as never
+    vi.mocked(update).mockResolvedValue(updated)
+
+    await scoreResetHandler({ gameNumber })
+
+    expect(update).toHaveBeenCalledWith(
+      { number: gameNumber, state: GameState.started },
+      expect.objectContaining({
+        $set: { score: { [Tf2Team.blu]: 0, [Tf2Team.red]: 0 } },
+        $push: {
+          events: expect.objectContaining({ event: GameEventType.gameRestarted }),
+        },
+      }),
+    )
+    expect(events.emit).toHaveBeenCalledWith('game:restarted', { game: updated })
+  })
+
+  it('ignores the reset when nothing was scored yet', async () => {
+    vi.mocked(collections.games.findOne).mockResolvedValue({
+      state: GameState.started,
+      score: { [Tf2Team.blu]: 0, [Tf2Team.red]: 0 },
+    } as never)
+
+    await scoreResetHandler({ gameNumber })
+
+    expect(update).not.toHaveBeenCalled()
+    expect(events.emit).not.toHaveBeenCalled()
+  })
+
+  it('ignores the reset when the game is not started', async () => {
+    vi.mocked(collections.games.findOne).mockResolvedValue({
+      state: GameState.launching,
+    } as never)
+
+    await scoreResetHandler({ gameNumber })
+
+    expect(update).not.toHaveBeenCalled()
+    expect(events.emit).not.toHaveBeenCalled()
+  })
+})

--- a/src/games/plugins/match-event-handler.ts
+++ b/src/games/plugins/match-event-handler.ts
@@ -51,16 +51,12 @@ export default fp(
         // The server reset its scoreboard mid-match (tournament restart —
         // everyone left to spectator, an admin re-exec'd the config, etc.) —
         // rounds won before the restart no longer count. Zero our score to
-        // match and record the restart. At the initial match start (or when
-        // nothing was scored yet) there is nothing to reset.
+        // match and record the restart.
         const game = await collections.games.findOne(
           { number: gameNumber },
-          { projection: { state: 1, score: 1 } },
+          { projection: { state: 1 } },
         )
-        if (
-          game?.state !== GameState.started ||
-          ((game.score?.[Tf2Team.blu] ?? 0) === 0 && (game.score?.[Tf2Team.red] ?? 0) === 0)
-        ) {
+        if (game?.state !== GameState.started) {
           return
         }
         const updated = await update(

--- a/src/games/plugins/match-event-handler.ts
+++ b/src/games/plugins/match-event-handler.ts
@@ -46,46 +46,13 @@ export default fp(
     )
 
     events.on(
-      'match:restarted',
-      safe(async ({ gameNumber }) => {
-        // Gameservers re-fire match:restarted (mp_restartgame, map reloads); only
-        // the started -> launching transition is meaningful. Ignore the rest
-        // instead of failing to find a started game.
-        const game = await collections.games.findOne(
-          { number: gameNumber },
-          { projection: { state: 1 } },
-        )
-        if (game?.state !== GameState.started) {
-          return
-        }
-        await update(
-          { number: gameNumber, state: GameState.started },
-          {
-            $set: {
-              state: GameState.launching,
-            },
-            $unset: {
-              score: 1,
-            },
-            $push: {
-              events: {
-                at: new Date(),
-                event: GameEventType.gameRestarted,
-              },
-            },
-          },
-        )
-      }),
-    )
-
-    events.on(
       'match/score:reset',
       safe(async ({ gameNumber }) => {
-        // The server reset its scoreboard mid-match (tournament restart, e.g.
-        // after everyone left to spectator) — rounds won before the restart no
-        // longer count. Zero our score to match and record the restart. At the
-        // initial match start (or when nothing was scored yet) there is
-        // nothing to reset.
+        // The server reset its scoreboard mid-match (tournament restart —
+        // everyone left to spectator, an admin re-exec'd the config, etc.) —
+        // rounds won before the restart no longer count. Zero our score to
+        // match and record the restart. At the initial match start (or when
+        // nothing was scored yet) there is nothing to reset.
         const game = await collections.games.findOne(
           { number: gameNumber },
           { projection: { state: 1, score: 1 } },

--- a/src/games/plugins/match-event-handler.ts
+++ b/src/games/plugins/match-event-handler.ts
@@ -79,6 +79,45 @@ export default fp(
     )
 
     events.on(
+      'match/score:reset',
+      safe(async ({ gameNumber }) => {
+        // The server reset its scoreboard mid-match (tournament restart, e.g.
+        // after everyone left to spectator) — rounds won before the restart no
+        // longer count. Zero our score to match and record the restart. At the
+        // initial match start (or when nothing was scored yet) there is
+        // nothing to reset.
+        const game = await collections.games.findOne(
+          { number: gameNumber },
+          { projection: { state: 1, score: 1 } },
+        )
+        if (
+          game?.state !== GameState.started ||
+          ((game.score?.[Tf2Team.blu] ?? 0) === 0 && (game.score?.[Tf2Team.red] ?? 0) === 0)
+        ) {
+          return
+        }
+        const updated = await update(
+          { number: gameNumber, state: GameState.started },
+          {
+            $set: {
+              score: {
+                [Tf2Team.blu]: 0,
+                [Tf2Team.red]: 0,
+              },
+            },
+            $push: {
+              events: {
+                at: new Date(),
+                event: GameEventType.gameRestarted,
+              },
+            },
+          },
+        )
+        events.emit('game:restarted', { game: updated })
+      }),
+    )
+
+    events.on(
       'match:ended',
       safe(async ({ gameNumber }) => {
         // Gameservers re-fire match:ended after the game already left the started

--- a/src/games/plugins/match-event-listener.test.ts
+++ b/src/games/plugins/match-event-listener.test.ts
@@ -76,4 +76,18 @@ describe('match-event-listener', () => {
     await onGameLogMessage(roundStart('07/13/2026 - 18:07:40'))
     expect(events.emit).not.toHaveBeenCalledWith('match/score:reset', { gameNumber })
   })
+
+  it('does not emit match/score:reset when a round was won in between', async () => {
+    // log replays re-stamp lines with the current time, so consecutive rounds
+    // can share a timestamp — a completed round marks a regular transition
+    await onGameLogMessage(roundStart('06/16/2026 - 10:38:23'))
+    await onGameLogMessage({
+      message: {
+        payload: '06/16/2026 - 10:38:23: World triggered "Round_Win" (winner "Blue")',
+        password: logSecret,
+      },
+    })
+    await onGameLogMessage(roundStart('06/16/2026 - 10:38:23'))
+    expect(events.emit).not.toHaveBeenCalledWith('match/score:reset', { gameNumber })
+  })
 })

--- a/src/games/plugins/match-event-listener.test.ts
+++ b/src/games/plugins/match-event-listener.test.ts
@@ -53,6 +53,15 @@ describe('match-event-listener', () => {
       .mocked(events.on)
       .mock.calls.find(([event]: [string, ...unknown[]]) => event === 'gamelog:message')
     onGameLogMessage = call![1] as typeof onGameLogMessage
+
+    // reset the module-level round start tracking between tests
+    await onGameLogMessage({
+      message: {
+        payload: '07/13/2026 - 00:00:00: World triggered "Game_Over" reason "test reset"',
+        password: logSecret,
+      },
+    })
+    vi.mocked(events.emit).mockClear()
   })
 
   const roundStart = (timestamp: string) => ({
@@ -65,10 +74,20 @@ describe('match-event-listener', () => {
     expect(events.emit).not.toHaveBeenCalledWith('match/score:reset', { gameNumber })
   })
 
-  it('emits match/score:reset for a doubled round start', async () => {
+  it('emits match/score:reset for a doubled round start mid-game', async () => {
+    // the real sequence of https://tf2pickup.pl/games/7615: the round started
+    // at 17:35:10 was aborted (everyone left to spectator) and the match was
+    // restarted at 17:39:30
+    await onGameLogMessage(roundStart('07/13/2026 - 17:35:10'))
     await onGameLogMessage(roundStart('07/13/2026 - 17:39:30'))
     await onGameLogMessage(roundStart('07/13/2026 - 17:39:30'))
     expect(events.emit).toHaveBeenCalledWith('match/score:reset', { gameNumber })
+  })
+
+  it('does not emit match/score:reset for the doubled round start at the initial match start', async () => {
+    await onGameLogMessage(roundStart('07/13/2026 - 17:33:28'))
+    await onGameLogMessage(roundStart('07/13/2026 - 17:33:28'))
+    expect(events.emit).not.toHaveBeenCalledWith('match/score:reset', { gameNumber })
   })
 
   it('does not emit match/score:reset for round starts at different times', async () => {

--- a/src/games/plugins/match-event-listener.test.ts
+++ b/src/games/plugins/match-event-listener.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('fastify-plugin', () => ({
+  default: <T>(fn: T): T => fn,
+}))
+
+vi.mock('../../events', () => ({
+  events: {
+    on: vi.fn(),
+    emit: vi.fn(),
+  },
+}))
+
+vi.mock('../../logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('../../database/collections', () => ({
+  collections: {
+    games: {
+      findOne: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('../../otel', () => ({
+  meter: {
+    createCounter: () => ({ add: vi.fn() }),
+  },
+}))
+
+import { events } from '../../events'
+import { collections } from '../../database/collections'
+import plugin from './match-event-listener'
+
+const gameNumber = 7615
+const logSecret = '12345'
+
+describe('match-event-listener', () => {
+  let onGameLogMessage: (params: {
+    message: { payload: string; password: string }
+  }) => Promise<void>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.mocked(collections.games.findOne).mockResolvedValue({ number: gameNumber } as never)
+    await (plugin as unknown as () => Promise<void>)()
+
+    const call = vi
+      .mocked(events.on)
+      .mock.calls.find(([event]: [string, ...unknown[]]) => event === 'gamelog:message')
+    onGameLogMessage = call![1] as typeof onGameLogMessage
+  })
+
+  const roundStart = (timestamp: string) => ({
+    message: { payload: `${timestamp}: World triggered "Round_Start"`, password: logSecret },
+  })
+
+  it('emits match:started for a regular round start', async () => {
+    await onGameLogMessage(roundStart('07/13/2026 - 17:44:53'))
+    expect(events.emit).toHaveBeenCalledWith('match:started', { gameNumber })
+    expect(events.emit).not.toHaveBeenCalledWith('match/score:reset', { gameNumber })
+  })
+
+  it('emits match/score:reset for a doubled round start', async () => {
+    await onGameLogMessage(roundStart('07/13/2026 - 17:39:30'))
+    await onGameLogMessage(roundStart('07/13/2026 - 17:39:30'))
+    expect(events.emit).toHaveBeenCalledWith('match/score:reset', { gameNumber })
+  })
+
+  it('does not emit match/score:reset for round starts at different times', async () => {
+    await onGameLogMessage(roundStart('07/13/2026 - 18:01:44'))
+    await onGameLogMessage(roundStart('07/13/2026 - 18:07:40'))
+    expect(events.emit).not.toHaveBeenCalledWith('match/score:reset', { gameNumber })
+  })
+})

--- a/src/games/plugins/match-event-listener.test.ts
+++ b/src/games/plugins/match-event-listener.test.ts
@@ -96,6 +96,35 @@ describe('match-event-listener', () => {
     expect(events.emit).not.toHaveBeenCalledWith('match/score:reset', { gameNumber })
   })
 
+  it('does not emit match/score:reset when a round ended in a stalemate in between', async () => {
+    // stalemates end a round with no Round_Win line; in compressed-timestamp
+    // log replays the post-stalemate round start shares the second with the
+    // previous one
+    await onGameLogMessage(roundStart('05/16/2026 - 16:46:17'))
+    await onGameLogMessage({
+      message: {
+        payload: '05/16/2026 - 16:46:17: World triggered "Round_Stalemate"',
+        password: logSecret,
+      },
+    })
+    await onGameLogMessage(roundStart('05/16/2026 - 16:46:17'))
+    expect(events.emit).not.toHaveBeenCalledWith('match/score:reset', { gameNumber })
+  })
+
+  it('emits match/score:reset for a doubled round start straddling a second boundary mid-game', async () => {
+    await onGameLogMessage(roundStart('07/13/2026 - 17:30:00'))
+    await onGameLogMessage(roundStart('07/13/2026 - 17:35:10'))
+    await onGameLogMessage(roundStart('07/13/2026 - 17:35:11'))
+    expect(events.emit).toHaveBeenCalledWith('match/score:reset', { gameNumber })
+  })
+
+  it('does not emit match/score:reset for the initial doubled round start straddling a second boundary', async () => {
+    // real case: https://logs.tf/4084159
+    await onGameLogMessage(roundStart('07/13/2026 - 16:35:01'))
+    await onGameLogMessage(roundStart('07/13/2026 - 16:35:02'))
+    expect(events.emit).not.toHaveBeenCalledWith('match/score:reset', { gameNumber })
+  })
+
   it('does not emit match/score:reset when a round was won in between', async () => {
     // log replays re-stamp lines with the current time, so consecutive rounds
     // can share a timestamp — a completed round marks a regular transition

--- a/src/games/plugins/match-event-listener.ts
+++ b/src/games/plugins/match-event-listener.ts
@@ -23,12 +23,28 @@ interface GameEvent {
 // converts 'Red' and 'Blue' to valid team names
 const fixTeamName = (teamName: string): Tf2Team => teamName.toLowerCase().substring(0, 3) as Tf2Team
 
+// timestamp of the last Round_Start line seen per game; used to detect the
+// doubled Round_Start below
+const lastRoundStartAt = new Map<GameNumber, string>()
+
 const gameEvents: GameEvent[] = [
   {
     // TODO rename to "round start"
     name: 'match started',
-    regex: /^[\d/\s-:]+World triggered "Round_Start"$/,
-    handle: gameNumber => events.emit('match:started', { gameNumber }),
+    // TF2 logs Round_Start once per regular round, but twice in the same
+    // second when a tournament match (re)starts — e.g. at the initial ready-up,
+    // or mid-game when everyone leaves to spectator and readies up again. The
+    // doubled line means the server has just reset its scoreboard.
+    regex: /^(\d{2}\/\d{2}\/\d{4}\s-\s\d{2}:\d{2}:\d{2}):\sWorld triggered "Round_Start"$/,
+    handle: (gameNumber, matches) => {
+      events.emit('match:started', { gameNumber })
+      if (matches[1]) {
+        if (lastRoundStartAt.get(gameNumber) === matches[1]) {
+          events.emit('match/score:reset', { gameNumber })
+        }
+        lastRoundStartAt.set(gameNumber, matches[1])
+      }
+    },
   },
   {
     name: 'game restarted',
@@ -64,7 +80,10 @@ const gameEvents: GameEvent[] = [
     // TODO rename to "game over"
     name: 'match ended',
     regex: /^[\d/\s-:]+World triggered "Game_Over" reason ".*"$/,
-    handle: gameNumber => events.emit('match:ended', { gameNumber }),
+    handle: gameNumber => {
+      lastRoundStartAt.delete(gameNumber)
+      events.emit('match:ended', { gameNumber })
+    },
   },
   {
     name: 'logs uploaded',

--- a/src/games/plugins/match-event-listener.ts
+++ b/src/games/plugins/match-event-listener.ts
@@ -1,4 +1,5 @@
 import fp from 'fastify-plugin'
+import { differenceInSeconds, parse } from 'date-fns'
 import type { GameNumber } from '../../database/models/game.model'
 import { events } from '../../events'
 import type { SteamId64 } from '../../shared/types/steam-id-64'
@@ -23,34 +24,38 @@ interface GameEvent {
 // converts 'Red' and 'Blue' to valid team names
 const fixTeamName = (teamName: string): Tf2Team => teamName.toLowerCase().substring(0, 3) as Tf2Team
 
-// the last Round_Start line seen per game (cleared when a round is won) and
-// whether any Round_Start was seen at all this match; used to detect the
-// doubled Round_Start below
-const lastRoundStart = new Map<GameNumber, { at: string; precededByRoundStart: boolean }>()
+// the last Round_Start line seen per game (cleared when a round ends with a
+// win or a stalemate) and whether any Round_Start was seen at all this match;
+// used to detect the doubled Round_Start below
+const lastRoundStart = new Map<GameNumber, { at: Date; precededByRoundStart: boolean }>()
 const seenRoundStart = new Set<GameNumber>()
+
+const parseLogTimestamp = (timestamp: string) =>
+  parse(timestamp, 'MM/dd/yyyy - HH:mm:ss', new Date())
 
 const gameEvents: GameEvent[] = [
   {
     // TODO rename to "round start"
     name: 'match started',
-    // TF2 logs Round_Start once per regular round, but twice in the same
-    // second when a tournament match (re)starts. A regular round transition
-    // always has a Round_Win between two Round_Starts (which clears the
-    // remembered line below), so a same-second pair can only be the (re)start
-    // doubling — even when log lines arrive with compressed timestamps, as in
-    // e2e log replays. The pair at the initial match start is expected; a pair
-    // preceded by an earlier Round_Start means the match was restarted
-    // mid-game (everyone left to spectator, an admin re-exec'd the config,
+    // TF2 logs Round_Start once per regular round, but twice within the same
+    // second (occasionally straddling a second boundary) when a tournament
+    // match (re)starts. A regular round transition always has a Round_Win or a
+    // Round_Stalemate between two Round_Starts (both clear the remembered line
+    // below), so a pair ≤1s apart can only be the (re)start doubling — even
+    // when log lines arrive with compressed timestamps, as in e2e log replays.
+    // The pair at the initial match start is expected; a pair preceded by an
+    // earlier Round_Start means the match was restarted mid-game (everyone
+    // left to spectator, an admin re-exec'd the config,
     // mp_tournament_restart) and the server reset its scoreboard.
     regex: /^(\d{2}\/\d{2}\/\d{4}\s-\s\d{2}:\d{2}:\d{2}):\sWorld triggered "Round_Start"$/,
     handle: (gameNumber, matches) => {
       events.emit('match:started', { gameNumber })
-      const at = matches[1]
-      if (!at) {
+      if (!matches[1]) {
         return
       }
+      const at = parseLogTimestamp(matches[1])
       const last = lastRoundStart.get(gameNumber)
-      if (last?.at === at) {
+      if (last && Math.abs(differenceInSeconds(at, last.at)) <= 1) {
         if (last.precededByRoundStart) {
           lastRoundStart.delete(gameNumber)
           events.emit('match/score:reset', { gameNumber })
@@ -75,6 +80,15 @@ const gameEvents: GameEvent[] = [
         const winner = fixTeamName(matches[1])
         events.emit('match:roundWon', { gameNumber, winner })
       }
+    },
+  },
+  {
+    name: 'round stalemate',
+    // a stalemate ends a round with no Round_Win line; clear the remembered
+    // Round_Start so the next one is not mistaken for a restart doubling
+    regex: /^\d{2}\/\d{2}\/\d{4}\s-\s\d{2}:\d{2}:\d{2}:\sWorld triggered "Round_Stalemate"$/,
+    handle: gameNumber => {
+      lastRoundStart.delete(gameNumber)
     },
   },
   {

--- a/src/games/plugins/match-event-listener.ts
+++ b/src/games/plugins/match-event-listener.ts
@@ -34,7 +34,11 @@ const gameEvents: GameEvent[] = [
     // TF2 logs Round_Start once per regular round, but twice in the same
     // second when a tournament match (re)starts — e.g. at the initial ready-up,
     // or mid-game when everyone leaves to spectator and readies up again. The
-    // doubled line means the server has just reset its scoreboard.
+    // doubled line means the server has just reset its scoreboard. A regular
+    // round transition always has a Round_Win between two Round_Starts (which
+    // clears the remembered timestamp below), so two same-second Round_Starts
+    // with no round won in between can only be the restart pair — even when
+    // log lines arrive with compressed timestamps, as in e2e log replays.
     regex: /^(\d{2}\/\d{2}\/\d{4}\s-\s\d{2}:\d{2}:\d{2}):\sWorld triggered "Round_Start"$/,
     handle: (gameNumber, matches) => {
       events.emit('match:started', { gameNumber })
@@ -57,6 +61,7 @@ const gameEvents: GameEvent[] = [
     regex:
       /^\d{2}\/\d{2}\/\d{4}\s-\s\d{2}:\d{2}:\d{2}:\sWorld triggered "Round_Win" \(winner "(.+)"\)$/,
     handle: (gameNumber, matches) => {
+      lastRoundStartAt.delete(gameNumber)
       if (matches[1]) {
         const winner = fixTeamName(matches[1])
         events.emit('match:roundWon', { gameNumber, winner })

--- a/src/games/plugins/match-event-listener.ts
+++ b/src/games/plugins/match-event-listener.ts
@@ -51,11 +51,6 @@ const gameEvents: GameEvent[] = [
     },
   },
   {
-    name: 'game restarted',
-    regex: /^\d{2}\/\d{2}\/\d{4}\s-\s\d{2}:\d{2}:\d{2}:\srcon from ".+": command "exec etf2l_.+"$/,
-    handle: gameNumber => events.emit('match:restarted', { gameNumber }),
-  },
-  {
     name: 'round win',
     // https://regex101.com/r/41LfKS/2
     regex:

--- a/src/games/plugins/match-event-listener.ts
+++ b/src/games/plugins/match-event-listener.ts
@@ -23,31 +23,45 @@ interface GameEvent {
 // converts 'Red' and 'Blue' to valid team names
 const fixTeamName = (teamName: string): Tf2Team => teamName.toLowerCase().substring(0, 3) as Tf2Team
 
-// timestamp of the last Round_Start line seen per game; used to detect the
+// the last Round_Start line seen per game (cleared when a round is won) and
+// whether any Round_Start was seen at all this match; used to detect the
 // doubled Round_Start below
-const lastRoundStartAt = new Map<GameNumber, string>()
+const lastRoundStart = new Map<GameNumber, { at: string; precededByRoundStart: boolean }>()
+const seenRoundStart = new Set<GameNumber>()
 
 const gameEvents: GameEvent[] = [
   {
     // TODO rename to "round start"
     name: 'match started',
     // TF2 logs Round_Start once per regular round, but twice in the same
-    // second when a tournament match (re)starts — e.g. at the initial ready-up,
-    // or mid-game when everyone leaves to spectator and readies up again. The
-    // doubled line means the server has just reset its scoreboard. A regular
-    // round transition always has a Round_Win between two Round_Starts (which
-    // clears the remembered timestamp below), so two same-second Round_Starts
-    // with no round won in between can only be the restart pair — even when
-    // log lines arrive with compressed timestamps, as in e2e log replays.
+    // second when a tournament match (re)starts. A regular round transition
+    // always has a Round_Win between two Round_Starts (which clears the
+    // remembered line below), so a same-second pair can only be the (re)start
+    // doubling — even when log lines arrive with compressed timestamps, as in
+    // e2e log replays. The pair at the initial match start is expected; a pair
+    // preceded by an earlier Round_Start means the match was restarted
+    // mid-game (everyone left to spectator, an admin re-exec'd the config,
+    // mp_tournament_restart) and the server reset its scoreboard.
     regex: /^(\d{2}\/\d{2}\/\d{4}\s-\s\d{2}:\d{2}:\d{2}):\sWorld triggered "Round_Start"$/,
     handle: (gameNumber, matches) => {
       events.emit('match:started', { gameNumber })
-      if (matches[1]) {
-        if (lastRoundStartAt.get(gameNumber) === matches[1]) {
+      const at = matches[1]
+      if (!at) {
+        return
+      }
+      const last = lastRoundStart.get(gameNumber)
+      if (last?.at === at) {
+        if (last.precededByRoundStart) {
+          lastRoundStart.delete(gameNumber)
           events.emit('match/score:reset', { gameNumber })
         }
-        lastRoundStartAt.set(gameNumber, matches[1])
+      } else {
+        lastRoundStart.set(gameNumber, {
+          at,
+          precededByRoundStart: seenRoundStart.has(gameNumber),
+        })
       }
+      seenRoundStart.add(gameNumber)
     },
   },
   {
@@ -56,7 +70,7 @@ const gameEvents: GameEvent[] = [
     regex:
       /^\d{2}\/\d{2}\/\d{4}\s-\s\d{2}:\d{2}:\d{2}:\sWorld triggered "Round_Win" \(winner "(.+)"\)$/,
     handle: (gameNumber, matches) => {
-      lastRoundStartAt.delete(gameNumber)
+      lastRoundStart.delete(gameNumber)
       if (matches[1]) {
         const winner = fixTeamName(matches[1])
         events.emit('match:roundWon', { gameNumber, winner })
@@ -81,7 +95,8 @@ const gameEvents: GameEvent[] = [
     name: 'match ended',
     regex: /^[\d/\s-:]+World triggered "Game_Over" reason ".*"$/,
     handle: gameNumber => {
-      lastRoundStartAt.delete(gameNumber)
+      lastRoundStart.delete(gameNumber)
+      seenRoundStart.delete(gameNumber)
       events.emit('match:ended', { gameNumber })
     },
   },

--- a/src/games/plugins/track-match-rounds.ts
+++ b/src/games/plugins/track-match-rounds.ts
@@ -156,6 +156,12 @@ export default fp(
     events.on('match:ended', async ({ gameNumber }) => {
       await collections.gamesRoundProgress.deleteOne({ gameNumber })
     })
+
+    // a match restart aborts the round in progress; drop any partially
+    // observed round data so it doesn't leak into the first post-restart round
+    events.on('match/score:reset', async ({ gameNumber }) => {
+      await collections.gamesRoundProgress.deleteOne({ gameNumber })
+    })
   },
   {
     name: 'track match rounds',

--- a/tests/20-game/12-handle-match-restart.spec.ts
+++ b/tests/20-game/12-handle-match-restart.spec.ts
@@ -6,9 +6,13 @@ test.use({ waitForStage: 'started' })
 test('handles match restart @6v6 @9v9', async ({ page, gameNumber, gameServer }) => {
   const gamePage = new GamePage(page, gameNumber)
   await gamePage.goto()
-  gameServer.log('rcon from "0.0.0.0:35610": command "exec etf2l_6v6_5cp"')
-  await expect(gamePage.gameEvent('Game restarted')).toBeVisible()
 
-  await gameServer.matchStarts()
-  await expect(gamePage.gameEvent('Game started')).toHaveCount(2)
+  await gameServer.roundEnds('blu')
+  await expect(gamePage.page.getByLabel('blu team score')).toHaveText('1')
+
+  // e.g. everyone goes to spectator, then both teams ready up again
+  await gameServer.matchRestarts()
+  await expect(gamePage.gameEvent('Game restarted')).toBeVisible()
+  await expect(gamePage.page.getByLabel('blu team score')).toHaveText('0')
+  await expect(gamePage.page.getByLabel('red team score')).toHaveText('0')
 })

--- a/tests/20-game/20-ignore-stalemate-rounds.spec.ts
+++ b/tests/20-game/20-ignore-stalemate-rounds.spec.ts
@@ -23,5 +23,6 @@ launchGame(
     await expect(gamePage.page.getByLabel('blu team score')).toHaveText('2')
     await expect(gamePage.page.getByLabel('red team score')).toHaveText('1')
     await expect(gamePage.gameEvent('Game restarted')).not.toBeVisible()
+    await expect(gamePage.gameEvent('Game started')).toHaveCount(1)
   },
 )

--- a/tests/20-game/20-ignore-stalemate-rounds.spec.ts
+++ b/tests/20-game/20-ignore-stalemate-rounds.spec.ts
@@ -1,0 +1,24 @@
+import { expect, launchGame } from '../fixtures/launch-game'
+import { GamePage } from '../pages/game.page'
+import { logFixture } from '../fixtures/log-fixture'
+
+launchGame.use({ waitForStage: 'started' })
+
+// Replays the real log of https://logs.tf/4056794 (cp_snakewater_final1, a 6v6
+// 5cp map). Two rounds end in a stalemate, so there is no Round_Win between
+// two Round_Starts. The replay re-stamps all lines to the current second — the
+// post-stalemate Round_Start must not be mistaken for the doubled Round_Start
+// of a match restart.
+launchGame(
+  'does not mistake stalemate rounds for a match restart @6v6 @9v9',
+  async ({ gameNumber, page, gameServer }) => {
+    const gamePage = new GamePage(page, gameNumber)
+    await gamePage.goto()
+
+    await gameServer.feedLogs(logFixture('cp_snakewater_4056794.log'))
+
+    await expect(gamePage.page.getByLabel('blu team score')).toHaveText('2')
+    await expect(gamePage.page.getByLabel('red team score')).toHaveText('1')
+    await expect(gamePage.gameEvent('Game restarted')).not.toBeVisible()
+  },
+)

--- a/tests/20-game/20-ignore-stalemate-rounds.spec.ts
+++ b/tests/20-game/20-ignore-stalemate-rounds.spec.ts
@@ -2,7 +2,10 @@ import { expect, launchGame } from '../fixtures/launch-game'
 import { GamePage } from '../pages/game.page'
 import { logFixture } from '../fixtures/log-fixture'
 
-launchGame.use({ waitForStage: 'started' })
+// the replayed log drives the whole match lifecycle, including the initial
+// doubled Round_Start — starting the match here would make that pair look
+// like a mid-game restart
+launchGame.use({ waitForStage: 'launching' })
 
 // Replays the real log of https://logs.tf/4056794 (cp_snakewater_final1, a 6v6
 // 5cp map). Two rounds end in a stalemate, so there is no Round_Win between

--- a/tests/20-game/21-handle-straddled-match-start.spec.ts
+++ b/tests/20-game/21-handle-straddled-match-start.spec.ts
@@ -22,5 +22,6 @@ launchGame(
     await expect(gamePage.page.getByLabel('red team score')).toHaveText('5')
     await expect(gamePage.page.getByLabel('blu team score')).toHaveText('1')
     await expect(gamePage.gameEvent('Game restarted')).not.toBeVisible()
+    await expect(gamePage.gameEvent('Game started')).toHaveCount(1)
   },
 )

--- a/tests/20-game/21-handle-straddled-match-start.spec.ts
+++ b/tests/20-game/21-handle-straddled-match-start.spec.ts
@@ -2,7 +2,10 @@ import { expect, launchGame } from '../fixtures/launch-game'
 import { GamePage } from '../pages/game.page'
 import { logFixture } from '../fixtures/log-fixture'
 
-launchGame.use({ waitForStage: 'started' })
+// the replayed log drives the whole match lifecycle, including the initial
+// doubled Round_Start — starting the match here would make that pair look
+// like a mid-game restart
+launchGame.use({ waitForStage: 'launching' })
 
 // Replays the real log of https://logs.tf/4084159 (cp_process_f12, a 6v6 5cp
 // map). The doubled Round_Start at the match start straddles a second boundary

--- a/tests/20-game/21-handle-straddled-match-start.spec.ts
+++ b/tests/20-game/21-handle-straddled-match-start.spec.ts
@@ -1,0 +1,23 @@
+import { expect, launchGame } from '../fixtures/launch-game'
+import { GamePage } from '../pages/game.page'
+import { logFixture } from '../fixtures/log-fixture'
+
+launchGame.use({ waitForStage: 'started' })
+
+// Replays the real log of https://logs.tf/4084159 (cp_process_f12, a 6v6 5cp
+// map). The doubled Round_Start at the match start straddles a second boundary
+// (16:35:01 / 16:35:02) — it must be recognized as the initial match start
+// doubling, not a mid-game restart, and the score must be kept as-is.
+launchGame(
+  'handles a match start doubled across a second boundary @6v6 @9v9',
+  async ({ gameNumber, page, gameServer }) => {
+    const gamePage = new GamePage(page, gameNumber)
+    await gamePage.goto()
+
+    await gameServer.feedLogs(logFixture('cp_process_4084159.log'))
+
+    await expect(gamePage.page.getByLabel('red team score')).toHaveText('5')
+    await expect(gamePage.page.getByLabel('blu team score')).toHaveText('1')
+    await expect(gamePage.gameEvent('Game restarted')).not.toBeVisible()
+  },
+)

--- a/tests/fixtures/logs/cp_process_4084159.log
+++ b/tests/fixtures/logs/cp_process_4084159.log
@@ -1,0 +1,56 @@
+L 07/09/2026 - 16:35:01: World triggered "Round_Start"
+L 07/09/2026 - 16:35:02: World triggered "Round_Start"
+L 07/09/2026 - 16:36:15: Team "Red" triggered "pointcaptured" (cp "2") (cpname "Middle Point") (numcappers "1") (player1 "wG tomciopaluch<11><[U:1:124205952]><Red>") (position1 "-92 -68 487") 
+L 07/09/2026 - 16:36:24: Team "Red" triggered "pointcaptured" (cp "1") (cpname "Blue Mini-Spire") (numcappers "2") (player1 "Drozdzers<5><[U:1:40373966]><Red>") (position1 "-1888 -2214 768") (player2 "wG tomciopaluch<11><[U:1:124205952]><Red>") (position2 "-1594 -2248 775") 
+L 07/09/2026 - 16:39:05: Team "Red" triggered "pointcaptured" (cp "0") (cpname "Blue Final Point") (numcappers "3") (player1 "Drozdzers<5><[U:1:40373966]><Red>") (position1 "-3472 -1305 583") (player2 "wG tomciopaluch<11><[U:1:124205952]><Red>") (position2 "-3575 -1211 583") (player3 "Amadi<14><[U:1:326278245]><Red>") (position3 "-3583 -1164 578") 
+L 07/09/2026 - 16:39:05: World triggered "Round_Win" (winner "Red")
+L 07/09/2026 - 16:39:05: World triggered "Round_Length" (seconds "243.81")
+L 07/09/2026 - 16:39:05: Team "Red" current score "1" with "6" players
+L 07/09/2026 - 16:39:05: Team "Blue" current score "0" with "6" players
+L 07/09/2026 - 16:39:22: World triggered "Round_Start"
+L 07/09/2026 - 16:40:10: Team "Blue" triggered "pointcaptured" (cp "2") (cpname "Middle Point") (numcappers "1") (player1 "deli<7><[U:1:56245732]><Blue>") (position1 "90 -48 487") 
+L 07/09/2026 - 16:40:49: Team "Red" triggered "pointcaptured" (cp "2") (cpname "Middle Point") (numcappers "4") (player1 "Drozdzers<5><[U:1:40373966]><Red>") (position1 "-402 -146 480") (player2 "Dosu<6><[U:1:186867964]><Red>") (position2 "-49 -26 487") (player3 "wG tomciopaluch<11><[U:1:124205952]><Red>") (position3 "-343 -74 480") (player4 "Amadi<14><[U:1:326278245]><Red>") (position4 "-320 -102 480") 
+L 07/09/2026 - 16:41:02: Team "Red" triggered "pointcaptured" (cp "1") (cpname "Blue Mini-Spire") (numcappers "4") (player1 "Drozdzers<5><[U:1:40373966]><Red>") (position1 "-1799 -2151 768") (player2 "Dosu<6><[U:1:186867964]><Red>") (position2 "-1684 -2177 775") (player3 "wG tomciopaluch<11><[U:1:124205952]><Red>") (position3 "-1595 -2263 775") (player4 "Amadi<14><[U:1:326278245]><Red>") (position4 "-1714 -2139 775") 
+L 07/09/2026 - 16:42:20: Team "Blue" triggered "pointcaptured" (cp "1") (cpname "Blue Mini-Spire") (numcappers "3") (player1 "CR8<8><[U:1:83755882]><Blue>") (position1 "-1764 -2084 768") (player2 "wonszu<4><[U:1:60952177]><Blue>") (position2 "-1713 -2055 773") (player3 "mejf tajson<10><[U:1:202138486]><Blue>") (position3 "-1647 -2271 775") 
+L 07/09/2026 - 16:43:53: Team "Red" triggered "pointcaptured" (cp "1") (cpname "Blue Mini-Spire") (numcappers "3") (player1 "Dosu<6><[U:1:186867964]><Red>") (position1 "-1624 -2187 775") (player2 "wG tomciopaluch<11><[U:1:124205952]><Red>") (position2 "-1726 -2212 775") (player3 "wG papito<12><[U:1:248256384]><Red>") (position3 "-1780 -2166 771") 
+L 07/09/2026 - 16:44:22: Team "Red" triggered "pointcaptured" (cp "0") (cpname "Blue Final Point") (numcappers "1") (player1 "maly<13><[U:1:114143419]><Red>") (position1 "-3577 -1316 583") 
+L 07/09/2026 - 16:44:22: World triggered "Round_Win" (winner "Red")
+L 07/09/2026 - 16:44:22: World triggered "Round_Length" (seconds "300.15")
+L 07/09/2026 - 16:44:22: Team "Red" current score "2" with "6" players
+L 07/09/2026 - 16:44:22: Team "Blue" current score "0" with "6" players
+L 07/09/2026 - 16:44:39: World triggered "Round_Start"
+L 07/09/2026 - 16:45:21: Team "Red" triggered "pointcaptured" (cp "2") (cpname "Middle Point") (numcappers "1") (player1 "Amadi<14><[U:1:326278245]><Red>") (position1 "-356 -127 480") 
+L 07/09/2026 - 16:45:32: Team "Red" triggered "pointcaptured" (cp "1") (cpname "Blue Mini-Spire") (numcappers "2") (player1 "wG tomciopaluch<11><[U:1:124205952]><Red>") (position1 "-1789 -2234 768") (player2 "Amadi<14><[U:1:326278245]><Red>") (position2 "-1889 -2171 768") 
+L 07/09/2026 - 16:46:00: Team "Red" triggered "pointcaptured" (cp "0") (cpname "Blue Final Point") (numcappers "1") (player1 "wG tomciopaluch<11><[U:1:124205952]><Red>") (position1 "-3599 -1369 583") 
+L 07/09/2026 - 16:46:00: World triggered "Round_Win" (winner "Red")
+L 07/09/2026 - 16:46:00: World triggered "Round_Length" (seconds "80.36")
+L 07/09/2026 - 16:46:00: Team "Red" current score "3" with "6" players
+L 07/09/2026 - 16:46:00: Team "Blue" current score "0" with "6" players
+L 07/09/2026 - 16:46:17: World triggered "Round_Start"
+L 07/09/2026 - 16:47:04: Team "Red" triggered "pointcaptured" (cp "2") (cpname "Middle Point") (numcappers "1") (player1 "Amadi<14><[U:1:326278245]><Red>") (position1 "-336 -113 480") 
+L 07/09/2026 - 16:47:12: Team "Red" triggered "pointcaptured" (cp "1") (cpname "Blue Mini-Spire") (numcappers "1") (player1 "Amadi<14><[U:1:326278245]><Red>") (position1 "-1764 -2153 775") 
+L 07/09/2026 - 16:47:40: Team "Red" triggered "pointcaptured" (cp "0") (cpname "Blue Final Point") (numcappers "2") (player1 "Drozdzers<5><[U:1:40373966]><Red>") (position1 "-3507 -1288 583") (player2 "Dosu<6><[U:1:186867964]><Red>") (position2 "-3399 -1167 576") 
+L 07/09/2026 - 16:47:40: World triggered "Round_Win" (winner "Red")
+L 07/09/2026 - 16:47:40: World triggered "Round_Length" (seconds "83.67")
+L 07/09/2026 - 16:47:40: Team "Red" current score "4" with "6" players
+L 07/09/2026 - 16:47:40: Team "Blue" current score "0" with "6" players
+L 07/09/2026 - 16:47:58: World triggered "Round_Start"
+L 07/09/2026 - 16:48:53: Team "Blue" triggered "pointcaptured" (cp "2") (cpname "Middle Point") (numcappers "1") (player1 "deli<7><[U:1:56245732]><Blue>") (position1 "194 -10 480") 
+L 07/09/2026 - 16:49:10: Team "Blue" triggered "pointcaptured" (cp "3") (cpname "Red Mini-Spire") (numcappers "1") (player1 "deli<7><[U:1:56245732]><Blue>") (position1 "1737 2213 775") 
+L 07/09/2026 - 16:49:12: Team "Blue" triggered "pointcaptured" (cp "4") (cpname "Red Final Point") (numcappers "3") (player1 "wonszu<4><[U:1:60952177]><Blue>") (position1 "3604 1195 583") (player2 "Zuri<9><[U:1:440805949]><Blue>") (position2 "3609 1322 583") (player3 "mejf tajson<10><[U:1:202138486]><Blue>") (position3 "3592 1321 583") 
+L 07/09/2026 - 16:49:12: World triggered "Round_Win" (winner "Blue")
+L 07/09/2026 - 16:49:12: World triggered "Round_Length" (seconds "74.11")
+L 07/09/2026 - 16:49:12: Team "Red" current score "4" with "6" players
+L 07/09/2026 - 16:49:12: Team "Blue" current score "1" with "6" players
+L 07/09/2026 - 16:49:29: World triggered "Round_Start"
+L 07/09/2026 - 16:51:00: Team "Blue" triggered "pointcaptured" (cp "2") (cpname "Middle Point") (numcappers "4") (player1 "CR8<8><[U:1:83755882]><Blue>") (position1 "-276 -7 480") (player2 "wonszu<4><[U:1:60952177]><Blue>") (position2 "343 -103 480") (player3 "Zuri<9><[U:1:440805949]><Blue>") (position3 "-239 11 480") (player4 "mejf tajson<10><[U:1:202138486]><Blue>") (position4 "219 -17 480") 
+L 07/09/2026 - 16:53:16: Team "Red" triggered "pointcaptured" (cp "2") (cpname "Middle Point") (numcappers "2") (player1 "Dosu<6><[U:1:186867964]><Red>") (position1 "-198 11 480") (player2 "Amadi<14><[U:1:326278245]><Red>") (position2 "-318 -76 480") 
+L 07/09/2026 - 16:53:44: Team "Red" triggered "pointcaptured" (cp "1") (cpname "Blue Mini-Spire") (numcappers "1") (player1 "Amadi<14><[U:1:326278245]><Red>") (position1 "-1842 -2146 768") 
+L 07/09/2026 - 16:53:55: Team "Red" triggered "pointcaptured" (cp "0") (cpname "Blue Final Point") (numcappers "2") (player1 "Drozdzers<5><[U:1:40373966]><Red>") (position1 "-3474 -1230 583") (player2 "maly<13><[U:1:114143419]><Red>") (position2 "-3627 -1302 583") 
+L 07/09/2026 - 16:53:55: World triggered "Round_Win" (winner "Red")
+L 07/09/2026 - 16:53:55: World triggered "Round_Length" (seconds "266.69")
+L 07/09/2026 - 16:53:55: Team "Red" current score "5" with "6" players
+L 07/09/2026 - 16:53:55: Team "Blue" current score "1" with "6" players
+L 07/09/2026 - 16:54:12: World triggered "Game_Over" reason "Reached Win Limit"
+L 07/09/2026 - 16:54:12: Team "Red" final score "5" with "2" players
+L 07/09/2026 - 16:54:12: Team "Blue" final score "1" with "0" players

--- a/tests/fixtures/logs/cp_snakewater_4056794.log
+++ b/tests/fixtures/logs/cp_snakewater_4056794.log
@@ -1,0 +1,59 @@
+L 05/16/2026 - 16:33:46: World triggered "Round_Start"
+L 05/16/2026 - 16:33:46: World triggered "Round_Start"
+L 05/16/2026 - 16:34:48: Team "Blue" triggered "pointcaptured" (cp "2") (cpname "#CP_cap_cp3") (numcappers "1") (player1 "mejf tajson<12><[U:1:202138486]><Blue>") (position1 "708 0 109") 
+L 05/16/2026 - 16:34:57: Team "Blue" triggered "pointcaptured" (cp "3") (cpname "the RED Forward Point") (numcappers "2") (player1 "front<3><[U:1:1010740820]><Blue>") (position1 "2756 -1813 -111") (player2 "kefju<9><[U:1:124205952]><Blue>") (position2 "2674 -1810 -111") 
+L 05/16/2026 - 16:35:39: Team "Blue" triggered "pointcaptured" (cp "4") (cpname "#CP_cap_red_cp1") (numcappers "2") (player1 "kefju<9><[U:1:124205952]><Blue>") (position1 "4984 -1428 -151") (player2 "Sochin<15><[U:1:1007147137]><Blue>") (position2 "4963 -1647 -144") 
+L 05/16/2026 - 16:35:39: World triggered "Round_Win" (winner "Blue")
+L 05/16/2026 - 16:35:39: World triggered "Round_Length" (seconds "113.36")
+L 05/16/2026 - 16:35:39: Team "Red" current score "0" with "6" players
+L 05/16/2026 - 16:35:39: Team "Blue" current score "1" with "6" players
+L 05/16/2026 - 16:35:56: World triggered "Round_Start"
+L 05/16/2026 - 16:37:14: Team "Red" triggered "pointcaptured" (cp "2") (cpname "#CP_cap_cp3") (numcappers "1") (player1 "Twelvef<4><[U:1:931860472]><Red>") (position1 "547 119 67") 
+L 05/16/2026 - 16:37:26: Team "Red" triggered "pointcaptured" (cp "1") (cpname "the BLU Forward Point") (numcappers "1") (player1 "Twelvef<4><[U:1:931860472]><Red>") (position1 "-1720 2453 -111") 
+L 05/16/2026 - 16:37:47: Team "Red" triggered "pointcaptured" (cp "0") (cpname "#CP_cap_blue_cp1") (numcappers "2") (player1 "CR8<10><[U:1:83755882]><Red>") (position1 "-4044 1895 -151") (player2 "wonszu<8><[U:1:60952177]><Red>") (position2 "-4143 1905 -151") 
+L 05/16/2026 - 16:37:47: World triggered "Round_Win" (winner "Red")
+L 05/16/2026 - 16:37:47: World triggered "Round_Length" (seconds "110.82")
+L 05/16/2026 - 16:37:47: Team "Red" current score "1" with "6" players
+L 05/16/2026 - 16:37:47: Team "Blue" current score "1" with "6" players
+L 05/16/2026 - 16:38:04: World triggered "Round_Start"
+L 05/16/2026 - 16:39:36: Team "Blue" triggered "pointcaptured" (cp "2") (cpname "#CP_cap_cp3") (numcappers "2") (player1 "kefju<9><[U:1:124205952]><Blue>") (position1 "665 110 68") (player2 "Sochin<15><[U:1:1007147137]><Blue>") (position2 "591 301 67") 
+L 05/16/2026 - 16:39:56: Team "Blue" triggered "pointcaptured" (cp "3") (cpname "the RED Forward Point") (numcappers "2") (player1 "kefju<9><[U:1:124205952]><Blue>") (position1 "2668 -1931 -104") (player2 "baichi<11><[U:1:288579558]><Blue>") (position2 "2605 -1816 -104") 
+L 05/16/2026 - 16:41:02: Team "Red" triggered "pointcaptured" (cp "3") (cpname "the RED Forward Point") (numcappers "2") (player1 "sam sung el dzekson<13><[U:1:148896172]><Red>") (position1 "2505 -1704 -56") (player2 "Zuri<14><[U:1:440805949]><Red>") (position2 "2733 -1807 -111") 
+L 05/16/2026 - 16:41:17: Team "Blue" triggered "pointcaptured" (cp "3") (cpname "the RED Forward Point") (numcappers "1") (player1 "baichi<11><[U:1:288579558]><Blue>") (position1 "2581 -1981 -104") 
+L 05/16/2026 - 16:46:17: World triggered "Round_Stalemate"
+L 05/16/2026 - 16:46:17: Team "Red" current score "1" with "6" players
+L 05/16/2026 - 16:46:17: Team "Blue" current score "1" with "6" players
+L 05/16/2026 - 16:46:34: World triggered "Round_Start"
+L 05/16/2026 - 16:47:34: Team "Blue" triggered "pointcaptured" (cp "2") (cpname "#CP_cap_cp3") (numcappers "1") (player1 "baichi<11><[U:1:288579558]><Blue>") (position1 "594 135 67") 
+L 05/16/2026 - 16:48:19: Team "Blue" triggered "pointcaptured" (cp "3") (cpname "the RED Forward Point") (numcappers "2") (player1 "front<3><[U:1:1010740820]><Blue>") (position1 "2684 -1890 -108") (player2 "Sochin<15><[U:1:1007147137]><Blue>") (position2 "2682 -1775 -111") 
+L 05/16/2026 - 16:53:19: World triggered "Round_Stalemate"
+L 05/16/2026 - 16:53:19: Team "Red" current score "1" with "6" players
+L 05/16/2026 - 16:53:19: Team "Blue" current score "1" with "6" players
+L 05/16/2026 - 16:53:36: World triggered "Round_Start"
+L 05/16/2026 - 16:54:33: Team "Red" triggered "pointcaptured" (cp "2") (cpname "#CP_cap_cp3") (numcappers "3") (player1 "CR8<10><[U:1:83755882]><Red>") (position1 "494 140 67") (player2 "sam sung el dzekson<13><[U:1:148896172]><Red>") (position2 "554 273 67") (player3 "Zuri<14><[U:1:440805949]><Red>") (position3 "604 86 64") 
+L 05/16/2026 - 16:56:51: Team "Blue" triggered "pointcaptured" (cp "2") (cpname "#CP_cap_cp3") (numcappers "2") (player1 "kefju<9><[U:1:124205952]><Blue>") (position1 "703 58 64") (player2 "Sochin<15><[U:1:1007147137]><Blue>") (position2 "391 170 64") 
+L 05/16/2026 - 16:57:27: Team "Blue" triggered "pointcaptured" (cp "3") (cpname "the RED Forward Point") (numcappers "2") (player1 "baichi<11><[U:1:288579558]><Blue>") (position1 "2484 -1874 -104") (player2 "mejf tajson<12><[U:1:202138486]><Blue>") (position2 "2578 -1933 -104") 
+L 05/16/2026 - 16:57:40: Team "Red" triggered "pointcaptured" (cp "3") (cpname "the RED Forward Point") (numcappers "3") (player1 "Twelvef<4><[U:1:931860472]><Red>") (position1 "2497 -1970 -104") (player2 "CR8<10><[U:1:83755882]><Red>") (position2 "2496 -1914 -104") (player3 "sam sung el dzekson<13><[U:1:148896172]><Red>") (position3 "2510 -2056 -54") 
+L 05/16/2026 - 16:58:10: Team "Red" triggered "pointcaptured" (cp "2") (cpname "#CP_cap_cp3") (numcappers "3") (player1 "CR8<10><[U:1:83755882]><Red>") (position1 "376 323 64") (player2 "wonszu<8><[U:1:60952177]><Red>") (position2 "552 284 67") (player3 "Zuri<14><[U:1:440805949]><Red>") (position3 "643 74 64") 
+L 05/16/2026 - 16:58:45: Team "Red" triggered "pointcaptured" (cp "1") (cpname "the BLU Forward Point") (numcappers "1") (player1 "Twelvef<4><[U:1:931860472]><Red>") (position1 "-1690 2345 -111") 
+L 05/16/2026 - 16:59:26: Team "Blue" triggered "pointcaptured" (cp "1") (cpname "the BLU Forward Point") (numcappers "5") (player1 "front<3><[U:1:1010740820]><Blue>") (position1 "-1370 2118 -111") (player2 "😡alov😡<5><[U:1:248256384]><Blue>") (position2 "-1379 2148 -111") (player3 "baichi<11><[U:1:288579558]><Blue>") (position3 "-1576 2365 -104") (player4 "mejf tajson<12><[U:1:202138486]><Blue>") (position4 "-1404 2333 -92") (player5 "Sochin<15><[U:1:1007147137]><Blue>") (position5 "-1505 2440 -111") 
+L 05/16/2026 - 16:59:55: Team "Blue" triggered "pointcaptured" (cp "2") (cpname "#CP_cap_cp3") (numcappers "1") (player1 "baichi<11><[U:1:288579558]><Blue>") (position1 "628 186 67") 
+L 05/16/2026 - 17:00:09: Team "Blue" triggered "pointcaptured" (cp "3") (cpname "the RED Forward Point") (numcappers "2") (player1 "kefju<9><[U:1:124205952]><Blue>") (position1 "2738 -1797 -111") (player2 "baichi<11><[U:1:288579558]><Blue>") (position2 "2521 -1914 -104") 
+L 05/16/2026 - 17:00:23: Team "Blue" triggered "pointcaptured" (cp "4") (cpname "#CP_cap_red_cp1") (numcappers "4") (player1 "😡alov😡<5><[U:1:248256384]><Blue>") (position1 "5041 -1473 -151") (player2 "baichi<11><[U:1:288579558]><Blue>") (position2 "5163 -1608 -144") (player3 "mejf tajson<12><[U:1:202138486]><Blue>") (position3 "5121 -1806 -125") (player4 "Sochin<15><[U:1:1007147137]><Blue>") (position4 "4994 -1765 -151") 
+L 05/16/2026 - 17:00:23: World triggered "Round_Win" (winner "Blue")
+L 05/16/2026 - 17:00:23: World triggered "Round_Length" (seconds "407.40")
+L 05/16/2026 - 17:00:23: Team "Red" current score "1" with "6" players
+L 05/16/2026 - 17:00:23: Team "Blue" current score "2" with "6" players
+L 05/16/2026 - 17:00:40: World triggered "Round_Start"
+L 05/16/2026 - 17:01:48: Team "Blue" triggered "pointcaptured" (cp "2") (cpname "#CP_cap_cp3") (numcappers "2") (player1 "kefju<9><[U:1:124205952]><Blue>") (position1 "512 311 67") (player2 "baichi<11><[U:1:288579558]><Blue>") (position2 "482 158 67") 
+L 05/16/2026 - 17:02:18: Team "Red" triggered "pointcaptured" (cp "2") (cpname "#CP_cap_cp3") (numcappers "2") (player1 "Twelvef<4><[U:1:931860472]><Red>") (position1 "346 392 64") (player2 "wonszu<8><[U:1:60952177]><Red>") (position2 "483 0 64") 
+L 05/16/2026 - 17:02:33: Team "Red" triggered "pointcaptured" (cp "1") (cpname "the BLU Forward Point") (numcappers "2") (player1 "sam sung el dzekson<13><[U:1:148896172]><Red>") (position1 "-1701 2495 -111") (player2 "Zuri<14><[U:1:440805949]><Red>") (position2 "-1337 2153 -111") 
+L 05/16/2026 - 17:03:01: Team "Blue" triggered "pointcaptured" (cp "1") (cpname "the BLU Forward Point") (numcappers "1") (player1 "kefju<9><[U:1:124205952]><Blue>") (position1 "-1622 2321 -106") 
+L 05/16/2026 - 17:03:21: Team "Red" triggered "pointcaptured" (cp "1") (cpname "the BLU Forward Point") (numcappers "1") (player1 "Twelvef<4><[U:1:931860472]><Red>") (position1 "-1617 2192 -111") 
+L 05/16/2026 - 17:03:44: World triggered "Round_Win" (winner "Blue")
+L 05/16/2026 - 17:03:44: World triggered "Round_Length" (seconds "184.09")
+L 05/16/2026 - 17:03:44: Team "Red" current score "1" with "6" players
+L 05/16/2026 - 17:03:44: Team "Blue" current score "2" with "6" players
+L 05/16/2026 - 17:04:02: World triggered "Game_Over" reason "Reached Time Limit"
+L 05/16/2026 - 17:04:02: Team "Red" final score "1" with "3" players
+L 05/16/2026 - 17:04:02: Team "Blue" final score "2" with "2" players

--- a/tests/game-server-simulator.ts
+++ b/tests/game-server-simulator.ts
@@ -373,7 +373,7 @@ export class GameServerSimulator {
     const header = Buffer.from([255, 255, 255, 255, 0x53])
     const logSecret = Buffer.from(this.logSecret ?? '')
     const magicStringEnd = Buffer.from('L ')
-    const timeStamp = format(new Date(), 'dd/MM/yyyy - HH:mm:ss')
+    const timeStamp = format(new Date(), 'MM/dd/yyyy - HH:mm:ss')
     const payloadBuffer = Buffer.from(`${timeStamp}: ${payload}`)
     return Buffer.concat([header, logSecret, magicStringEnd, payloadBuffer, Buffer.from([0, 0])])
   }

--- a/tests/game-server-simulator.ts
+++ b/tests/game-server-simulator.ts
@@ -302,6 +302,17 @@ export class GameServerSimulator {
     await delay(this.eventDelay / 2)
   }
 
+  // a tournament match restart logs Round_Start twice in the same second
+  async matchRestarts() {
+    await delay(this.eventDelay / 2)
+    this.log('World triggered "Round_Start"')
+    this.log('World triggered "Round_Start"')
+    this.roundStartTimestamp = Date.now()
+    this.score.blu = 0
+    this.score.red = 0
+    await delay(this.eventDelay / 2)
+  }
+
   async matchEnds() {
     const playersPerTeam = this.addedPlayers.length / 2
     await delay(this.eventDelay / 2)


### PR DESCRIPTION
## Problem

In [game 7615](https://tf2pickup.pl/games/7615) the final score was "corrected" from the true 5:3 to a wrong 5:4. After round 1, everyone left to spectator to sort out a substitute, which forced a tournament match restart — TF2 reset its scoreboard to 0:0, but the site:

- kept its pre-restart score (1:0), since the only restart detection was the `exec etf2l_*` rcon log line,
- skipped the first post-restart round win as "score is the same, not updating",
- uploaded the full log (including the aborted round) to logs.tf, whose parsed score counted 9 round wins instead of 8 — and `reconcileScoreWithLogsTf` then overwrote the correct live score with it.

## Fix

TF2 logs `Round_Start` twice in the same second when a tournament match (re)starts, and once for regular round transitions — that doubled line is the restart fingerprint (verified against the raw log of game 7615). It fires for every restart cause: everyone-to-spec, `mp_tournament_restart`, config re-exec. Two checks keep it precise:

- a regular round transition always has a `Round_Win` between two `Round_Start`s, so only a same-second pair with no round won in between matches — which keeps the detection correct even when log lines arrive with compressed timestamps (as in the e2e log replays, which re-stamp fixture lines with the current time);
- the doubled pair at the initial match start is the first `Round_Start` of the match, while a genuine restart pair is always preceded by an earlier one — so the initial pair is told apart structurally, deterministically, and a restart is recorded at any score, including 0:0.

The flow: `match-event-listener` detects the pair and emits `match/score:reset`; `match-event-handler` zeroes the tracked score, pushes a `gameRestarted` timeline event and emits `game:restarted`; `game-log-collector` prunes the stored game logs on it, so the backend-uploaded log contains only the restarted match and logs.tf's parsed score agrees with ours — no phantom correction; `track-match-rounds` drops partially observed round data so pre-restart captures don't leak into the first post-restart round.

The old `match:restarted` flow (detection via the `exec etf2l_*` rcon line) is deleted — it was a narrower duplicate of the doubled-`Round_Start` detection, since a config re-exec puts the match back at ready-up exactly like everyone-to-spec does. All restarts now converge on `game:restarted`. Two minor semantic changes: the game no longer flips back to `launching` during an exec-triggered ready-up (the restart is recorded when the ready-up completes instead), and game logs are no longer pruned at the launch-time config exec (which only trimmed a few seconds of rcon echo).

Known limitation: instances using the gameserver (TFTrue) upload method upload the server's complete log file, which we can't prune, so logs.tf reconciliation could still miscorrect restarted games there. tf2pickup.pl uses the backend upload method and is not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)