### PR TITLE
fix(game-servers): free static game servers when a game is reassigned

### DIFF
--- a/src/static-game-servers/plugins/free-game-servers.test.ts
+++ b/src/static-game-servers/plugins/free-game-servers.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { GameServerProvider, GameState } from '../../database/models/game.model'
+import type { GameModel } from '../../database/models/game.model'
+
+const emitter = new EventEmitter()
+
+vi.mock('../../events', () => ({
+  events: {
+    on: (event: string, handler: (...args: unknown[]) => void) => emitter.on(event, handler),
+  },
+}))
+
+vi.mock('../update', () => ({
+  update: vi.fn(),
+}))
+
+vi.mock('../../tasks', () => ({
+  tasks: {
+    register: vi.fn(),
+    schedule: vi.fn(),
+  },
+}))
+
+vi.mock('../../logger', () => ({
+  logger: { error: vi.fn() },
+}))
+
+import freeGameServers from './free-game-servers'
+import { update } from '../update'
+
+function makeGame(gameServer?: Partial<GameModel['gameServer']>): GameModel {
+  return {
+    number: 6862,
+    state: GameState.started,
+    ...(gameServer && { gameServer }),
+  } as GameModel
+}
+
+function emit(event: string, params: unknown): Promise<void> {
+  emitter.emit(event, params)
+  return new Promise(resolve => setImmediate(resolve))
+}
+
+describe('free game servers on reassignment', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    emitter.removeAllListeners()
+    await freeGameServers(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      {},
+    )
+  })
+
+  it('frees the old static server when the game is reassigned to another server', async () => {
+    await emit('game:updated', {
+      before: makeGame({ provider: GameServerProvider.static, id: 'srv-8', name: '#8' }),
+      after: makeGame({ provider: GameServerProvider.servemeTf, id: 'srv-x', name: 'serveme' }),
+    })
+    expect(update).toHaveBeenCalledWith({ id: 'srv-8', game: 6862 }, { $unset: { game: 1 } })
+  })
+
+  it('does nothing when the game server did not change', async () => {
+    const gameServer = { provider: GameServerProvider.static, id: 'srv-8', name: '#8' }
+    await emit('game:updated', {
+      before: makeGame(gameServer),
+      after: makeGame(gameServer),
+    })
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the previous server was not static', async () => {
+    await emit('game:updated', {
+      before: makeGame({ provider: GameServerProvider.servemeTf, id: 'srv-x', name: 'serveme' }),
+      after: makeGame({ provider: GameServerProvider.static, id: 'srv-8', name: '#8' }),
+    })
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('does nothing on the initial assignment', async () => {
+    await emit('game:updated', {
+      before: makeGame(),
+      after: makeGame({ provider: GameServerProvider.static, id: 'srv-8', name: '#8' }),
+    })
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when the old server is already freed', async () => {
+    vi.mocked(update).mockRejectedValue(new Error('not found'))
+    await emit('game:updated', {
+      before: makeGame({ provider: GameServerProvider.static, id: 'srv-8', name: '#8' }),
+      after: makeGame({ provider: GameServerProvider.static, id: 'srv-6', name: '#6' }),
+    })
+    expect(update).toHaveBeenCalled()
+  })
+})

--- a/src/static-game-servers/plugins/free-game-servers.ts
+++ b/src/static-game-servers/plugins/free-game-servers.ts
@@ -4,6 +4,7 @@ import { update } from '../update'
 import { tasks } from '../../tasks'
 import { secondsToMilliseconds } from 'date-fns'
 import { GameServerProvider, GameState } from '../../database/models/game.model'
+import { logger } from '../../logger'
 
 const freeGameServerDelay = secondsToMilliseconds(30)
 
@@ -12,6 +13,26 @@ export default fp(
   async () => {
     tasks.register('staticGameServers:free', async ({ id }) => {
       await update({ id }, { $unset: { game: 1 } })
+    })
+
+    events.on('game:updated', async ({ before, after }) => {
+      const previous = before.gameServer
+      if (
+        previous?.provider !== GameServerProvider.static ||
+        (after.gameServer?.provider === GameServerProvider.static &&
+          after.gameServer.id === previous.id)
+      ) {
+        return
+      }
+
+      try {
+        await update({ id: previous.id, game: before.number }, { $unset: { game: 1 } })
+      } catch (error) {
+        logger.error(
+          { error },
+          `failed to free static game server ${previous.name} after game #${before.number} was reassigned`,
+        )
+      }
     })
 
     events.on('game:ended', async ({ game }) => {


### PR DESCRIPTION
## Problem

Reported by tf2pickup.fi: static game servers get stuck as assigned to an old game (e.g. two servers stuck on game #6862), and stay unavailable until an admin manually clicks the ✕ to unassign them.

## Root cause

The only path that clears a static server's `game` field is the `game:ended` handler in `free-game-servers.ts`, and it frees only the **currently** assigned server (`game.gameServer`). When an admin reassigns a game to a different server (as happened on game #6862: tf2pickup.fi #8 → tf2pickup.fi #6 → OmerBrigade #02 after configure errors), the previously assigned static servers keep `game: <number>` forever and are excluded from `findFree()`.

## Fix

Listen to `game:updated` in the same plugin and free the previous static server whenever the game's server changes to a different one. The update filter includes the game number so a server that was already freed (or re-purposed) is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)