### PR TITLE
chore: migrate Claude config to Codex

### DIFF
--- a/.codex/skills/generate-og-cards/SKILL.md
+++ b/.codex/skills/generate-og-cards/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: generate-og-cards
+description: Regenerate the static branded social/OpenGraph cards in public/og-image.png and public/branding/*/og-image.png by compositing each logo onto bg.png at 1200x630. Use when a logo or bg.png changes, a branding instance is added, or static OG fallback cards need refreshing.
+---
+
+# Generate static branded OG cards
+
+The static `1200x630` social card at `/og-image.png` is the default `og:image` and the fallback when dynamic game or player card rendering fails. Static serving checks branding directories before `public/`, so each branding instance with a `logo.png` needs its own committed `og-image.png`.
+
+The generator cover-crops `public/bg.png` and centers a logo scaled to fit `760x220`.
+
+## Regenerate cards
+
+Require ImageMagick (`magick`; for example, `brew install imagemagick`). From any repository directory, run:
+
+```bash
+.codex/skills/generate-og-cards/scripts/generate-og-cards.sh
+```
+
+It regenerates the default card and one card for each `public/branding/*/` directory containing `logo.png`.
+
+## Verify and commit
+
+- Visually inspect `public/og-image.png` and at least one branded output; the logo must be centered and legible.
+- Stage the changed `og-image.png` assets. `pnpm build` copies `public/` to `dist/public` automatically.
+- Do not use this for dynamic per-game or per-player cards; those are generated at request time in `src/og-image/`.

--- a/.codex/skills/generate-og-cards/agents/openai.yaml
+++ b/.codex/skills/generate-og-cards/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Generate OG Cards"
+  short_description: "Regenerate branded OpenGraph image cards"
+  default_prompt: "Use $generate-og-cards to refresh the static branded social cards."

--- a/.codex/skills/generate-og-cards/agents/openai.yaml
+++ b/.codex/skills/generate-og-cards/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Generate OG Cards"
-  short_description: "Regenerate branded OpenGraph image cards"
-  default_prompt: "Use $generate-og-cards to refresh the static branded social cards."
+  display_name: 'Generate OG Cards'
+  short_description: 'Regenerate branded OpenGraph image cards'
+  default_prompt: 'Use $generate-og-cards to refresh the static branded social cards.'

--- a/.codex/skills/generate-og-cards/scripts/generate-og-cards.sh
+++ b/.codex/skills/generate-og-cards/scripts/generate-og-cards.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Regenerate static branded social cards (1200x630) from the site background and logos.
+set -euo pipefail
+
+if ! command -v magick >/dev/null 2>&1; then
+  echo "error: ImageMagick 'magick' not found — install it (e.g. brew install imagemagick)" >&2
+  exit 1
+fi
+
+root="$(git rev-parse --show-toplevel)"
+public="$root/public"
+bg="$public/bg.png"
+
+make_card() {
+  local logo="$1" out="$2"
+  magick "$bg" -resize 1200x630^ -gravity center -extent 1200x630 \
+    \( "$logo" -resize 760x220 \) -gravity center -composite \
+    "$out"
+  echo "generated ${out#"$root"/}"
+}
+
+make_card "$public/logo.png" "$public/og-image.png"
+
+for dir in "$public"/branding/*/; do
+  if [ -f "${dir}logo.png" ]; then
+    make_card "${dir}logo.png" "${dir}og-image.png"
+  fi
+done

--- a/.codex/skills/signoz-query/SKILL.md
+++ b/.codex/skills/signoz-query/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: signoz-query
+description: Query this project's SigNoz observability instance at https://logs.tf2pickup.org through its REST API for metrics, logs, traces, dashboards, and alert rules. Use to investigate tf2pickup production errors or latency, check metrics, search logs, inspect or build dashboards and alerts, or diagnose production behavior.
+---
+
+# Query SigNoz
+
+Use the self-hosted SigNoz v0.100.x EE instance at `https://logs.tf2pickup.org` to investigate production behavior. Read `SIGNOZ_API_KEY` from `.env` and send it as `SIGNOZ-API-KEY`; never print, log, or commit the key.
+
+```bash
+KEY=$(grep '^SIGNOZ_API_KEY=' .env | cut -d= -f2- | tr -d '"' | tr -d "'")
+BASE=https://logs.tf2pickup.org
+```
+
+## Query data
+
+Use `POST /api/v4/query_range` for metrics, logs, and traces. Use v4 rather than v5. Set `start` and `end` as epoch milliseconds and use builder queries.
+
+For metrics, discover `tf2pickup.*` names using `GET /api/v3/autocomplete/aggregate_attributes?aggregateOperator=count&dataSource=metrics&searchText=tf2pickup`. Discover metric attributes through `attribute_keys` and `attribute_values` autocomplete endpoints. Use `rate` or `increase` plus `sum` for counters, `.bucket` with `p50`, `p90`, or `p99` plus `rate` for histogram percentiles, and `max` for gauges.
+
+For logs, use `dataSource: "logs"`. `severity_text` values are uppercase. Pino error objects are in `exception.type`, `exception.message`, and `exception.stacktrace`; the log message is `body`. Request-completed logs include `res.statusCode` and `responseTime`; filter 5xx responses using `res.statusCode >= 500`. Treat `service.name` as a resource attribute.
+
+Use a table query with `groupBy` and `count` (logs) or `sum_rate` (metrics) for quick top-N breakdowns. Query before selecting an alert threshold.
+
+## Dashboards and alerts
+
+- Use `/api/v1/dashboards` to list, retrieve, and update dashboards. For panel additions, clone an existing compatible widget and add matching entries to both `widgets` and `layout`.
+- The main dashboard is titled `tf2pickup`; its instance variable maps to `service.name`.
+- Use `/api/v1/rules` and `/api/v1/channels` for alerting. Rules require `preferredChannels`; `POST /api/v1/testRule` may return 500 even for valid rules, so create valid rules directly instead.
+- SigNoz has no native Discord channel. Configure a Discord webhook as a Slack channel using its `/slack` endpoint. `testChannel` sends a live message, so only use it when authorized.
+- In alert annotations, convert dotted label names to underscores: `service.name` becomes `{{$labels.service_name}}`.
+
+Common deployed service names include `tf2pickup-pl`, `tf2pickup-fr`, `tf2pickup-eu`, `tf2pickup-ru`, and `hl-tf2pickup-eu`.

--- a/.codex/skills/signoz-query/agents/openai.yaml
+++ b/.codex/skills/signoz-query/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Query SigNoz"
-  short_description: "Investigate tf2pickup production observability"
-  default_prompt: "Use $signoz-query to investigate recent tf2pickup production errors."
+  display_name: 'Query SigNoz'
+  short_description: 'Investigate tf2pickup production observability'
+  default_prompt: 'Use $signoz-query to investigate recent tf2pickup production errors.'

--- a/.codex/skills/signoz-query/agents/openai.yaml
+++ b/.codex/skills/signoz-query/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Query SigNoz"
+  short_description: "Investigate tf2pickup production observability"
+  default_prompt: "Use $signoz-query to investigate recent tf2pickup production errors."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# tf2pickup.org
+
+Team Fortress 2 pick-up game coordination platform. Full-stack Node.js application using Fastify, MongoDB, server-rendered HTML, and HTMX.
+
+## Commands
+
+- `pnpm dev` — start the development server with hot reload.
+- `pnpm build` — compile TypeScript, run `tsc-alias`, and copy assets to `dist/`.
+- `pnpm lint` — run Prettier checks and ESLint.
+- `pnpm format` — format with Prettier.
+- `pnpm test` — run Vitest unit tests.
+- `pnpm test -- src/path/to/file.test.ts` — run one test file.
+- `pnpm test:e2e` — run Playwright tests; requires the application and MongoDB.
+- `docker-compose up -d mongo` — start MongoDB for development.
+
+Before starting a development server or MongoDB, check whether one is already running (for example, ports 3000 and 27017) and reuse it.
+
+## Architecture
+
+- Fastify 5 with the Zod type provider for request validation.
+- Raw MongoDB driver with typed collections in `src/database/collections.ts`; models are in `src/database/models/`.
+- `@kitajs/html` renders type-safe JSX to HTML; HTMX supplies partial-page updates. Detect the `hx-request` header when serving a fragment.
+- Tailwind CSS 4 is processed through PostCSS and embedded at render time.
+- esbuild bundles browser code from `src/html/@client/`.
+
+### Startup and modules
+
+`src/main.ts` initializes OpenTelemetry, runs Umzug migrations, registers Fastify plugins, then auto-loads `**/plugins/**`, `**/middleware/**`, and routes in `src/routes/`.
+
+Use the feature-driven structure under `src/`: business logic plus optional `plugins/`, `middleware/`, `views/html/`, and `schemas/` directories. Plugins subscribe to the typed event emitter in `src/events.ts`.
+
+Routes are auto-loaded with directory-name prefixes. Export routes through the `routes()` wrapper from `src/utils/routes.ts`:
+
+```ts
+export default routes(async app => {
+  app.get('/', async (_req, reply) => reply.html(MyPage()))
+})
+```
+
+### Database and environment
+
+Add database indexes through `ensureIndexes()` rather than migrations unless specifically asked otherwise. Environment variables are Zod-validated in `src/environment.ts`; consult `sample.env` for `MONGODB_URI`, `STEAM_API_KEY`, `QUEUE_CONFIG`, and `WEBSITE_URL`.
+
+### Observability
+
+OpenTelemetry in `src/otel.ts` sends `tf2pickup.*` metrics, logs, and traces to SigNoz. Use the `signoz-query` skill for production investigations. There are three distinct channels:
+
+- OTel/SigNoz: operational health, outcomes, and diagnostics.
+- Umami: per-instance in-browser product analytics via `data-umami-event`.
+- tf2pickup telemetry: anonymous cross-instance feature-adoption snapshots in `src/telemetry/build-snapshot.ts`.
+
+Use the framework in `docs/observability.md`. For a new feature, add a snapshot entry for configuration or feature flags, a Umami tag for user-facing interactions, or OTel instrumentation for operational health/outcomes; omit instrumentation when none apply.
+
+## Conventions
+
+- Keep one export per file and match its name to the hyphenated filename (`foo-bar.ts` exports `fooBar`).
+- Use conventional commits.
+- Use date-fns duration helpers rather than raw time values.
+- Use camelCase for all constants; never SCREAMING_SNAKE_CASE.
+- Keep TypeScript strict and ESM-only. Use pnpm.
+- Adapt third-party code to this project’s styles rather than vendoring it unchanged.
+- For production imports, confirm a package is a runtime dependency. Lazy-import optional or development-only modules.
+- Avoid barrel imports that cause `environment.ts` to load.
+- Disclose non-obvious asset or data transformations.
+
+## Verification
+
+After code changes, run linting, type checking, and relevant tests. For a PR, also watch CI until it is green before considering it complete.


### PR DESCRIPTION
## Summary
- add repository instructions for Codex in AGENTS.md
- migrate OpenGraph card generation to a Codex skill
- migrate SigNoz querying guidance to a Codex skill
- retain existing Claude configuration and skills