### PR TITLE
fix: player list layout on small screens

### DIFF
--- a/src/players/views/html/player-list.page.tsx
+++ b/src/players/views/html/player-list.page.tsx
@@ -37,7 +37,7 @@ export async function PlayerListPage() {
         <div class="container mx-auto">
           <div class="text-abru-light-75 my-9 text-[48px] font-bold">Players</div>
 
-          <div class="text-abru-light-75 hidden flex-row flex-wrap justify-between gap-x-3 gap-y-1 text-2xl font-bold md:flex">
+          <div class="player-list-index">
             {groups.map(letter => (
               <a href={`#${letter}`} style="uppercase" safe>
                 {letter}
@@ -46,26 +46,20 @@ export async function PlayerListPage() {
           </div>
 
           {groups.map(letter => (
-            <>
-              <div class="bg-abru-light-15 my-4 h-[2px]"></div>
-              <div class="text-abru-light-75 grid min-h-[120px] grid-cols-3 gap-x-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-10">
-                <a id={letter} class="text-[64px] leading-none font-bold" safe>
-                  {letter}
-                </a>
+            <div class="player-list-section">
+              <div class="section-divider"></div>
+              <a id={letter} class="section-letter" safe>
+                {letter}
+              </a>
 
-                <div class="player-group col-span-1 grid grid-cols-9 content-start md:col-span-3 lg:col-span-5 xl:col-span-9">
-                  {groupedPlayers.get(letter)?.map(player => (
-                    <a
-                      href={`/players/${player.steamId}`}
-                      class="truncate whitespace-nowrap hover:underline"
-                      safe
-                    >
-                      {player.name}
-                    </a>
-                  ))}
-                </div>
+              <div class="player-group">
+                {groupedPlayers.get(letter)?.map(player => (
+                  <a href={`/players/${player.steamId}`} safe>
+                    {player.name}
+                  </a>
+                ))}
               </div>
-            </>
+            </div>
           ))}
         </div>
       </Page>

--- a/src/players/views/html/style.css
+++ b/src/players/views/html/style.css
@@ -2,8 +2,96 @@
 @import '../../../games/views/html/game-list.css';
 
 @layer components {
-  .player-group {
-    grid-template-columns: subgrid;
+  .player-list-section {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    column-gap: 8px;
+    min-height: 120px;
+    color: var(--color-abru-light-75);
+
+    @media (width >= theme(--breakpoint-lg)) {
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+    }
+
+    @media (width >= theme(--breakpoint-xl)) {
+      grid-template-columns: repeat(10, minmax(0, 1fr));
+    }
+
+    .section-divider {
+      grid-column: 1 / -1;
+      margin-block: 16px;
+      height: 2px;
+      background-color: var(--color-abru-light-15);
+    }
+
+    .section-letter {
+      font-size: 64px;
+      line-height: 1;
+      font-weight: 700;
+    }
+
+    .player-group {
+      display: grid;
+      align-content: start;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+
+      @media (width >= theme(--breakpoint-md)) {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+      }
+
+      @media (width >= theme(--breakpoint-lg)) {
+        grid-column: span 5;
+        grid-template-columns: repeat(9, minmax(0, 1fr));
+      }
+
+      @media (width >= theme(--breakpoint-xl)) {
+        grid-column: span 9;
+      }
+
+      a {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+
+    @media (width < theme(--breakpoint-lg)) {
+      .section-letter {
+        order: 1;
+        margin-top: 24px;
+      }
+
+      .section-divider {
+        order: 2;
+      }
+
+      .player-group {
+        order: 3;
+      }
+    }
+  }
+
+  .player-list-index {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+    column-gap: 12px;
+    row-gap: 4px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    color: var(--color-abru-light-75);
+    font-size: 24px;
+    line-height: 32px;
+    font-weight: 700;
+
+    @media (width >= theme(--breakpoint-lg)) {
+      flex-wrap: wrap;
+      overflow-x: visible;
+    }
   }
 
   .player-presentation {


### PR DESCRIPTION
## Summary
- render the player list letter sections stacked on viewports below `lg`: big letter, divider below it, player names in 2 columns (mobile) / 4 columns (md) instead of 9 truncated columns squeezed next to the letter
- show the A–Z index on small screens as a single horizontally scrollable row (scrollbar hidden); it wraps as before on `lg`+
- extract the repeated Tailwind utility soup into `player-list-index` and `player-list-section` component classes in `style.css`; drop the dead `.player-group { grid-template-columns: subgrid }` rule that was always overridden by the `grid-cols-*` utilities

## Test plan
- [x] verified visually at 393px, 790px, 1100px and 1440px — small screens match the mockup, `lg`+ renders identically to master
- [x] `pnpm lint`, `pnpm build`, `pnpm test` (383 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)