### PR TITLE
fix: respond with 404 to unauthorized admin routes

### DIFF
--- a/src/auth/plugins/authorize.ts
+++ b/src/auth/plugins/authorize.ts
@@ -24,6 +24,11 @@ export default fp(
         return
       }
 
+      if (request.routeOptions.url?.startsWith('/admin')) {
+        reply.callNotFound()
+        return
+      }
+
       return reply.forbidden()
     })
   },

--- a/src/auth/plugins/authorize.ts
+++ b/src/auth/plugins/authorize.ts
@@ -20,16 +20,7 @@ export default fp(
         return
       }
 
-      if (request.routeOptions.url?.startsWith('/admin')) {
-        reply.callNotFound()
-        return
-      }
-
-      if (!request.user) {
-        return reply.unauthorized()
-      }
-
-      return reply.forbidden()
+      reply.callNotFound()
     })
   },
   {

--- a/src/auth/plugins/authorize.ts
+++ b/src/auth/plugins/authorize.ts
@@ -11,22 +11,22 @@ export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
   async app => {
     app.addHook('preHandler', async (request, reply) => {
-      if (!request.routeOptions.config.authorize) {
+      const roles = request.routeOptions.config.authorize
+      if (!roles) {
         return
       }
 
-      if (!request.user) {
-        return reply.unauthorized()
-      }
-
-      const roles = request.routeOptions.config.authorize
-      if (roles.some(r => request.user!.player.roles.includes(r))) {
+      if (request.user && roles.some(r => request.user!.player.roles.includes(r))) {
         return
       }
 
       if (request.routeOptions.url?.startsWith('/admin')) {
         reply.callNotFound()
         return
+      }
+
+      if (!request.user) {
+        return reply.unauthorized()
       }
 
       return reply.forbidden()

--- a/tests/90-admin/01-admin-panel.spec.ts
+++ b/tests/90-admin/01-admin-panel.spec.ts
@@ -13,8 +13,8 @@ authUsers('admin panel is not visible for non-admins @6v6 @9v9', async ({ users 
   await expect(userPage.getByRole('link', { name: 'Admin panel' })).not.toBeVisible()
 
   await userPage.goto('/admin')
-  await expect(userPage.getByText('403')).toBeVisible()
-  await expect(userPage.getByText('Forbidden')).toBeVisible()
+  await expect(userPage.getByText('404')).toBeVisible()
+  await expect(userPage.getByText('Not found')).toBeVisible()
   await expect(userPage.getByRole('link', { name: 'Go back home' })).toBeVisible()
 })
 
@@ -45,8 +45,8 @@ authUsers('admin panel is not visible for anonymous users @6v6 @9v9', async ({ p
     async ({ users }) => {
       const userPage = await users.getNext(u => !u.isAdmin).page()
       await userPage.goto(adminPage)
-      await expect(userPage.getByText('403')).toBeVisible()
-      await expect(userPage.getByText('Forbidden')).toBeVisible()
+      await expect(userPage.getByText('404')).toBeVisible()
+      await expect(userPage.getByText('Not found')).toBeVisible()
       await expect(userPage.getByRole('link', { name: 'Go back home' })).toBeVisible()
     },
   )

--- a/tests/90-admin/01-admin-panel.spec.ts
+++ b/tests/90-admin/01-admin-panel.spec.ts
@@ -23,8 +23,8 @@ authUsers('admin panel is not visible for anonymous users @6v6 @9v9', async ({ p
   await expect(page.getByRole('link', { name: 'Admin panel' })).not.toBeVisible()
 
   await page.goto('/admin')
-  await expect(page.getByText('401')).toBeVisible()
-  await expect(page.getByText('Unauthorized')).toBeVisible()
+  await expect(page.getByText('404')).toBeVisible()
+  await expect(page.getByText('Not found')).toBeVisible()
   await expect(page.getByRole('link', { name: 'Go back home' })).toBeVisible()
 })
 ;[

--- a/tests/90-admin/05-skill-import-export.spec.ts
+++ b/tests/90-admin/05-skill-import-export.spec.ts
@@ -21,8 +21,8 @@ authUsers(
   async ({ users: userManager }) => {
     const userPage = await userManager.getNext(u => !u.isAdmin).page()
     await userPage.goto('/admin/skill-import-export')
-    await expect(userPage.getByText('403')).toBeVisible()
-    await expect(userPage.getByText('Forbidden')).toBeVisible()
+    await expect(userPage.getByText('404')).toBeVisible()
+    await expect(userPage.getByText('Not found')).toBeVisible()
   },
 )
 


### PR DESCRIPTION
## Summary
- any request failing a role check (`authorize` route config) — anonymous or logged-in without the required role — now gets a 404 instead of a 401/403, so responses don't disclose the existence of privileged routes (`/admin/*`, `/players/:steamId/edit/*`, chat moderation endpoints)
- the failed check calls `reply.callNotFound()`, routing through the app's not-found handler — the response (JSON or HTML error page) is byte-identical to a genuinely missing route
- login-required routes without a role requirement (`authenticate` config, e.g. `/settings`) still return 401, and domain-level 403s with actionable messages (muted, ETF2L ban) are untouched