### PR TITLE
fix(ui): make admin panel and edit player views usable on mobile

### DIFF
--- a/src/admin/activity-log/views/html/activity-log-entry-list.tsx
+++ b/src/admin/activity-log/views/html/activity-log-entry-list.tsx
@@ -64,7 +64,7 @@ export function ActivityLogEntryList(props: ActivityLogEntryListProps) {
   return (
     <>
       <input type="hidden" name="sort" value={props.sort} />
-      <table class="w-full text-left text-sm">
+      <table class="w-full text-left text-sm max-lg:min-w-2xl">
         <thead>
           <tr class="border-abru-light-25 border-b">
             <th class="w-[160px] px-4 py-2">

--- a/src/admin/activity-log/views/html/activity-log.page.tsx
+++ b/src/admin/activity-log/views/html/activity-log.page.tsx
@@ -86,7 +86,7 @@ export function ActivityLogPage(props: ActivityLogPageProps) {
           />
         </div>
 
-        <div id="activity-log-results">
+        <div id="activity-log-results" class="max-lg:overflow-x-auto">
           <ActivityLogEntryList {...props} />
         </div>
       </div>

--- a/src/admin/bypass-registration-restrictions/views/html/bypass-registration-restrictions.page.tsx
+++ b/src/admin/bypass-registration-restrictions/views/html/bypass-registration-restrictions.page.tsx
@@ -13,9 +13,14 @@ export function BypassRegistrationRestrictionsPage() {
 
         <BypassedSteamIds />
 
-        <form method="post" action="" class="row flex items-center gap-2">
-          <input type="text" name="steamId" />
-          <button type="submit" class="button" data-variant="accent" data-size="dense">
+        <form method="post" action="" class="row flex items-center gap-2 max-lg:flex-wrap">
+          <input type="text" name="steamId" class="max-lg:w-full max-lg:min-w-0" />
+          <button
+            type="submit"
+            class="button whitespace-nowrap"
+            data-variant="accent"
+            data-size="dense"
+          >
             <IconPlus size={20} />
             <span>Add user Steam ID</span>
           </button>

--- a/src/admin/game-servers/views/html/game-servers.page.tsx
+++ b/src/admin/game-servers/views/html/game-servers.page.tsx
@@ -19,7 +19,9 @@ export async function GameServersPage() {
 
       <div class="admin-panel-set mt-4">
         <h4 class="pb-4">Static servers</h4>
-        <StaticGameServerList />
+        <div class="max-lg:overflow-x-auto">
+          <StaticGameServerList />
+        </div>
       </div>
 
       <div class="admin-panel-set mt-4">

--- a/src/admin/game-servers/views/html/static-game-server-list.tsx
+++ b/src/admin/game-servers/views/html/static-game-server-list.tsx
@@ -10,7 +10,7 @@ export async function StaticGameServerList() {
     .toArray()
 
   return (
-    <table class="w-full table-fixed" id="admin-panel-static-game-server-list">
+    <table class="w-full table-fixed max-lg:min-w-2xl" id="admin-panel-static-game-server-list">
       <thead>
         <tr>
           <th class="border-ash/50 w-[15%] border-b pb-3 text-left">Name</th>

--- a/src/admin/map-pool/views/html/map-pool.page.tsx
+++ b/src/admin/map-pool/views/html/map-pool.page.tsx
@@ -10,7 +10,7 @@ export async function MapPoolPage() {
     <Admin activePage="map-pool">
       <form action="" method="post">
         <div class="admin-panel-set">
-          <table class="table-auto">
+          <table class="table-auto max-lg:w-full">
             <thead>
               <tr>
                 <th>Map name</th>
@@ -53,10 +53,21 @@ export function MapPoolEntry(props: { name: string; execConfig?: string | undefi
   return (
     <tr>
       <td>
-        <input type="text" name="name[]" value={props.name} required />
+        <input
+          type="text"
+          name="name[]"
+          value={props.name}
+          required
+          class="max-lg:w-full max-lg:min-w-0"
+        />
       </td>
       <td>
-        <input type="text" name="execConfig[]" value={props.execConfig} />
+        <input
+          type="text"
+          name="execConfig[]"
+          value={props.execConfig}
+          class="max-lg:w-full max-lg:min-w-0"
+        />
       </td>
       <td>
         <button class="text-white" data-remove-closest="tr">

--- a/src/admin/player-action-logs/views/html/log-entry-list.tsx
+++ b/src/admin/player-action-logs/views/html/log-entry-list.tsx
@@ -22,7 +22,7 @@ export function LogEntryList(props: LogEntryListProps) {
   return (
     <>
       <input type="hidden" name="sort" value={props.sort} />
-      <table class="w-full table-fixed text-left text-sm rtl:text-right">
+      <table class="w-full table-fixed text-left text-sm max-lg:min-w-2xl rtl:text-right">
         <thead>
           <tr>
             <th class="w-[160px] px-4 py-2">

--- a/src/admin/player-action-logs/views/html/player-action-logs.page.tsx
+++ b/src/admin/player-action-logs/views/html/player-action-logs.page.tsx
@@ -18,7 +18,7 @@ export function PlayerActionLogsPage(props: PlayerActionLogsPageProps) {
   return (
     <Admin activePage="player-action-logs">
       <div class="admin-panel-set">
-        <div class="flex items-center gap-4 p-4">
+        <div class="flex flex-wrap items-center gap-4 p-4">
           <input type="hidden" name="page" value="1" />
 
           <select
@@ -68,7 +68,7 @@ export function PlayerActionLogsPage(props: PlayerActionLogsPageProps) {
           />
         </div>
 
-        <div id="log-results">
+        <div id="log-results" class="max-lg:overflow-x-auto">
           <LogEntryList
             logs={props.logs}
             playerNames={props.playerNames}

--- a/src/admin/scramble-maps/views/html/map-vote-options.tsx
+++ b/src/admin/scramble-maps/views/html/map-vote-options.tsx
@@ -11,7 +11,7 @@ export async function MapVoteOptions() {
       ))}
 
       {mapOptions.map(({ name }) => (
-        <p class="text-center" safe>
+        <p class="text-center [overflow-wrap:anywhere] max-lg:text-sm" safe>
           {name}
         </p>
       ))}

--- a/src/admin/view-for-nerds/views/html/view-for-nerds.page.tsx
+++ b/src/admin/view-for-nerds/views/html/view-for-nerds.page.tsx
@@ -19,15 +19,15 @@ export async function ViewForNerdsPage() {
   return (
     <Admin activePage="view-for-nerds">
       <div class="admin-panel-set">
-        <div class="table w-full">
-          <div class="table-header-group">
+        <div class="table w-full max-lg:block">
+          <div class="table-header-group max-lg:hidden">
             <div class="table-row">
               <div class="table-cell">Key</div>
               <div class="table-cell">Value</div>
             </div>
           </div>
 
-          <div class="table-row-group">
+          <div class="table-row-group max-lg:block max-lg:space-y-4">
             {entries.map(props => (
               <ConfigurationEntryEdit {...props} />
             ))}
@@ -66,12 +66,12 @@ export function ConfigurationEntryEdit(props: {
 
   return (
     <form
-      class="hover:bg-abru-dark-15 table-row"
+      class="hover:bg-abru-dark-15 table-row max-lg:grid max-lg:grid-cols-[1fr_auto] max-lg:items-center max-lg:gap-x-2"
       hx-post="/admin/view-for-nerds"
       hx-swap="outerHTML"
     >
       <input type="hidden" name="key" value={props._key} />
-      <div class="text-abru-light-75 table-cell">
+      <div class="text-abru-light-75 table-cell max-lg:col-span-2 max-lg:[overflow-wrap:anywhere]">
         <label for={`${props._key}-edit`} class={[isDefault && 'font-normal']}>
           {props._key}
         </label>

--- a/src/admin/voice-server/views/html/voice-server.page.tsx
+++ b/src/admin/voice-server/views/html/voice-server.page.tsx
@@ -98,8 +98,14 @@ export async function VoiceServerPage() {
                   id="mumble-url"
                   value={mumbleUrl ?? ''}
                   placeholder="mumble.tf2pickup.org"
+                  class="max-lg:min-w-0 max-lg:flex-1"
                 />
-                <input type="number" name="mumblePort" value={mumblePort.toString()} />
+                <input
+                  type="number"
+                  name="mumblePort"
+                  value={mumblePort.toString()}
+                  class="max-lg:w-24 max-lg:min-w-0"
+                />
               </dd>
             </dl>
 

--- a/src/html/components/admin-panel.tsx
+++ b/src/html/components/admin-panel.tsx
@@ -1,11 +1,26 @@
 import type { Children } from '@kitajs/html'
 
 export function AdminPanel(props?: { children?: Children }) {
-  return <div class="container mx-auto grid grid-cols-5 gap-8">{props?.children}</div>
+  return (
+    <div class="container mx-auto grid grid-cols-1 gap-4 lg:grid-cols-5 lg:gap-8">
+      {props?.children}
+    </div>
+  )
 }
 
 export function AdminPanelSidebar(props?: { children?: Children }) {
-  return <div class="flex flex-col gap-y-1">{props?.children}</div>
+  return (
+    <div class="flex gap-1 max-lg:[scrollbar-width:none] max-lg:overflow-x-auto lg:flex-col">
+      {props?.children}
+      <script>{`
+        if (!window.matchMedia('(min-width: 64rem)').matches) {
+          document.currentScript.parentElement
+            .querySelector('.admin-panel-link.active')
+            ?.scrollIntoView({ block: 'nearest', inline: 'center' });
+        }
+      `}</script>
+    </div>
+  )
 }
 
 export function AdminPanelSection(props: { children: Children }) {
@@ -21,7 +36,7 @@ export function AdminPanelLink(props: { href: string; active?: boolean; children
 }
 
 export function AdminPanelBody(props?: { children?: Children }) {
-  return <div class="col-span-4">{props?.children}</div>
+  return <div class="lg:col-span-4">{props?.children}</div>
 }
 
 export function AdminPanelHeader(props?: { children?: Children }) {

--- a/src/html/styles/admin-panel.css
+++ b/src/html/styles/admin-panel.css
@@ -5,10 +5,24 @@
     font-weight: 500;
     padding: 8px 12px;
 
+    @media (width < theme(--breakpoint-lg)) {
+      flex-shrink: 0;
+      align-self: center;
+      white-space: nowrap;
+    }
+
     &:not(:first-child) {
       border-top: 1px solid var(--color-abru-light-25);
       padding-top: 16px;
       margin-top: 8px;
+
+      @media (width < theme(--breakpoint-lg)) {
+        border-top: none;
+        border-left: 1px solid var(--color-abru-light-25);
+        padding: 8px 12px 8px 16px;
+        margin-top: 0;
+        margin-left: 4px;
+      }
     }
   }
 
@@ -47,6 +61,11 @@
     padding: 6px 12px;
     position: relative;
 
+    @media (width < theme(--breakpoint-lg)) {
+      flex-shrink: 0;
+      white-space: nowrap;
+    }
+
     &:hover {
       background-color: color-mix(in hsl, var(--color-abru-dark-25), transparent 80%);
     }
@@ -63,6 +82,13 @@
         height: calc(100% - 8px);
         background-color: var(--color-accent);
         border-radius: 2px;
+
+        @media (width < theme(--breakpoint-lg)) {
+          top: auto;
+          bottom: 0;
+          width: calc(100% - 8px);
+          height: 3px;
+        }
       }
     }
   }

--- a/src/html/styles/switch.css
+++ b/src/html/styles/switch.css
@@ -4,6 +4,7 @@
     display: inline-block;
     width: 47px;
     height: 24px;
+    flex-shrink: 0;
 
     input {
       opacity: 0;

--- a/src/players/views/html/edit-player.page.tsx
+++ b/src/players/views/html/edit-player.page.tsx
@@ -67,7 +67,7 @@ export async function EditPlayerProfilePage(props: { steamId: SteamId64 }) {
     <EditPlayer player={player} activePage="/profile">
       <form action="" method="post">
         <div class="admin-panel-set">
-          <div class="grid grid-cols-[1fr_184px] gap-y-4">
+          <div class="grid grid-cols-1 gap-y-4 lg:grid-cols-[1fr_184px]">
             <div class="input-group">
               <label class="form-label" for="player-nickname">
                 Nickname
@@ -76,7 +76,7 @@ export async function EditPlayerProfilePage(props: { steamId: SteamId64 }) {
               <NicknameHistoryOverview nameHistory={player.nameHistory ?? []} />
             </div>
 
-            <div class="row-span-3">
+            <div class="max-lg:order-first max-lg:justify-self-center lg:row-span-3">
               <img
                 src={playerAvatarUrl(player.avatar, 'large')}
                 width="184"


### PR DESCRIPTION
On mobile screens the admin panel and edit player views were largely unusable: the sidebar was crushed into a narrow column, and several pages overflowed the viewport horizontally.

The sidebar (shared \`AdminPanel*\` components) now becomes a horizontally scrollable tab strip at the top on screens below \`lg\`, with the active link auto-centered on load and the accent indicator moved to the bottom edge to match the horizontal orientation. Section labels turn into inline dividers. Desktop layout is unchanged — all fixes are scoped to \`max-lg:\`, apart from \`flex-shrink: 0\` on \`.switch\` (a fixed-size control should never be crushed by flexbox).

Individual page fixes at mobile widths:
- **Edit player / profile**: the fixed 184px avatar column overflowed and overlapped inputs; the form now stacks with the avatar centered on top
- **Scramble maps**: map names overlapped; they now wrap
- **Map pool**: rows overflowed, pushing remove buttons off-screen; inputs are now fluid
- **Game servers**: static server table columns overlapped; the table now scrolls horizontally (wrapper lives outside the component because the sync plugin swaps the table by id)
- **Voice server**: mumble URL + port inputs overflowed
- **View for nerds**: entries now stack (key above full-width value input)
- **Player action logs / activity log**: filters wrap and tables scroll horizontally
- **Bypass restrictions**: the add button wrapped over four lines; the form now wraps into two rows

All pages verified with Playwright screenshots at 375px and 1440px.