### PR TITLE
feat(players): add staff page

### DIFF
--- a/src/html/components/footer.tsx
+++ b/src/html/components/footer.tsx
@@ -16,6 +16,7 @@ export function Footer() {
           </span>
           <div class="grow" />
           <div class="flex flex-col items-center gap-2 md:flex-row md:gap-5">
+            <a href="/staff">Staff</a>
             <a href="/privacy-policy">Privacy policy</a>
             <a
               href="https://github.com/tf2pickup-org/tf2pickup"

--- a/src/players/views/html/staff.page.css
+++ b/src/players/views/html/staff.page.css
@@ -1,0 +1,53 @@
+@reference '../../../html/styles/main.css';
+
+@layer components {
+  .staff-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 16px;
+  }
+
+  .staff-card {
+    @apply transition-colors;
+    @apply duration-75;
+
+    display: flex;
+    flex-direction: row;
+    gap: 16px;
+    padding: 14px;
+
+    background-color: rgba(19, 16, 20, 0.5);
+    color: var(--color-abru-light-75);
+    border-radius: 8px;
+
+    &:hover {
+      background-color: color-mix(in srgb, var(--color-abru-light-5) 70%, transparent);
+    }
+
+    &.staff-card--super-user {
+      --role-color: var(--color-accent);
+    }
+
+    &.staff-card--admin {
+      --role-color: var(--color-alert);
+    }
+
+    .staff-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 4px;
+      border-bottom: 3px solid var(--role-color);
+    }
+
+    .online-dot {
+      position: absolute;
+      right: -4px;
+      bottom: -4px;
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background-color: var(--color-game-result-win);
+      border: 3px solid var(--color-abru-dark-29);
+    }
+  }
+}

--- a/src/players/views/html/staff.page.tsx
+++ b/src/players/views/html/staff.page.tsx
@@ -1,0 +1,122 @@
+import { resolve } from 'node:path'
+import { format } from 'date-fns'
+import type { PickDeep } from 'type-fest'
+import { collections } from '../../../database/collections'
+import { PlayerRole, type PlayerModel } from '../../../database/models/player.model'
+import { environment } from '../../../environment'
+import { Footer } from '../../../html/components/footer'
+import { NavigationBar } from '../../../html/components/navigation-bar'
+import { Page } from '../../../html/components/page'
+import { Layout } from '../../../html/layout'
+import { makeTitle } from '../../../html/make-title'
+import { playerAvatarUrl } from '../../../shared/player-avatar-url'
+
+type StaffMember = PickDeep<
+  PlayerModel,
+  'steamId' | 'name' | 'avatar' | 'roles' | 'joinedAt' | 'stats.totalGames'
+>
+
+export async function StaffPage() {
+  const staff = await collections.players
+    .find<StaffMember>(
+      { roles: { $in: [PlayerRole.superUser, PlayerRole.admin] } },
+      {
+        projection: {
+          _id: 0,
+          steamId: 1,
+          name: 1,
+          avatar: 1,
+          roles: 1,
+          joinedAt: 1,
+          'stats.totalGames': 1,
+        },
+      },
+    )
+    .toArray()
+  staff.sort((a, b) => {
+    const aSuperUser = a.roles.includes(PlayerRole.superUser)
+    const bSuperUser = b.roles.includes(PlayerRole.superUser)
+    if (aSuperUser !== bSuperUser) {
+      return aSuperUser ? -1 : 1
+    }
+    return a.joinedAt.getTime() - b.joinedAt.getTime()
+  })
+
+  const onlineSteamIds = new Set(
+    (
+      await collections.onlinePlayers
+        .find({ steamId: { $in: staff.map(({ steamId }) => steamId) } })
+        .toArray()
+    ).map(({ steamId }) => steamId),
+  )
+
+  return (
+    <Layout
+      title={makeTitle('staff')}
+      description={`the people who keep ${environment.WEBSITE_NAME} running`}
+      canonical="/staff"
+      embedStyle={resolve(import.meta.dirname, 'staff.page.css')}
+    >
+      <NavigationBar />
+      <Page>
+        <div class="container mx-auto">
+          <div class="my-9">
+            <div class="text-abru-light-75 text-[48px] font-bold">Staff</div>
+            <div class="text-abru-light-60 text-lg">
+              The people who keep <span safe>{environment.WEBSITE_NAME}</span> running
+            </div>
+          </div>
+
+          <div class="staff-list">
+            {staff.map(member => (
+              <StaffCard member={member} isOnline={onlineSteamIds.has(member.steamId)} />
+            ))}
+          </div>
+        </div>
+      </Page>
+      <Footer />
+    </Layout>
+  )
+}
+
+function StaffCard(props: { member: StaffMember; isOnline: boolean }) {
+  const { member } = props
+  const isSuperUser = member.roles.includes(PlayerRole.superUser)
+  return (
+    <a
+      class={['staff-card', isSuperUser ? 'staff-card--super-user' : 'staff-card--admin']}
+      href={`/players/${member.steamId}`}
+      preload="mousedown"
+    >
+      <div class="relative shrink-0 self-start">
+        <img
+          src={playerAvatarUrl(member.avatar, 'large')}
+          width="184"
+          height="184"
+          class="staff-avatar"
+          alt={`${member.name}'s avatar`}
+        />
+        {props.isOnline && <span class="online-dot" title="online now"></span>}
+      </div>
+
+      <div class="flex min-w-0 flex-col items-start gap-1">
+        <span class="max-w-full truncate text-2xl font-bold" safe>
+          {member.name}
+        </span>
+        {isSuperUser ? (
+          <span class="bg-accent rounded-[3px] px-[8px] py-[6px] leading-none font-bold text-white">
+            super user
+          </span>
+        ) : (
+          <span class="bg-alert text-abru-light-3 rounded-[3px] px-[8px] py-[6px] leading-none font-bold">
+            admin
+          </span>
+        )}
+        <span class="mt-1 text-sm font-light" safe>
+          since {format(member.joinedAt, 'MMMM yyyy')}
+        </span>
+        <span class="text-sm font-light">{member.stats.totalGames} games played</span>
+      </div>
+    </a>
+  )
+}

--- a/src/routes/staff/index.ts
+++ b/src/routes/staff/index.ts
@@ -1,0 +1,9 @@
+import { StaffPage } from '../../players/views/html/staff.page'
+import { routes } from '../../utils/routes'
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export default routes(async app => {
+  app.get('/', async (_request, reply) => {
+    await reply.status(200).html(StaffPage())
+  })
+})


### PR DESCRIPTION
Adds a public \`/staff\` page so players can see who runs the instance and who is reachable right now — until now the only way to find an admin was to stumble upon their profile badge.

- Roster cards for everyone with the \`super user\` or \`admin\` role: avatar, role badge (reusing the existing profile chip colors), member-since date and games played; super users sort first, then by seniority.
- Live presence dot fed by the \`onlinePlayers\` collection, so players can tell which staff member is online at a glance.
- Linked from the footer next to Privacy policy.