### PR TITLE
fix(games): make RCON console dialog work without 'unsafe-eval' CSP

### DIFF
--- a/src/games/views/html/rcon-console-dialog.tsx
+++ b/src/games/views/html/rcon-console-dialog.tsx
@@ -5,12 +5,7 @@ const dialogId = 'rcon-console-dialog'
 
 export function RconConsoleDialog(props: { game: GameModel }) {
   return (
-    <dialog
-      id={dialogId}
-      class="rcon-console"
-      hx-on-open={`document.getElementById('${dialogId}').showModal()`}
-      hx-on-close={`document.getElementById('${dialogId}').close()`}
-    >
+    <dialog id={dialogId} class="rcon-console" data-dialog-events>
       <header>
         <span class="title">RCON console</span>
         {props.game.gameServer !== undefined && (
@@ -33,7 +28,7 @@ export function RconConsoleDialog(props: { game: GameModel }) {
         hx-target="#rcon-console-transcript"
         hx-swap="beforeend scroll:bottom"
         hx-disabled-elt="find input, find button"
-        hx-on--after-request="if(event.detail.successful) { this.reset(); this.querySelector('input').focus(); }"
+        data-reset-on-success="input"
       >
         <span class="prompt" aria-hidden="true">
           ]


### PR DESCRIPTION
## Why

The RCON console (#735) doesn't open in production: it was developed before `'unsafe-eval'` was removed from the CSP (#750) and still uses `hx-on-*` attributes, which htmx evaluates via the `Function` constructor — now blocked by `script-src 'self'`.

## What

Replace the three `hx-on` attributes in `rcon-console-dialog.tsx` with the CSP-safe client-bundle behaviors introduced in #750:

- `hx-on-open`/`hx-on-close` → `data-dialog-events` (same pattern as the choose-game-server dialog; the toolbox button's `htmx.trigger(..., 'open')` is unchanged)
- `hx-on--after-request` (reset form + refocus input) → `data-reset-on-success="input"`

## Verification

- Lint, typecheck/build, and unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)