### PR TITLE
feat(admin): add skill suggestions admin page and weekly Discord digest

### DIFF
--- a/src/admin/player-restrictions/views/html/player-restrictions.page.tsx
+++ b/src/admin/player-restrictions/views/html/player-restrictions.page.tsx
@@ -16,6 +16,7 @@ export async function PlayerRestrictionsPage() {
           <PlayerSkillThreshold />
           <SkillStep />
           <SkillSuggestions />
+          <SkillSuggestionsDigest />
           <DefaultPlayerSkill />
 
           <p>
@@ -187,6 +188,32 @@ async function SkillSuggestions() {
         </dd>
       </dl>
       <Switch id="skillSuggestions" checked={skillSuggestions} name="skillSuggestions" />
+    </div>
+  )
+}
+
+async function SkillSuggestionsDigest() {
+  const skillSuggestionsDigest = await configuration.get('games.skill_suggestions_digest')
+  return (
+    <div class="group flex flex-row items-center justify-between">
+      <dl>
+        <dt>
+          <label class="text-abru-light-75" for="skillSuggestionsDigest">
+            Skill suggestions Discord digest
+          </label>
+        </dt>
+        <dd class="text-abru-light-75">
+          <span class="hidden group-has-checked:inline-block">
+            A weekly digest of pending skill suggestions is sent to Discord admin channels
+          </span>
+          <span class="group-has-checked:hidden">No digest is sent</span>
+        </dd>
+      </dl>
+      <Switch
+        id="skillSuggestionsDigest"
+        checked={skillSuggestionsDigest}
+        name="skillSuggestionsDigest"
+      />
     </div>
   )
 }

--- a/src/admin/skill-suggestions/views/html/skill-suggestions.page.tsx
+++ b/src/admin/skill-suggestions/views/html/skill-suggestions.page.tsx
@@ -1,0 +1,125 @@
+import { configuration } from '../../../../configuration'
+import type { PlayerSkillSuggestions } from '../../../../players/collect-skill-suggestions'
+import { collectSkillSuggestions } from '../../../../players/collect-skill-suggestions'
+import { Admin } from '../../../views/html/admin'
+import { GameClassIcon } from '../../../../html/components/game-class-icon'
+import type { Tf2ClassName } from '../../../../shared/types/tf2-class-name'
+
+export async function SkillSuggestionsPage() {
+  const enabled = await configuration.get('games.skill_suggestions')
+  return (
+    <Admin activePage="skill-suggestions">
+      <div class="admin-panel-set flex flex-col gap-4">
+        {enabled ? <Suggestions /> : <FeatureDisabled />}
+      </div>
+    </Admin>
+  )
+}
+
+function FeatureDisabled() {
+  return (
+    <p class="text-abru-light-75">
+      Skill suggestions are disabled. Enable them in{' '}
+      <a href="/admin/player-restrictions" class="underline">
+        Player restrictions
+      </a>
+      .
+    </p>
+  )
+}
+
+async function Suggestions() {
+  const [all, skillStep, defaultSkill] = await Promise.all([
+    collectSkillSuggestions(),
+    configuration.get('games.skill_step'),
+    configuration.get('games.default_player_skill'),
+  ])
+
+  if (all.length === 0) {
+    return <p class="text-abru-light-75">No pending skill suggestions.</p>
+  }
+
+  return (
+    <>
+      <p class="text-abru-light-75 text-sm">
+        Players whose game results consistently diverge from their assigned skill, based on
+        per-class elo tracked from every ended game. Applying a suggestion adjusts the player's
+        skill by the configured skill step.
+      </p>
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-abru-dark-29 border-b">
+            <th class="p-2 text-left">Player</th>
+            <th class="p-2 text-center">Class</th>
+            <th class="p-2 text-center">Current skill</th>
+            <th class="p-2 text-center">Elo</th>
+            <th class="p-2 text-center">Games on class</th>
+            <th class="p-2 text-right">Suggestion</th>
+          </tr>
+        </thead>
+        <tbody>
+          {all.flatMap(({ player, suggestions }) =>
+            [...suggestions.entries()].map(([gameClass, direction]) => (
+              <SuggestionRow
+                player={player}
+                gameClass={gameClass}
+                direction={direction}
+                skillStep={skillStep}
+                currentSkill={player.skill?.[gameClass] ?? defaultSkill[gameClass] ?? 0}
+              />
+            )),
+          )}
+        </tbody>
+      </table>
+    </>
+  )
+}
+
+function SuggestionRow(props: {
+  player: PlayerSkillSuggestions['player']
+  gameClass: Tf2ClassName
+  direction: 'up' | 'down'
+  skillStep: number
+  currentSkill: number
+}) {
+  const { player, gameClass, direction, skillStep, currentSkill } = props
+  const isUp = direction === 'up'
+  const newSkill = isUp ? currentSkill + skillStep : currentSkill - skillStep
+  return (
+    <tr class="border-abru-dark-29 border-b">
+      <td class="p-2">
+        <a href={`/players/${player.steamId}`} class="hover:underline" safe>
+          {player.name}
+        </a>
+      </td>
+      <td class="p-2 text-center">
+        <GameClassIcon gameClass={gameClass} size={24} />
+      </td>
+      <td class="p-2 text-center">{currentSkill}</td>
+      <td class="p-2 text-center">{player.elo?.[gameClass]}</td>
+      <td class="p-2 text-center">{player.stats.gamesByClass[gameClass] ?? 0}</td>
+      <td class="p-2 text-right">
+        <form method="post" action="" class="inline-block">
+          <input type="hidden" name="steamId" value={player.steamId} />
+          <input type="hidden" name="gameClass" value={gameClass} />
+          <input type="hidden" name="direction" value={direction} />
+          <button
+            type="submit"
+            class="button compact"
+            data-variant="accent"
+            title={isUp ? 'Skill too low' : 'Skill too high'}
+            data-umami-event="apply-skill-suggestion"
+            data-umami-event-player={player.steamId}
+          >
+            <span class={isUp ? 'text-yellow-500' : 'text-orange-500'}>
+              {(isUp ? '↑' : '↓') as 'safe'}
+            </span>
+            <span>
+              {currentSkill} → {newSkill}
+            </span>
+          </button>
+        </form>
+      </td>
+    </tr>
+  )
+}

--- a/src/admin/skill-suggestions/views/html/skill-suggestions.page.tsx
+++ b/src/admin/skill-suggestions/views/html/skill-suggestions.page.tsx
@@ -105,8 +105,7 @@ function SuggestionRow(props: {
           <input type="hidden" name="direction" value={direction} />
           <button
             type="submit"
-            class="button compact"
-            data-variant="accent"
+            class="button"
             title={isUp ? 'Skill too low' : 'Skill too high'}
             data-umami-event="apply-skill-suggestion"
             data-umami-event-player={player.steamId}

--- a/src/admin/views/html/admin.tsx
+++ b/src/admin/views/html/admin.tsx
@@ -13,6 +13,7 @@ import {
   IconAlertSquareRounded,
   IconArrowsShuffle,
   IconBrandDiscord,
+  IconChartArrowsVertical,
   IconHeadset,
   IconHistory,
   IconLogs,
@@ -99,6 +100,11 @@ const adminPages = {
   'skill-import-export': {
     title: 'Skill import/export',
     icon: IconTable,
+    section: 'Actions',
+  },
+  'skill-suggestions': {
+    title: 'Skill suggestions',
+    icon: IconChartArrowsVertical,
     section: 'Actions',
   },
   rules: {

--- a/src/database/models/configuration-entry.model.ts
+++ b/src/database/models/configuration-entry.model.ts
@@ -198,6 +198,14 @@ export const configurationSchema = z.discriminatedUnion('key', [
     .describe(
       'Experimental: show skill adjustment suggestions in the admin toolbox based on player performance',
     ),
+  z
+    .object({
+      key: z.literal('games.skill_suggestions_digest'),
+      value: z.boolean().default(false),
+    })
+    .describe(
+      'Send a weekly digest of pending skill suggestions to Discord admin notification channels',
+    ),
   z.object({
     key: z.literal('misc.discord_invite_link'),
     value: z.url().nullable().default(null),

--- a/src/discord/plugins/skill-suggestions-digest.ts
+++ b/src/discord/plugins/skill-suggestions-digest.ts
@@ -1,0 +1,82 @@
+import fp from 'fastify-plugin'
+import { EmbedBuilder } from 'discord.js'
+import { milliseconds } from 'date-fns'
+import { client } from '../client'
+import { collections } from '../../database/collections'
+import { configuration } from '../../configuration'
+import { environment } from '../../environment'
+import { collectSkillSuggestions } from '../../players/collect-skill-suggestions'
+import { tasks } from '../../tasks'
+import { toAdmins } from '../to-admins'
+
+const digestInterval = milliseconds({ weeks: 1 })
+const maxPlayersListed = 10
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export default fp(async app => {
+  tasks.register('discord:skillSuggestionsDigest', async () => {
+    if (!client) {
+      return
+    }
+    await tasks.schedule('discord:skillSuggestionsDigest', digestInterval)
+    await maybeSendDigest()
+  })
+
+  app.addHook('onReady', async () => {
+    if (!client) {
+      return
+    }
+    const pending = await collections.tasks.findOne({ name: 'discord:skillSuggestionsDigest' })
+    if (!pending) {
+      await tasks.schedule('discord:skillSuggestionsDigest', digestInterval)
+    }
+  })
+})
+
+async function maybeSendDigest() {
+  const [suggestionsEnabled, digestEnabled] = await Promise.all([
+    configuration.get('games.skill_suggestions'),
+    configuration.get('games.skill_suggestions_digest'),
+  ])
+  if (!suggestionsEnabled || !digestEnabled) {
+    return
+  }
+
+  const all = await collectSkillSuggestions()
+  if (all.length === 0) {
+    return
+  }
+
+  const lines = all.slice(0, maxPlayersListed).map(({ player, suggestions }) => {
+    const classes = [...suggestions.entries()]
+      .map(([gameClass, direction]) => `${gameClass} ${direction === 'up' ? '↑' : '↓'}`)
+      .join(', ')
+    return `**[${player.name}](${environment.WEBSITE_URL}/players/${player.steamId})** — ${classes}`
+  })
+  if (all.length > maxPlayersListed) {
+    lines.push(`…and ${all.length - maxPlayersListed} more`)
+  }
+
+  await toAdmins({
+    embeds: [
+      new EmbedBuilder()
+        .setColor('#f0b132')
+        .setAuthor({
+          name: 'tf2pickup.org bot',
+        })
+        .setTitle('Pending skill suggestions')
+        .setDescription(
+          [
+            ...lines,
+            '',
+            `Review them in the [admin panel](${environment.WEBSITE_URL}/admin/skill-suggestions).`,
+          ].join('\n'),
+        )
+        .setFooter({
+          text: environment.WEBSITE_NAME,
+          iconURL: `${environment.WEBSITE_URL}/favicon.png`,
+        })
+        .setTimestamp(),
+    ],
+  })
+}

--- a/src/players/collect-skill-suggestions.ts
+++ b/src/players/collect-skill-suggestions.ts
@@ -1,0 +1,29 @@
+import { collections } from '../database/collections'
+import type { PlayerModel } from '../database/models/player.model'
+import { defaultElo } from '../games/calculate-elo-updates'
+import { makeSkillSuggestions } from './make-skill-suggestions'
+
+export interface PlayerSkillSuggestions {
+  player: PlayerModel
+  suggestions: ReturnType<typeof makeSkillSuggestions>
+}
+
+/**
+ * Collects pending skill suggestions for all players, sorted by how far the
+ * player's elo has drifted from the default (strongest signal first).
+ */
+export async function collectSkillSuggestions(): Promise<PlayerSkillSuggestions[]> {
+  const candidates = await collections.players.find({ elo: { $exists: true } }).toArray()
+  return candidates
+    .map(player => ({ player, suggestions: makeSkillSuggestions({ player }) }))
+    .filter(({ suggestions }) => suggestions.size > 0)
+    .sort((a, b) => eloDrift(b) - eloDrift(a))
+}
+
+function eloDrift({ player, suggestions }: PlayerSkillSuggestions): number {
+  return Math.max(
+    ...[...suggestions.keys()].map(gameClass =>
+      Math.abs((player.elo?.[gameClass] ?? defaultElo) - defaultElo),
+    ),
+  )
+}

--- a/src/routes/admin/player-restrictions/index.ts
+++ b/src/routes/admin/player-restrictions/index.ts
@@ -45,6 +45,7 @@ export default routes(async app => {
               minimumInGameHours: z.coerce.number(),
               requirePlayerVerification: z.coerce.boolean().default(false),
               skillSuggestions: z.coerce.boolean().default(false),
+              skillSuggestionsDigest: z.coerce.boolean().default(false),
               skillStep: z.coerce.number().positive(),
               ...queue.config.classes
                 .map(({ name }) => name)
@@ -63,6 +64,7 @@ export default routes(async app => {
           requirePlayerVerification,
           playerSkillThresholdEnabled,
           skillSuggestions,
+          skillSuggestionsDigest,
           skillStep,
         } = request.body
         const defaultPlayerSkill = Object.entries(request.body)
@@ -85,6 +87,7 @@ export default routes(async app => {
           configuration.set('games.default_player_skill', defaultPlayerSkill, actor),
           configuration.set('games.skill_step', skillStep, actor),
           configuration.set('games.skill_suggestions', skillSuggestions, actor),
+          configuration.set('games.skill_suggestions_digest', skillSuggestionsDigest, actor),
         ])
         requestContext.set('messages', { success: ['Configuration saved'] })
         await reply.status(200).html(PlayerRestrictionsPage())

--- a/src/routes/admin/skill-suggestions/index.ts
+++ b/src/routes/admin/skill-suggestions/index.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod'
+import { PlayerRole } from '../../../database/models/player.model'
+import { SkillSuggestionsPage } from '../../../admin/skill-suggestions/views/html/skill-suggestions.page'
+import { configuration } from '../../../configuration'
+import { players } from '../../../players'
+import { queue } from '../../../queue-auto'
+import { steamId64 } from '../../../shared/schemas/steam-id-64'
+import { Tf2ClassName } from '../../../shared/types/tf2-class-name'
+import { recordSkillSuggestionUsage } from '../../../telemetry/record-skill-suggestion-usage'
+import { routes } from '../../../utils/routes'
+import { safe } from '../../../utils/safe'
+import { requestContext } from '@fastify/request-context'
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export default routes(async app => {
+  app
+    .get(
+      '/',
+      {
+        config: {
+          authorize: [PlayerRole.admin],
+        },
+      },
+      async (_request, reply) => {
+        await reply.status(200).html(SkillSuggestionsPage())
+      },
+    )
+    .post(
+      '/',
+      {
+        config: {
+          authorize: [PlayerRole.admin],
+        },
+        schema: {
+          body: z.object({
+            steamId: steamId64,
+            gameClass: z.enum(Tf2ClassName),
+            direction: z.enum(['up', 'down']),
+          }),
+        },
+      },
+      async (request, reply) => {
+        const { steamId, gameClass, direction } = request.body
+        const [player, defaultSkill, skillStep] = await Promise.all([
+          players.bySteamId(steamId, ['steamId', 'name', 'skill', 'elo', 'stats', 'skillHistory']),
+          configuration.get('games.default_player_skill'),
+          configuration.get('games.skill_step'),
+        ])
+
+        const skill = Object.fromEntries(
+          queue.config.classes.map(({ name }) => [
+            name,
+            player.skill?.[name] ?? defaultSkill[name] ?? 0,
+          ]),
+        ) as Partial<Record<Tf2ClassName, number>>
+        skill[gameClass] = (skill[gameClass] ?? 0) + (direction === 'up' ? skillStep : -skillStep)
+
+        await players.setSkill({
+          steamId,
+          skill,
+          actor: request.user!.player.steamId,
+        })
+        safe(() =>
+          recordSkillSuggestionUsage({ player, oldSkill: player.skill ?? {}, newSkill: skill }),
+        )()
+
+        requestContext.set('messages', {
+          success: [`${player.name}'s ${gameClass} skill updated`],
+        })
+        await reply.status(200).html(SkillSuggestionsPage())
+      },
+    )
+})

--- a/src/tasks/tasks.ts
+++ b/src/tasks/tasks.ts
@@ -58,6 +58,10 @@ export const tasksSchema = z.discriminatedUnion('name', [
     name: z.literal('logsTf:fetchLog'),
     args: z.object({ gameNumber, logId: z.number() }),
   }),
+  z.object({
+    name: z.literal('discord:skillSuggestionsDigest'),
+    args: z.object({}),
+  }),
 ])
 
 type TasksT = z.infer<typeof tasksSchema>

--- a/src/telemetry/build-snapshot.ts
+++ b/src/telemetry/build-snapshot.ts
@@ -28,6 +28,7 @@ function registeredPlayersBucket(count: number): string {
 export async function buildSnapshot() {
   const [
     skillSuggestions,
+    skillSuggestionsDigest,
     skillStep,
     logsTfUploadMethod,
     hideServerInfo,
@@ -44,6 +45,7 @@ export async function buildSnapshot() {
     extraCommands,
   ] = await Promise.all([
     configuration.get('games.skill_suggestions'),
+    configuration.get('games.skill_suggestions_digest'),
     configuration.get('games.skill_step'),
     configuration.get('games.logs_tf_upload_method'),
     configuration.get('games.hide_server_info_from_spectators'),
@@ -92,6 +94,12 @@ export async function buildSnapshot() {
       key: 'games.skill_suggestions',
       value: skillSuggestions,
       label: 'Skill suggestions',
+      group: 'Games',
+    },
+    {
+      key: 'games.skill_suggestions_digest',
+      value: skillSuggestionsDigest,
+      label: 'Skill suggestions Discord digest',
       group: 'Games',
     },
     { key: 'games.skill_step', value: skillStep, label: 'Skill adjustment step', group: 'Games' },


### PR DESCRIPTION
## Summary

Skill suggestions (elo-based up/down hints) were only visible inside the admin toolbox on individual player profiles, so pending suggestions for players whose profiles nobody visits went unnoticed indefinitely. Analysis of recent games showed several long-time regulars with clearly drifted elo (e.g. 1543–1545 after 100+ games) whose skill had never been adjusted.

- **New admin page** `/admin/skill-suggestions` (Actions section): lists every player with a pending suggestion — current skill, elo, games on class — sorted by elo drift (strongest signal first), with a one-click apply button that adjusts the class skill by the configured skill step. Applying goes through `players.setSkill`, so skill history, activity log and suggestion-usage telemetry all work as with the toolbox.
- **Weekly Discord digest**: posts pending suggestions to admin notification channels via the persistent task scheduler. Off by default, behind the new `games.skill_suggestions_digest` config option (toggle in Player restrictions, next to the existing skill suggestions switch). The digest respects both toggles and skips quietly when there is nothing to report.
- New config flag reported in the telemetry snapshot per docs/observability.md.

## Test plan

- [x] typecheck, lint, unit tests green
- [x] manual: page renders real pending suggestions from a prod dump, sorted by elo drift
- [x] manual: apply adjusts only the suggested class by ±skill step, records history with actor, flashes success, and the player drops off the list (existing 3-game cooldown)
- [x] route requires admin role (401 unauthenticated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)