### PR TITLE
feat(admin): preview game server startup commands on games config page

### DIFF
--- a/src/admin/games/views/html/game-server-command-preview.tsx
+++ b/src/admin/games/views/html/game-server-command-preview.tsx
@@ -1,0 +1,67 @@
+import { Html } from '@kitajs/html'
+import { environment } from '../../../../environment'
+import { LogsTfUploadMethod } from '../../../../shared/types/logs-tf-upload-method'
+
+// keep in sync with compileConfig() in src/games/rcon/configure.ts
+export function GameServerCommandPreview(props: {
+  whitelistId: string | null
+  executeExtraCommands: string[]
+  logsTfUploadMethod: LogsTfUploadMethod
+}) {
+  return (
+    <div class="bg-abru-dark-25 flex flex-col overflow-x-auto rounded-lg p-4 font-mono text-sm whitespace-nowrap text-white">
+      <span safe>
+        logaddress_add {environment.LOG_RELAY_ADDRESS}:{environment.LOG_RELAY_PORT}
+      </span>
+      <span>kickall</span>
+      <span>
+        changelevel <Placeholder text="map" />{' '}
+        <Comment text="skipped on serveme.tf servers - they start with the right map" />
+      </span>
+      <span>
+        exec <Placeholder text="map config" />{' '}
+        <Comment text="only if the map has a config assigned" />
+      </span>
+      {props.whitelistId ? (
+        <span safe>tftrue_whitelist_id {props.whitelistId}</span>
+      ) : (
+        <span class="italic opacity-40">
+          <Comment text="tftrue_whitelist_id skipped - no whitelist ID set" />
+        </span>
+      )}
+      <span>
+        sv_password <Placeholder text="generated password" />
+      </span>
+      <span>
+        sm_game_player_add <Placeholder text="steamId" /> -name <Placeholder text="name" /> -team{' '}
+        <Placeholder text="team" /> -class <Placeholder text="class" />{' '}
+        <Comment text="one line per player" />
+      </span>
+      <span>sm_game_player_whitelist 1</span>
+      <span>
+        logstf_title {Html.escapeHtml(environment.WEBSITE_NAME)} #
+        <Placeholder text="game number" />
+      </span>
+      <span>
+        logstf_autoupload {props.logsTfUploadMethod === LogsTfUploadMethod.gameserver ? '2' : '0'}
+      </span>
+      {props.executeExtraCommands
+        .filter(command => command.length > 0)
+        .map(command => (
+          <span safe>{command}</span>
+        ))}
+    </div>
+  )
+}
+
+function Placeholder(props: { text: string }) {
+  return (
+    <span class="text-abru-light-75 italic" safe>
+      {`<${props.text}>`}
+    </span>
+  )
+}
+
+function Comment(props: { text: string }) {
+  return <span class="text-abru-light-75/60 italic" safe>{`// ${props.text}`}</span>
+}

--- a/src/admin/games/views/html/game-server-command-preview.tsx
+++ b/src/admin/games/views/html/game-server-command-preview.tsx
@@ -10,8 +10,9 @@ export function GameServerCommandPreview(props: {
 }) {
   return (
     <div class="bg-abru-dark-25 flex flex-col overflow-x-auto rounded-lg p-4 font-mono text-sm whitespace-nowrap text-white">
-      <span safe>
-        logaddress_add {environment.LOG_RELAY_ADDRESS}:{environment.LOG_RELAY_PORT}
+      <span>
+        logaddress_add{' '}
+        {Html.escapeHtml(`${environment.LOG_RELAY_ADDRESS}:${environment.LOG_RELAY_PORT}`)}
       </span>
       <span>kickall</span>
       <span>

--- a/src/admin/games/views/html/games.page.tsx
+++ b/src/admin/games/views/html/games.page.tsx
@@ -3,6 +3,7 @@ import { configuration } from '../../../../configuration'
 import { LogsTfUploadMethod } from '../../../../shared/types/logs-tf-upload-method'
 import { Admin } from '../../../views/html/admin'
 import { SaveButton } from '../../../views/html/save-button'
+import { GameServerCommandPreview } from './game-server-command-preview'
 
 export async function GamesPage() {
   const whitelistId = await configuration.get('games.whitelist_id')
@@ -113,6 +114,21 @@ export async function GamesPage() {
                   Gameserver - logs will be uploaded by the logs.tf sourcemod plugin
                 </option>
               </select>
+            </dd>
+          </dl>
+
+          <dl>
+            <dt>Game server startup commands</dt>
+            <dd class="flex flex-col">
+              <GameServerCommandPreview
+                whitelistId={whitelistId}
+                executeExtraCommands={executeExtraCommands}
+                logsTfUploadMethod={logsTfUploadMethod}
+              />
+              <span class="text-abru-light-75 text-sm">
+                Commands executed on the game server when a game starts, in order. Reflects the
+                saved configuration above.
+              </span>
             </dd>
           </dl>
 

--- a/src/games/rcon/configure.ts
+++ b/src/games/rcon/configure.ts
@@ -226,6 +226,7 @@ async function doConfigure(game: GameModel, options: { signal?: AbortSignal } = 
   })
 }
 
+// keep in sync with GameServerCommandPreview in src/admin/games/views/html/game-server-command-preview.tsx
 async function* compileConfig(game: GameModel, password: string): AsyncGenerator<RconCommand> {
   yield `logaddress_add ${environment.LOG_RELAY_ADDRESS}:${environment.LOG_RELAY_PORT}`
   yield 'kickall'


### PR DESCRIPTION
## Summary

Admins had no clear indication of what commands are executed on the game server when a game starts. This adds a read-only preview block to the Games configuration page (`/admin/games`) that mirrors the command sequence from `compileConfig()`:

- config-driven lines show real values: `tftrue_whitelist_id` (or a dimmed *skipped* note when unset), `logstf_autoupload 2/0` based on the logs.tf upload method, and each extra command verbatim
- game-specific values (`<map>`, `<generated password>`, `<steamId>`, …) render as dimmed italic placeholders
- `//` comments explain conditional lines (changelevel skipped on serveme.tf, exec only when the map has a config)
- user-controlled values are HTML-escaped via the `safe` attribute

The preview reflects saved configuration and refreshes on Save. Both the preview and `compileConfig()` carry keep-in-sync comments pointing at each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)