### PR TITLE
fix(telemetry): report games30d instead of per-instance ratios

### DIFF
--- a/src/telemetry/build-snapshot.test.ts
+++ b/src/telemetry/build-snapshot.test.ts
@@ -52,12 +52,10 @@ vi.mock('./get-usage-counters', () => ({
     skillSuggestionsApplied30d: 12,
     adminSkillChanges30d: 30,
     eloPageRenders30d: 7,
+    games30d: 200,
     gameReinitializations30d: 4,
-    gameReinitializationsPerGame: 0.02,
     gameServerReassignments30d: 2,
-    gameServerReassignmentsPerGame: 0.01,
     gamesForceEnded30d: 3,
-    gamesForceEndedShare: 0.015,
   }),
 }))
 
@@ -139,12 +137,10 @@ describe('buildSnapshot', () => {
       skillSuggestionsApplied30d: 12,
       adminSkillChanges30d: 30,
       eloPageRenders30d: 7,
+      games30d: 200,
       gameReinitializations30d: 4,
-      gameReinitializationsPerGame: 0.02,
       gameServerReassignments30d: 2,
-      gameServerReassignmentsPerGame: 0.01,
       gamesForceEnded30d: 3,
-      gamesForceEndedShare: 0.015,
       gamesLaunchedLifetime: 5000,
       staticGameServers: 3,
     })

--- a/src/telemetry/build-snapshot.ts
+++ b/src/telemetry/build-snapshot.ts
@@ -224,14 +224,14 @@ export async function buildSnapshot() {
       label: 'ELO page renders (30d)',
     },
     {
+      key: 'games30d',
+      value: usage.games30d,
+      label: 'Games launched (30d)',
+    },
+    {
       key: 'gameReinitializations30d',
       value: usage.gameReinitializations30d,
       label: 'Game reinitializations (30d)',
-    },
-    {
-      key: 'gameReinitializationsPerGame',
-      value: usage.gameReinitializationsPerGame,
-      label: 'Game reinitializations per game (30d)',
     },
     {
       key: 'gameServerReassignments30d',
@@ -239,19 +239,9 @@ export async function buildSnapshot() {
       label: 'Game server reassignments (30d)',
     },
     {
-      key: 'gameServerReassignmentsPerGame',
-      value: usage.gameServerReassignmentsPerGame,
-      label: 'Game server reassignments per game (30d)',
-    },
-    {
       key: 'gamesForceEnded30d',
       value: usage.gamesForceEnded30d,
       label: 'Games force-ended (30d)',
-    },
-    {
-      key: 'gamesForceEndedShare',
-      value: usage.gamesForceEndedShare,
-      label: 'Games force-ended share (30d)',
     },
     {
       key: 'gamesLaunchedLifetime',

--- a/src/telemetry/get-usage-counters.ts
+++ b/src/telemetry/get-usage-counters.ts
@@ -4,10 +4,6 @@ import { GameEventType } from '../database/models/game-event.model'
 import { GameState } from '../database/models/game.model'
 import { utcDayKey } from './utc-day-key'
 
-function perGame(count: number, games: number): number {
-  return games === 0 ? 0 : Math.round((count / games) * 1000) / 1000
-}
-
 export async function getUsageCounters() {
   const since = subDays(new Date(), 30)
   const [[totals], [gameTotals]] = await Promise.all([
@@ -68,20 +64,13 @@ export async function getUsageCounters() {
       .toArray(),
   ])
 
-  const games = gameTotals?.games ?? 0
-  const reinitializations = gameTotals?.reinitializations ?? 0
-  const reassignments = gameTotals?.reassignments ?? 0
-  const forceEnded = gameTotals?.forceEnded ?? 0
-
   return {
     skillSuggestionsApplied30d: totals?.applied ?? 0,
     adminSkillChanges30d: totals?.changes ?? 0,
     eloPageRenders30d: totals?.eloPageRenders ?? 0,
-    gameReinitializations30d: reinitializations,
-    gameReinitializationsPerGame: perGame(reinitializations, games),
-    gameServerReassignments30d: reassignments,
-    gameServerReassignmentsPerGame: perGame(reassignments, games),
-    gamesForceEnded30d: forceEnded,
-    gamesForceEndedShare: perGame(forceEnded, games),
+    games30d: gameTotals?.games ?? 0,
+    gameReinitializations30d: gameTotals?.reinitializations ?? 0,
+    gameServerReassignments30d: gameTotals?.reassignments ?? 0,
+    gamesForceEnded30d: gameTotals?.forceEnded ?? 0,
   }
 }


### PR DESCRIPTION
## Summary
The usage snapshot reported three ratio metrics (`gameReinitializationsPerGame`, `gameServerReassignmentsPerGame`, `gamesForceEndedShare`). The telemetry dashboard sums every usage metric across instances, so these showed nonsense (e.g. a force-ended "share" of 0.968). Ratios can't be aggregated by summing — instead, report `games30d` so the telemetry service can derive fleet-wide ratios from summed numerators/denominators.

Counterpart service PR: tf2pickup-org/telemetry (derives the ratios server-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)