### PR TITLE
fix(queue): prevent launching the queue with vacated slots

### DIFF
--- a/src/database/ensure-indexes.ts
+++ b/src/database/ensure-indexes.ts
@@ -26,6 +26,9 @@ const definitions: Partial<Record<keyof typeof collections, IndexDefinition[]>> 
     { spec: { 'stats.totalGames': -1 } },
     { spec: { 'stats.gamesByClass.medic': -1 } },
     { spec: { avatarLastSyncedAt: 1 } },
+    // Sparse: preReadyUntil is $unset once the pre-ready lapses, so this only
+    // ever holds the handful of players pre-readied right now.
+    { spec: { preReadyUntil: 1 }, options: { sparse: true } },
   ],
   games: [
     { spec: { number: 1 }, options: { unique: true } },

--- a/src/queue-auto/leave.ts
+++ b/src/queue-auto/leave.ts
@@ -24,7 +24,7 @@ export async function leave(steamId: SteamId64): Promise<QueueSlotModel> {
         'player.steamId': steamId,
       },
       {
-        $set: { player: null },
+        $set: { player: null, ready: false },
       },
       {
         returnDocument: 'after',

--- a/src/queue/set-state.test.ts
+++ b/src/queue/set-state.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../database/collections', () => ({
+  collections: {
+    queueSlots: {
+      countDocuments: vi.fn(),
+    },
+    queueState: {
+      updateOne: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('../events', () => ({
+  events: { emit: vi.fn() },
+}))
+
+vi.mock('../logger', () => ({
+  logger: { trace: vi.fn(), info: vi.fn() },
+}))
+
+vi.mock('../pre-ready', () => ({
+  preReady: { start: vi.fn() },
+}))
+
+vi.mock('./with-queue-lock', () => ({
+  withQueueLock: vi.fn(async (_operation: string, fn: () => Promise<unknown>) => await fn()),
+}))
+
+import { setState } from './set-state'
+import { QueueState } from '../database/models/queue-state.model'
+import { collections } from '../database/collections'
+import { events } from '../events'
+
+describe('setState()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('when transitioning to launching', () => {
+    it('rejects when a queue slot is empty or unready', async () => {
+      vi.mocked(collections.queueSlots.countDocuments).mockResolvedValue(1)
+
+      await expect(setState(QueueState.launching)).rejects.toThrow(
+        'cannot launch: queue is no longer full and ready',
+      )
+      expect(collections.queueState.updateOne).not.toHaveBeenCalled()
+      expect(events.emit).not.toHaveBeenCalled()
+    })
+
+    it('proceeds when every slot is taken and ready', async () => {
+      vi.mocked(collections.queueSlots.countDocuments).mockResolvedValue(0)
+
+      await setState(QueueState.launching)
+
+      expect(collections.queueState.updateOne).toHaveBeenCalledWith(
+        {},
+        { $set: { state: QueueState.launching } },
+      )
+      expect(events.emit).toHaveBeenCalledWith('queue/state:updated', {
+        state: QueueState.launching,
+      })
+    })
+  })
+
+  it('does not verify slots for other transitions', async () => {
+    await setState(QueueState.waiting)
+
+    expect(collections.queueSlots.countDocuments).not.toHaveBeenCalled()
+    expect(collections.queueState.updateOne).toHaveBeenCalledWith(
+      {},
+      { $set: { state: QueueState.waiting } },
+    )
+  })
+})

--- a/src/queue/set-state.ts
+++ b/src/queue/set-state.ts
@@ -4,11 +4,25 @@ import { errors } from '../errors'
 import { events } from '../events'
 import { logger } from '../logger'
 import { preReady } from '../pre-ready'
+import { withLogLevel } from '../utils/with-log-level'
 import { withQueueLock } from './with-queue-lock'
 
 export async function setState(state: QueueState) {
   await withQueueLock('set-state', async () => {
     logger.trace({ state }, 'queue.setState()')
+
+    if (state === QueueState.launching) {
+      const notReadyCount = await collections.queueSlots.countDocuments({
+        $or: [{ player: { $eq: null } }, { ready: { $eq: false } }],
+      })
+      if (notReadyCount > 0) {
+        throw withLogLevel(
+          errors.conflict('cannot launch: queue is no longer full and ready'),
+          'warn',
+        )
+      }
+    }
+
     await collections.queueState.updateOne({}, { $set: { state } })
 
     if (state === QueueState.ready) {

--- a/src/queue/set-state.ts
+++ b/src/queue/set-state.ts
@@ -1,4 +1,5 @@
 import { collections } from '../database/collections'
+import type { PlayerModel } from '../database/models/player.model'
 import { QueueState } from '../database/models/queue-state.model'
 import { errors } from '../errors'
 import { events } from '../events'
@@ -31,12 +32,12 @@ export async function setState(state: QueueState) {
         throw errors.internalServerError('invalid queue state: last undefined')
       }
 
-      const preReadiesPlayers = await collections.players
-        .find({ preReadyUntil: { $gte: new Date() } })
+      const preReadiedPlayers = await collections.players
+        .find<Pick<PlayerModel, 'steamId'>>({ preReadyUntil: { $gte: new Date() } }, { projection: { steamId: 1 }})
         .toArray()
       const toReadyUp = (
         await collections.queueSlots
-          .find({ 'player.steamId': { $in: preReadiesPlayers.map(({ steamId }) => steamId) } })
+          .find({ 'player.steamId': { $in: preReadiedPlayers.map(({ steamId }) => steamId) } })
           .toArray()
       ).map(slot => slot.player!.steamId)
 

--- a/src/queue/set-state.ts
+++ b/src/queue/set-state.ts
@@ -33,7 +33,10 @@ export async function setState(state: QueueState) {
       }
 
       const preReadiedPlayers = await collections.players
-        .find<Pick<PlayerModel, 'steamId'>>({ preReadyUntil: { $gte: new Date() } }, { projection: { steamId: 1 }})
+        .find<Pick<PlayerModel, 'steamId'>>(
+          { preReadyUntil: { $gte: new Date() } },
+          { projection: { steamId: 1 } },
+        )
         .toArray()
       const toReadyUp = (
         await collections.queueSlots


### PR DESCRIPTION
When a readied-up player left the queue during the ready-up phase, their slot kept the leftover `ready: true` flag and still counted toward the all-players-ready check, so the queue could transition to `launching` with an empty slot. Game creation then threw `queue slot <id> is empty` and the queue stayed stuck in `launching` forever, rejecting every join/leave/kick with `invalid queue state` — this is what wedged tf2pickup.ru today (2026-07-23 16:38 UTC).

Two changes close the hole:

- `leave()` now resets `ready: false` when vacating a slot, matching what `kick()` already did.
- `setState(launching)` re-verifies under the queue lock that every slot is occupied and ready, and aborts the transition otherwise. Since `leave()`/`kick()` run under the same lock, either they commit first (the launch aborts and the queue stays in `ready` with its timeout tasks still armed) or the transition commits first (they are rejected by the existing `launching` guard) — no interleaving can launch with a vacated slot anymore.

Recovery for the case where a launch still fails is handled separately in a follow-up PR.
