### PR TITLE
fix(games): revert queue to waiting when game creation fails

### DIFF
--- a/src/games/launch-game.test.ts
+++ b/src/games/launch-game.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../queue-auto', () => ({
+  queue: {
+    getSlots: vi.fn().mockResolvedValue([]),
+    getMapWinner: vi.fn().mockResolvedValue('cp_badlands'),
+    getFriends: vi.fn().mockResolvedValue([]),
+  },
+}))
+
+vi.mock('../queue-auto/unready-queue', () => ({
+  unreadyQueue: vi.fn(),
+}))
+
+vi.mock('./create', () => ({
+  create: vi.fn(),
+}))
+
+vi.mock('./assign-game-server', () => ({
+  assignGameServer: vi.fn(),
+}))
+
+vi.mock('./rcon/configure', () => ({
+  configure: vi.fn(),
+}))
+
+vi.mock('../logger', () => ({
+  logger: { info: vi.fn(), trace: vi.fn(), error: vi.fn() },
+}))
+
+import { launchGame } from './launch-game'
+import { unreadyQueue } from '../queue-auto/unready-queue'
+import { create } from './create'
+import { assignGameServer } from './assign-game-server'
+
+describe('launchGame()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('assigns a game server to the created game', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(create).mockResolvedValue({ number: 42 } as any)
+
+    await launchGame()
+
+    expect(assignGameServer).toHaveBeenCalledWith(42, { retries: 3 })
+    expect(unreadyQueue).not.toHaveBeenCalled()
+  })
+
+  it('reverts the queue when game creation fails', async () => {
+    vi.mocked(create).mockRejectedValue(new Error('queue slot medic-1 is empty'))
+
+    await launchGame()
+
+    expect(unreadyQueue).toHaveBeenCalled()
+    expect(assignGameServer).not.toHaveBeenCalled()
+  })
+})

--- a/src/games/launch-game.test.ts
+++ b/src/games/launch-game.test.ts
@@ -5,11 +5,8 @@ vi.mock('../queue-auto', () => ({
     getSlots: vi.fn().mockResolvedValue([]),
     getMapWinner: vi.fn().mockResolvedValue('cp_badlands'),
     getFriends: vi.fn().mockResolvedValue([]),
+    unreadyQueue: vi.fn().mockResolvedValue(),
   },
-}))
-
-vi.mock('../queue-auto/unready-queue', () => ({
-  unreadyQueue: vi.fn(),
 }))
 
 vi.mock('./create', () => ({
@@ -29,9 +26,9 @@ vi.mock('../logger', () => ({
 }))
 
 import { launchGame } from './launch-game'
-import { unreadyQueue } from '../queue-auto/unready-queue'
 import { create } from './create'
 import { assignGameServer } from './assign-game-server'
+import { queue } from '../queue-auto'
 
 describe('launchGame()', () => {
   beforeEach(() => {
@@ -45,7 +42,7 @@ describe('launchGame()', () => {
     await launchGame()
 
     expect(assignGameServer).toHaveBeenCalledWith(42, { retries: 3 })
-    expect(unreadyQueue).not.toHaveBeenCalled()
+    expect(queue.unreadyQueue).not.toHaveBeenCalled()
   })
 
   it('reverts the queue when game creation fails', async () => {
@@ -53,7 +50,7 @@ describe('launchGame()', () => {
 
     await launchGame()
 
-    expect(unreadyQueue).toHaveBeenCalled()
+    expect(queue.unreadyQueue).toHaveBeenCalled()
     expect(assignGameServer).not.toHaveBeenCalled()
   })
 })

--- a/src/games/launch-game.ts
+++ b/src/games/launch-game.ts
@@ -1,16 +1,27 @@
+import type { GameModel } from '../database/models/game.model'
 import { logger } from '../logger'
 import { queue } from '../queue-auto'
+import { unreadyQueue } from '../queue-auto/unready-queue'
 import { assignGameServer } from './assign-game-server'
 import { create } from './create'
 import { configure } from './rcon/configure'
 
 export async function launchGame() {
   logger.info('launching game')
-  const slots = await queue.getSlots()
-  const map = await queue.getMapWinner()
-  const friends = await queue.getFriends()
-  logger.trace({ slots, map, friends }, 'launchGame()')
-  const { number } = await create(slots, map, friends)
-  await assignGameServer(number, { retries: 3 })
-  void configure(number)
+
+  let game: GameModel
+  try {
+    const slots = await queue.getSlots()
+    const map = await queue.getMapWinner()
+    const friends = await queue.getFriends()
+    logger.trace({ slots, map, friends }, 'launchGame()')
+    game = await create(slots, map, friends)
+  } catch (error) {
+    logger.error({ error }, 'failed to launch game; reverting queue')
+    await unreadyQueue()
+    return
+  }
+
+  await assignGameServer(game.number, { retries: 3 })
+  void configure(game.number)
 }

--- a/src/games/launch-game.ts
+++ b/src/games/launch-game.ts
@@ -1,7 +1,6 @@
 import type { GameModel } from '../database/models/game.model'
 import { logger } from '../logger'
 import { queue } from '../queue-auto'
-import { unreadyQueue } from '../queue-auto/unready-queue'
 import { assignGameServer } from './assign-game-server'
 import { create } from './create'
 import { configure } from './rcon/configure'
@@ -18,7 +17,7 @@ export async function launchGame() {
     game = await create(slots, map, friends)
   } catch (error) {
     logger.error({ error }, 'failed to launch game; reverting queue')
-    await unreadyQueue()
+    await queue.unreadyQueue()
     return
   }
 

--- a/src/queue-auto/index.ts
+++ b/src/queue-auto/index.ts
@@ -8,6 +8,7 @@ import { reset } from './reset'
 import { resetMapOptions } from '../maps/reset-options'
 import { getFriends } from './get-friends'
 import { getMapVoteResults } from './get-map-vote-results'
+import { unreadyQueue } from './unready-queue'
 
 const slotCount = await collections.queueSlots.countDocuments()
 if (slotCount === 0) {
@@ -23,4 +24,5 @@ export const queue = {
   getSlots,
   getState,
   resetMapOptions,
+  unreadyQueue,
 } as const

--- a/src/queue-auto/plugins/auto-update-queue-state.ts
+++ b/src/queue-auto/plugins/auto-update-queue-state.ts
@@ -7,7 +7,7 @@ import { logger } from '../../logger'
 import { QueueState } from '../../database/models/queue-state.model'
 import { setState } from '../../queue/set-state'
 import { kick } from '../kick'
-import { unready } from '../unready'
+import { unreadyQueue } from '../unready-queue'
 import { configuration } from '../../configuration'
 import { tasks } from '../../tasks'
 
@@ -56,15 +56,6 @@ export default fp(
           .toArray()
       ).map(slot => slot.player!.steamId)
       await kick(...unreadyPlayers)
-    }
-
-    async function unreadyQueue() {
-      logger.info('unready queue')
-      await setState(QueueState.waiting)
-      const allPlayers = (
-        await collections.queueSlots.find({ player: { $ne: null } }).toArray()
-      ).map(slot => slot.player!.steamId)
-      await unready(...allPlayers)
     }
 
     async function readyUpTimeout() {

--- a/src/queue-auto/unready-queue.ts
+++ b/src/queue-auto/unready-queue.ts
@@ -1,0 +1,14 @@
+import { collections } from '../database/collections'
+import { QueueState } from '../database/models/queue-state.model'
+import { logger } from '../logger'
+import { setState } from '../queue/set-state'
+import { unready } from './unready'
+
+export async function unreadyQueue() {
+  logger.info('unready queue')
+  await setState(QueueState.waiting)
+  const allPlayers = (await collections.queueSlots.find({ player: { $ne: null } }).toArray()).map(
+    slot => slot.player!.steamId,
+  )
+  await unready(...allPlayers)
+}


### PR DESCRIPTION
Related: #757

If `launchGame()` threw before the game was created, the queue stayed in `launching` forever — nothing reset the state, and every subsequent join/leave/kick was rejected with `invalid queue state`. A restart didn't help either: the `onListen` hook retried the launch, failed the same way, and wedged again. This is the failure mode that kept tf2pickup.ru stuck today until a manual DB edit.

`launchGame()` now reverts the queue (state back to `waiting`, all players unreadied) when anything up to and including game creation fails. Failures after creation are left alone — at that point `game:created` has already triggered the queue reset via the auto-reset plugin. This also makes a wedged instance self-heal on restart: the relaunch attempt fails and reverts instead of wedging again.

The plugin-private `unreadyQueue` helper is extracted into `src/queue-auto/unready-queue.ts` so `launchGame` can reuse it.
