### PR TITLE
refactor(pre-ready): expire pre-readies on a scheduled task

### DIFF
--- a/src/database/ensure-indexes.ts
+++ b/src/database/ensure-indexes.ts
@@ -43,8 +43,6 @@ const definitions: Partial<Record<keyof typeof collections, IndexDefinition[]>> 
   configuration: [{ spec: { key: 1 }, options: { unique: true } }],
   documents: [{ spec: { name: 1 }, options: { unique: true } }],
   announcements: [{ spec: { createdAt: -1 } }],
-  // every cancel()/cancelAll() filters by name, and leave/kick now cancel a
-  // pre-ready expiry per player while holding the queue lock
   tasks: [{ spec: { at: 1 } }, { spec: { name: 1 } }],
   discordBotState: [{ spec: { guildId: 1 }, options: { unique: true } }],
   keys: [{ spec: { name: 1 }, options: { unique: true } }],

--- a/src/database/ensure-indexes.ts
+++ b/src/database/ensure-indexes.ts
@@ -43,7 +43,9 @@ const definitions: Partial<Record<keyof typeof collections, IndexDefinition[]>> 
   configuration: [{ spec: { key: 1 }, options: { unique: true } }],
   documents: [{ spec: { name: 1 }, options: { unique: true } }],
   announcements: [{ spec: { createdAt: -1 } }],
-  tasks: [{ spec: { at: 1 } }],
+  // every cancel()/cancelAll() filters by name, and leave/kick now cancel a
+  // pre-ready expiry per player while holding the queue lock
+  tasks: [{ spec: { at: 1 } }, { spec: { name: 1 } }],
   discordBotState: [{ spec: { guildId: 1 }, options: { unique: true } }],
   keys: [{ spec: { name: 1 }, options: { unique: true } }],
   secrets: [{ spec: { name: 1 }, options: { unique: true } }],

--- a/src/pre-ready/cancel.test.ts
+++ b/src/pre-ready/cancel.test.ts
@@ -16,8 +16,15 @@ vi.mock('../events', () => ({
   },
 }))
 
+vi.mock('../tasks', () => ({
+  tasks: {
+    cancel: vi.fn(),
+  },
+}))
+
 import { players } from '../players'
 import { events } from '../events'
+import { tasks } from '../tasks'
 import { cancel } from './cancel'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 
@@ -36,5 +43,11 @@ describe('preReady.cancel', () => {
       steamId,
       preReadyUntil: undefined,
     })
+  })
+
+  it('disarms the scheduled expiry', async () => {
+    await cancel(steamId)
+
+    expect(tasks.cancel).toHaveBeenCalledWith('preReady:cancel', { player: steamId })
   })
 })

--- a/src/pre-ready/cancel.ts
+++ b/src/pre-ready/cancel.ts
@@ -2,9 +2,11 @@ import { events } from '../events'
 import { logger } from '../logger'
 import { players } from '../players'
 import type { SteamId64 } from '../shared/types/steam-id-64'
+import { tasks } from '../tasks'
 
 export async function cancel(player: SteamId64) {
   logger.trace({ player }, 'preReady.cancel()')
+  await tasks.cancel('preReady:cancel', { player })
   await players.update(player, { $unset: { preReadyUntil: 1 } })
   events.emit('player/preReady:updated', { steamId: player, preReadyUntil: undefined })
 }

--- a/src/pre-ready/plugins/auto-cancel.test.ts
+++ b/src/pre-ready/plugins/auto-cancel.test.ts
@@ -11,24 +11,23 @@ vi.mock('../../events', () => ({
   },
 }))
 
-vi.mock('../../players/update', () => ({
-  update: vi.fn(),
-}))
-
 vi.mock('../../utils/safe', () => ({
   safe: <T>(fn: T): T => fn,
 }))
 
-vi.mock('../../database/collections', () => ({
-  collections: {
-    players: {
-      find: vi.fn(),
-    },
+vi.mock('../../tasks', () => ({
+  tasks: {
+    register: vi.fn(),
   },
 }))
 
+vi.mock('../cancel', () => ({
+  cancel: vi.fn(),
+}))
+
 import { events } from '../../events'
-import { update } from '../../players/update'
+import { tasks } from '../../tasks'
+import { cancel } from '../cancel'
 import plugin from './auto-cancel'
 import type { GameModel, GameNumber } from '../../database/models/game.model'
 import type { SteamId64 } from '../../shared/types/steam-id-64'
@@ -41,7 +40,6 @@ describe('auto-cancel pre-ready up', () => {
 
   beforeEach(async () => {
     vi.resetAllMocks()
-    vi.mocked(update).mockResolvedValue({} as never)
     await (plugin as unknown as () => Promise<void>)()
     const call = vi
       .mocked(events.on)
@@ -49,7 +47,16 @@ describe('auto-cancel pre-ready up', () => {
     gameCreatedHandler = call![1] as typeof gameCreatedHandler
   })
 
-  it('emits player/preReady:updated with undefined for each player on game:created', async () => {
+  it('cancels the pre-ready when the scheduled expiry fires', async () => {
+    const [name, handler] = vi.mocked(tasks.register).mock.calls[0]!
+
+    expect(name).toBe('preReady:cancel')
+    await handler({ player: player1 })
+
+    expect(cancel).toHaveBeenCalledWith(player1)
+  })
+
+  it('cancels the pre-ready of every player on game:created', async () => {
     const game = {
       number: 1 as GameNumber,
       slots: [{ player: player1 }, { player: player2 }],
@@ -57,13 +64,7 @@ describe('auto-cancel pre-ready up', () => {
 
     await gameCreatedHandler({ game })
 
-    expect(events.emit).toHaveBeenCalledWith('player/preReady:updated', {
-      steamId: player1,
-      preReadyUntil: undefined,
-    })
-    expect(events.emit).toHaveBeenCalledWith('player/preReady:updated', {
-      steamId: player2,
-      preReadyUntil: undefined,
-    })
+    expect(cancel).toHaveBeenCalledWith(player1)
+    expect(cancel).toHaveBeenCalledWith(player2)
   })
 })

--- a/src/pre-ready/plugins/auto-cancel.ts
+++ b/src/pre-ready/plugins/auto-cancel.ts
@@ -1,36 +1,22 @@
 import fp from 'fastify-plugin'
-import { collections } from '../../database/collections'
-import { update } from '../../players/update'
-import { secondsToMilliseconds } from 'date-fns'
 import { events } from '../../events'
 import { safe } from '../../utils/safe'
-import type { PlayerModel } from '../../database/models/player.model'
-
-async function process() {
-  const toRemove = await collections.players
-    .find<Pick<PlayerModel, 'steamId'>>(
-      { preReadyUntil: { $lte: new Date() } },
-      { projection: { steamId: 1 } },
-    )
-    .toArray()
-  for (const p of toRemove) {
-    await update(p.steamId, { $unset: { preReadyUntil: 1 } })
-    events.emit('player/preReady:updated', { steamId: p.steamId, preReadyUntil: undefined })
-  }
-}
+import { tasks } from '../../tasks'
+import { cancel } from '../cancel'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
   async () => {
-    setInterval(process, secondsToMilliseconds(1))
+    tasks.register('preReady:cancel', async ({ player }) => {
+      await cancel(player)
+    })
 
     events.on(
       'game:created',
       safe(async ({ game }) => {
         await Promise.all(
           game.slots.map(async ({ player }) => {
-            await update(player, { $unset: { preReadyUntil: 1 } })
-            events.emit('player/preReady:updated', { steamId: player, preReadyUntil: undefined })
+            await cancel(player)
           }),
         )
       }),

--- a/src/pre-ready/start.test.ts
+++ b/src/pre-ready/start.test.ts
@@ -22,9 +22,17 @@ vi.mock('../events', () => ({
   },
 }))
 
+vi.mock('../tasks', () => ({
+  tasks: {
+    cancel: vi.fn(),
+    schedule: vi.fn(),
+  },
+}))
+
 import { configuration } from '../configuration'
 import { players } from '../players'
 import { events } from '../events'
+import { tasks } from '../tasks'
 import { start } from './start'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 
@@ -47,11 +55,21 @@ describe('preReady.start', () => {
     })
   })
 
+  it('schedules the expiry, replacing any previously armed one', async () => {
+    vi.mocked(configuration.get).mockResolvedValue(30_000)
+
+    await start(steamId)
+
+    expect(tasks.cancel).toHaveBeenCalledWith('preReady:cancel', { player: steamId })
+    expect(tasks.schedule).toHaveBeenCalledWith('preReady:cancel', 30_000, { player: steamId })
+  })
+
   it('does not emit player/preReady:updated when timeout is zero', async () => {
     vi.mocked(configuration.get).mockResolvedValue(0)
 
     await start(steamId)
 
     expect(events.emit).not.toHaveBeenCalled()
+    expect(tasks.schedule).not.toHaveBeenCalled()
   })
 })

--- a/src/pre-ready/start.ts
+++ b/src/pre-ready/start.ts
@@ -3,6 +3,7 @@ import { events } from '../events'
 import { logger } from '../logger'
 import { players } from '../players'
 import type { SteamId64 } from '../shared/types/steam-id-64'
+import { tasks } from '../tasks'
 
 export async function start(player: SteamId64) {
   const timeout = await configuration.get('queue.pre_ready_up_timeout')
@@ -12,6 +13,10 @@ export async function start(player: SteamId64) {
 
   if (timeout > 0) {
     await players.update(player, { $set: { preReadyUntil } })
+    // start() runs again every time the player re-enters the ready flow, so the
+    // previous expiry has to go before arming the new one
+    await tasks.cancel('preReady:cancel', { player })
+    await tasks.schedule('preReady:cancel', timeout, { player })
     events.emit('player/preReady:updated', { steamId: player, preReadyUntil })
   }
 }

--- a/src/tasks/tasks.ts
+++ b/src/tasks/tasks.ts
@@ -35,6 +35,12 @@ export const tasksSchema = z.discriminatedUnion('name', [
     }),
   }),
   z.object({
+    name: z.literal('preReady:cancel'),
+    args: z.object({
+      player: steamId64,
+    }),
+  }),
+  z.object({
     name: z.literal('queue:readyUpTimeout'),
     args: z.object({}),
   }),


### PR DESCRIPTION
`src/pre-ready/plugins/auto-cancel.ts` ran `setInterval(process, secondsToMilliseconds(1))` for the whole process lifetime, and every tick scanned the entire `players` collection for `{ preReadyUntil: { $lte: new Date() } }`. That is 86400 collection scans a day to service a handful of expiries.

The `tasks` scheduler already does this properly — persisted in mongo, re-armed on startup by `arm-persisted-tasks`, cancellable by args — and is what the queue, games, mumble, logs.tf and serveme.tf modules all use. So the poll becomes a task:

- `preReady.start()` arms `preReady:cancel` for exactly the pre-ready window. It cancels any previously armed one first, because `start()` runs again every time a player re-enters the ready flow (`join` into a ready queue → `ready-up` → `setState(ready)`); without that, a stale expiry would cancel a freshly started pre-ready early.
- `preReady.cancel()` disarms it, so a manually cancelled pre-ready doesn't fire a redundant expiry later.
- The task handler is `preReady.cancel()` itself — which is exactly what the poll body already was. The `game:created` handler was a third copy of the same `$unset` + emit, so it collapses into the same call and now disarms the pending task too.

Net effect: the expiry fires once, at the moment it is due, instead of being noticed up to a second late by a scan. Restart behaviour is unchanged — `arm()` clamps a past due date to a zero delay, so a pre-ready that lapsed while the process was down is cancelled immediately on boot.

Also indexes `tasks.name`. Every `cancel()` / `cancelAll()` filters by it and the collection only had `{ at: 1 }`; `leave()` / `kick()` now cancel a pre-ready expiry per player while holding the queue lock, so those calls should be seeks rather than scans.

### Note on deploy

Players holding a live `preReadyUntil` at deploy time have no task scheduled for them, so their value is never actively unset. It is inert — `isPreReadied()`, the `$gte` filter in `setState()` and the button all compare against the current time, so it reads as expired — the only effect is that their button won't clear until the next render. Self-limited to one `queue.pre_ready_up_timeout` window after deploy, so no migration.

### Testing

`pnpm lint`, `tsc --noEmit` and `pnpm test` (73 files, 406 tests) pass locally. The e2e `pre-ready expires` spec in `tests/10-queue/07-pre-ready-up.spec.ts` covers the behaviour end to end and asserts the button clears within 2s of the deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)