### PR TITLE
feat(queue): add the captain draft matching engine

### DIFF
--- a/src/queue-captains/draft-simulation.test.ts
+++ b/src/queue-captains/draft-simulation.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import { _6v6 } from '../queue-auto/configs/6v6'
+import { _9v9 } from '../queue-auto/configs/9v9'
+import type { QueueConfig } from '../queue/types/queue-config'
+import type { SteamId64 } from '../shared/types/steam-id-64'
+import type { Tf2ClassName } from '../shared/types/tf2-class-name'
+import { Tf2Team } from '../shared/types/tf2-team'
+import { legalPicks } from './matching/legal-picks'
+import { queueReadiness } from './matching/queue-readiness'
+import { pickOrder } from './pick-order'
+import { teamSlots } from './team-slots'
+import type { DraftCandidate } from './types/draft-candidate'
+
+// deterministic, so a failure is always reproducible from its seed
+function makeRandom(seed: number): () => number {
+  let state = seed
+  return () => {
+    state = (state * 1103515245 + 12345) % 2147483648
+    return state / 2147483648
+  }
+}
+
+function makePool(random: () => number, size: number, config: QueueConfig): DraftCandidate[] {
+  const classes = config.classes.map(({ name }) => name)
+  return Array.from({ length: size }, (_, index) => {
+    const gameClasses = classes.filter(() => random() < 0.45)
+    if (gameClasses.length === 0) {
+      gameClasses.push(classes[Math.floor(random() * classes.length)]!)
+    }
+    return { steamId: `player-${index}` as unknown as SteamId64, gameClasses }
+  })
+}
+
+/**
+ * Play a whole draft out, always taking the first legal pick. Throws the moment a captain is left
+ * with nothing to choose — the dead-end this whole module exists to prevent.
+ */
+function runDraft(pool: DraftCandidate[], config: QueueConfig) {
+  const captains: Record<Tf2Team, SteamId64> = {
+    [Tf2Team.blu]: pool[0]!.steamId,
+    [Tf2Team.red]: pool[1]!.steamId,
+  }
+  let candidates: DraftCandidate[] = pool.map((candidate, index) => ({
+    ...candidate,
+    ...(index === 0 && { team: Tf2Team.blu }),
+    ...(index === 1 && { team: Tf2Team.red }),
+  }))
+  let openSlots = teamSlots(config)
+  const picked: { steamId: SteamId64; gameClass: Tf2ClassName; team: Tf2Team }[] = []
+
+  for (const team of pickOrder(config)) {
+    const picks = legalPicks({ openSlots, candidates, team })
+    if (picks.length === 0) {
+      throw new Error(`dead end on turn ${picked.length + 1} for ${team}`)
+    }
+
+    const pick = picks[0]!
+    const slot = openSlots.findIndex(
+      open => open.team === team && open.gameClass === pick.gameClass,
+    )
+    openSlots = openSlots.filter((_, index) => index !== slot)
+    candidates = candidates.filter(candidate => candidate.steamId !== pick.steamId)
+    picked.push({ ...pick, team })
+  }
+
+  return { picked, openSlots, candidates, captains }
+}
+
+describe('a draft driven by legalPicks()', () => {
+  describe.each([
+    ['6v6', _6v6, 12],
+    ['9v9', _9v9, 18],
+  ])('%s', (_name, config, required) => {
+    // generated pools, keeping only the ones the queue would have accepted as full
+    const pools = Array.from({ length: 150 }, (_, seed) => {
+      const random = makeRandom(seed + 1)
+      return makePool(random, required + (seed % 5), config)
+    }).filter(pool => queueReadiness(pool, config).fillable === required)
+
+    // each draft is played out once and then asserted on from every angle
+    const outcomes = pools.map(pool => {
+      try {
+        return { pool, draft: runDraft(pool, config), deadEnd: null as string | null }
+      } catch (error) {
+        return { pool, draft: null, deadEnd: (error as Error).message }
+      }
+    })
+    const drafts = outcomes.flatMap(outcome =>
+      outcome.draft === null ? [] : [{ pool: outcome.pool, ...outcome.draft }],
+    )
+
+    it('generates enough ready pools to be worth anything', () => {
+      expect(pools.length).toBeGreaterThan(20)
+    })
+
+    it('never dead-ends', () => {
+      expect(outcomes.flatMap(outcome => outcome.deadEnd ?? [])).toEqual([])
+    })
+
+    it('leaves exactly one slot per team, for the two captains', () => {
+      for (const { openSlots } of drafts) {
+        expect(openSlots).toHaveLength(2)
+        expect(openSlots.map(slot => slot.team).sort()).toEqual([Tf2Team.blu, Tf2Team.red])
+      }
+    })
+
+    it('leaves each captain a slot they can actually play', () => {
+      for (const { openSlots, candidates, captains } of drafts) {
+        for (const team of [Tf2Team.blu, Tf2Team.red]) {
+          const captain = candidates.find(candidate => candidate.steamId === captains[team])!
+          const slot = openSlots.find(open => open.team === team)!
+          expect(captain.gameClasses).toContain(slot.gameClass)
+        }
+      }
+    })
+
+    it('never picks the same player twice, nor a captain', () => {
+      for (const { picked, captains } of drafts) {
+        const steamIds = picked.map(pick => pick.steamId)
+        expect(new Set(steamIds).size).toBe(steamIds.length)
+        expect(steamIds).not.toContain(captains[Tf2Team.blu])
+        expect(steamIds).not.toContain(captains[Tf2Team.red])
+      }
+    })
+
+    it('only ever picks a class the player signed up for', () => {
+      for (const { pool, picked } of drafts) {
+        for (const pick of picked) {
+          const player = pool.find(candidate => candidate.steamId === pick.steamId)!
+          expect(player.gameClasses).toContain(pick.gameClass)
+        }
+      }
+    })
+  })
+})

--- a/src/queue-captains/matching/is-feasible.test.ts
+++ b/src/queue-captains/matching/is-feasible.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import { Tf2Team } from '../../shared/types/tf2-team'
+import type { DraftCandidate } from '../types/draft-candidate'
+import type { TeamSlot } from '../types/team-slot'
+import { isFeasible } from './is-feasible'
+
+const { scout, soldier, demoman } = Tf2ClassName
+const { blu, red } = Tf2Team
+
+function player(name: string, gameClasses: Tf2ClassName[], team?: Tf2Team): DraftCandidate {
+  return { steamId: name as unknown as SteamId64, gameClasses, ...(team && { team }) }
+}
+
+function slot(team: Tf2Team, gameClass: Tf2ClassName): TeamSlot {
+  return { team, gameClass }
+}
+
+describe('isFeasible()', () => {
+  it('accepts a pool that covers every slot', () => {
+    expect(
+      isFeasible(
+        [slot(blu, scout), slot(red, soldier)],
+        [player('a', [scout]), player('b', [soldier])],
+      ),
+    ).toBe(true)
+  })
+
+  it('accepts spare players sitting the game out', () => {
+    expect(isFeasible([slot(blu, scout)], [player('a', [scout]), player('b', [scout])])).toBe(true)
+  })
+
+  it('rejects a slot nobody can fill', () => {
+    expect(isFeasible([slot(blu, scout), slot(blu, demoman)], [player('a', [scout])])).toBe(false)
+  })
+
+  it('accepts nothing left to do', () => {
+    expect(isFeasible([], [])).toBe(true)
+  })
+
+  describe('captains', () => {
+    it('rejects a completion that leaves a captain without a slot', () => {
+      // BLU is already full, so the remaining slot can only go to 'a' — and that squeezes the BLU
+      // captain out of their own game, which is not a valid way to finish a draft
+      expect(
+        isFeasible(
+          [slot(red, soldier)],
+          [player('captain', [soldier], blu), player('a', [soldier])],
+        ),
+      ).toBe(false)
+    })
+
+    it('accepts when the captain can still be fitted in', () => {
+      expect(
+        isFeasible(
+          [slot(blu, soldier), slot(red, soldier)],
+          [player('captain', [soldier], blu), player('a', [soldier])],
+        ),
+      ).toBe(true)
+    })
+
+    it('rejects a captain who cannot play any class their team still needs', () => {
+      expect(
+        isFeasible(
+          [slot(blu, scout), slot(red, soldier)],
+          [player('captain', [soldier], blu), player('a', [scout])],
+        ),
+      ).toBe(false)
+    })
+
+    it('fits both captains at once', () => {
+      expect(
+        isFeasible(
+          [slot(blu, demoman), slot(red, demoman)],
+          [player('one', [demoman], blu), player('two', [demoman], red)],
+        ),
+      ).toBe(true)
+    })
+  })
+})

--- a/src/queue-captains/matching/is-feasible.ts
+++ b/src/queue-captains/matching/is-feasible.ts
@@ -1,0 +1,21 @@
+import type { DraftCandidate } from '../types/draft-candidate'
+import type { TeamSlot } from '../types/team-slot'
+import { maxAssignment } from './max-assignment'
+
+/**
+ * Can the draft still be completed from here?
+ *
+ * Two things have to hold: every slot gets filled, and every captain gets a slot. Spare players
+ * sitting the game out is fine and expected — the pool is allowed to be bigger than the game — but
+ * a captain being squeezed out is not a valid finish.
+ */
+export function isFeasible(slots: TeamSlot[], candidates: DraftCandidate[]): boolean {
+  const assignment = maxAssignment(slots, candidates)
+
+  return (
+    assignment.slots.every(candidate => candidate !== null) &&
+    candidates.every(
+      (candidate, index) => candidate.team === undefined || assignment.candidates[index] !== null,
+    )
+  )
+}

--- a/src/queue-captains/matching/legal-picks.test.ts
+++ b/src/queue-captains/matching/legal-picks.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import { Tf2Team } from '../../shared/types/tf2-team'
+import type { DraftCandidate } from '../types/draft-candidate'
+import type { TeamSlot } from '../types/team-slot'
+import { legalPicks } from './legal-picks'
+
+const { scout, soldier, demoman } = Tf2ClassName
+const { blu, red } = Tf2Team
+
+function player(name: string, gameClasses: Tf2ClassName[], team?: Tf2Team): DraftCandidate {
+  return { steamId: name as unknown as SteamId64, gameClasses, ...(team && { team }) }
+}
+
+function slot(team: Tf2Team, gameClass: Tf2ClassName): TeamSlot {
+  return { team, gameClass }
+}
+
+function names(picks: { steamId: SteamId64; gameClass: Tf2ClassName }[]): string[] {
+  return picks.map(pick => `${pick.steamId as unknown as string}/${pick.gameClass}`).sort()
+}
+
+describe('legalPicks()', () => {
+  it('offers nothing when the team has no open slot', () => {
+    const picks = legalPicks({
+      openSlots: [slot(red, scout)],
+      candidates: [player('a', [scout])],
+      team: blu,
+    })
+    expect(picks).toEqual([])
+  })
+
+  it('offers only the classes a player signed up for', () => {
+    // b on scout would strand the soldier slot, since a cannot cover it
+    const picks = legalPicks({
+      openSlots: [slot(blu, scout), slot(blu, soldier)],
+      candidates: [player('a', [scout]), player('b', [scout, soldier])],
+      team: blu,
+    })
+    expect(names(picks)).toEqual(['a/scout', 'b/soldier'])
+  })
+
+  it('never offers a captain — they take whatever their team has left', () => {
+    const picks = legalPicks({
+      openSlots: [slot(blu, soldier), slot(blu, scout), slot(red, soldier)],
+      candidates: [
+        player('captain', [soldier, scout], blu),
+        player('a', [soldier]),
+        player('b', [scout]),
+        player('c', [soldier]),
+      ],
+      team: blu,
+    })
+    expect(names(picks)).toEqual(['a/soldier', 'b/scout', 'c/soldier'])
+  })
+
+  it('refuses a pick that would squeeze the captain out of the game', () => {
+    // BLU's only soldier slot is the captain's only possible slot, so it is not up for grabs
+    const picks = legalPicks({
+      openSlots: [slot(blu, soldier), slot(red, soldier)],
+      candidates: [
+        player('captain', [soldier], blu),
+        player('a', [soldier]),
+        player('b', [soldier]),
+      ],
+      team: blu,
+    })
+    expect(picks).toEqual([])
+  })
+
+  // The board from the design mockup: pick 8 of 10, BLU on the clock.
+  // BLU has kestrel on scout, axolotl on soldier and dusk on medic; RED has bramble and gale on
+  // scout, flint on soldier and ivy on medic. cinder captains BLU, harbor captains RED.
+  describe('mid-draft, with the pool running thin', () => {
+    const openSlots = [
+      slot(blu, scout),
+      slot(blu, soldier),
+      slot(blu, demoman),
+      slot(red, soldier),
+      slot(red, demoman),
+    ]
+    const candidates = [
+      player('cinder', [soldier, demoman], blu),
+      player('harbor', [scout, demoman], red),
+      player('ember', [scout]),
+      player('juniper', [demoman, scout]),
+      player('larch', [soldier]),
+      player('moss', [scout]),
+    ]
+
+    const picks = legalPicks({ openSlots, candidates, team: blu })
+
+    it('offers exactly the picks that keep the draft completable', () => {
+      expect(names(picks)).toEqual(['ember/scout', 'juniper/demoman', 'moss/scout'])
+    })
+
+    it('locks larch, the last soldier RED can still use', () => {
+      expect(names(picks)).not.toContain('larch/soldier')
+    })
+
+    it('locks juniper on scout, which would strand BLU’s own demoman slot', () => {
+      // juniper on demoman is fine, so this is feasibility talking, not the class count
+      expect(names(picks)).toContain('juniper/demoman')
+      expect(names(picks)).not.toContain('juniper/scout')
+    })
+  })
+
+  it('offers a pick that empties a class only when nobody else needs it', () => {
+    // 'a' is the last demoman but the only open demoman slot belongs to BLU, so taking them is fine
+    const picks = legalPicks({
+      openSlots: [slot(blu, demoman), slot(red, scout)],
+      candidates: [player('a', [demoman]), player('b', [scout])],
+      team: blu,
+    })
+    expect(names(picks)).toEqual(['a/demoman'])
+  })
+
+  it('offers a forced last pick', () => {
+    const picks = legalPicks({
+      openSlots: [slot(red, soldier)],
+      candidates: [player('larch', [soldier]), player('moss', [scout])],
+      team: red,
+    })
+    expect(names(picks)).toEqual(['larch/soldier'])
+  })
+})

--- a/src/queue-captains/matching/legal-picks.ts
+++ b/src/queue-captains/matching/legal-picks.ts
@@ -1,0 +1,57 @@
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import type { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import type { Tf2Team } from '../../shared/types/tf2-team'
+import type { DraftCandidate } from '../types/draft-candidate'
+import type { TeamSlot } from '../types/team-slot'
+import { isFeasible } from './is-feasible'
+
+export interface LegalPick {
+  steamId: SteamId64
+  gameClass: Tf2ClassName
+}
+
+export interface LegalPicksParams {
+  // slots still to be filled, across both teams
+  openSlots: TeamSlot[]
+
+  // everyone still unassigned, including both captains
+  candidates: DraftCandidate[]
+
+  // the team on the clock
+  team: Tf2Team
+}
+
+/**
+ * Every player-and-class a captain is allowed to take this turn.
+ *
+ * Checking the class alone is not enough: taking the last player who can cover some class leaves
+ * the draft with no valid completion, and a captain could otherwise pick their way into a corner.
+ * So each candidate pick is provisionally applied and kept only if the rest of both teams can
+ * still be filled.
+ *
+ * Captains are never pickable — they take whatever slot their own team has left over.
+ */
+export function legalPicks({ openSlots, candidates, team }: LegalPicksParams): LegalPick[] {
+  const picks: LegalPick[] = []
+
+  for (const [index, candidate] of candidates.entries()) {
+    if (candidate.team !== undefined) {
+      continue
+    }
+
+    for (const gameClass of new Set(candidate.gameClasses)) {
+      const slot = openSlots.findIndex(open => open.team === team && open.gameClass === gameClass)
+      if (slot < 0) {
+        continue
+      }
+
+      const remainingSlots = openSlots.filter((_, open) => open !== slot)
+      const remainingCandidates = candidates.filter((_, other) => other !== index)
+      if (isFeasible(remainingSlots, remainingCandidates)) {
+        picks.push({ steamId: candidate.steamId, gameClass })
+      }
+    }
+  }
+
+  return picks
+}

--- a/src/queue-captains/matching/max-assignment.test.ts
+++ b/src/queue-captains/matching/max-assignment.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import { Tf2Team } from '../../shared/types/tf2-team'
+import type { DraftCandidate } from '../types/draft-candidate'
+import type { TeamSlot } from '../types/team-slot'
+import { maxAssignment } from './max-assignment'
+
+const { scout, soldier, demoman, medic } = Tf2ClassName
+const { blu, red } = Tf2Team
+
+// the name doubles as the steam id so failures name the player
+function player(name: string, gameClasses: Tf2ClassName[], team?: Tf2Team): DraftCandidate {
+  return { steamId: name as unknown as SteamId64, gameClasses, ...(team && { team }) }
+}
+
+function slot(team: Tf2Team, gameClass: Tf2ClassName): TeamSlot {
+  return { team, gameClass }
+}
+
+function filled(slots: TeamSlot[], candidates: DraftCandidate[]): number {
+  return maxAssignment(slots, candidates).slots.filter(candidate => candidate !== null).length
+}
+
+describe('maxAssignment()', () => {
+  it('fills every slot when the pool covers them', () => {
+    const slots = [slot(blu, scout), slot(blu, medic), slot(red, scout), slot(red, medic)]
+    const candidates = [
+      player('a', [scout]),
+      player('b', [medic]),
+      player('c', [scout]),
+      player('d', [medic]),
+    ]
+    expect(filled(slots, candidates)).toBe(4)
+  })
+
+  it('leaves a slot empty when nobody plays that class', () => {
+    const slots = [slot(blu, scout), slot(blu, medic)]
+    const candidates = [player('a', [scout]), player('b', [scout])]
+
+    const assignment = maxAssignment(slots, candidates).slots
+    expect(assignment[0]).not.toBeNull()
+    expect(assignment[1]).toBeNull()
+  })
+
+  it('reshuffles an earlier assignment to fit a later slot', () => {
+    // 'a' is the only medic, so the scout slot has to fall to 'b' even though 'a' was tried first
+    const slots = [slot(blu, scout), slot(blu, medic)]
+    const candidates = [player('a', [scout, medic]), player('b', [scout])]
+    expect(filled(slots, candidates)).toBe(2)
+  })
+
+  it('never assigns one player to two slots', () => {
+    const slots = [slot(blu, scout), slot(red, scout)]
+    const candidates = [player('a', [scout])]
+
+    const assignment = maxAssignment(slots, candidates).slots
+    expect(assignment.filter(candidate => candidate !== null)).toHaveLength(1)
+  })
+
+  it('tolerates a pool larger than the game', () => {
+    const slots = [slot(blu, scout)]
+    const candidates = [player('a', [scout]), player('b', [scout]), player('c', [scout])]
+    expect(filled(slots, candidates)).toBe(1)
+  })
+
+  it('returns nothing to fill when the pool is empty', () => {
+    expect(maxAssignment([slot(blu, scout)], []).slots).toEqual([null])
+  })
+
+  describe('when a candidate is pinned to a team', () => {
+    it('keeps them out of the other team', () => {
+      const slots = [slot(red, soldier)]
+      const candidates = [player('captain', [soldier], blu)]
+      expect(filled(slots, candidates)).toBe(0)
+    })
+
+    it('still places them on their own team', () => {
+      const slots = [slot(blu, soldier), slot(red, soldier)]
+      const candidates = [player('captain', [soldier], blu), player('a', [soldier])]
+
+      const assignment = maxAssignment(slots, candidates).slots
+      expect(assignment[0]).toBe(0)
+      expect(assignment[1]).toBe(1)
+    })
+
+    it('displaces an unpinned player who took their slot first', () => {
+      // 'a' fits either side, the captain only fits BLU — 'a' has to move to RED
+      const slots = [slot(blu, demoman), slot(red, demoman)]
+      const candidates = [player('a', [demoman]), player('captain', [demoman], blu)]
+      expect(filled(slots, candidates)).toBe(2)
+    })
+  })
+})

--- a/src/queue-captains/matching/max-assignment.ts
+++ b/src/queue-captains/matching/max-assignment.ts
@@ -1,0 +1,84 @@
+import type { DraftCandidate } from '../types/draft-candidate'
+import type { TeamSlot } from '../types/team-slot'
+
+export interface Assignment {
+  // slot index -> candidate filling it, or null when the slot could not be filled
+  slots: (number | null)[]
+
+  // candidate index -> slot they were given, or null when they sit this game out
+  candidates: (number | null)[]
+}
+
+/**
+ * Maximum bipartite matching (Kuhn's algorithm) between team slots and the players who could fill
+ * them.
+ *
+ * Captains are matched first, because unlike everyone else they cannot sit the game out — the
+ * pool is allowed to be bigger than the game, but a captain is always in it. Augmenting paths only
+ * ever reroute a matched vertex, never unmatch one, so filling the remaining slots afterwards can
+ * move a captain to a different slot but can never drop them.
+ *
+ * At most 18 slots and a couple dozen candidates, so the O(V*E) walk is far cheaper than the
+ * database round-trip that feeds it.
+ */
+export function maxAssignment(slots: TeamSlot[], candidates: DraftCandidate[]): Assignment {
+  const slotToCandidate: (number | null)[] = slots.map(() => null)
+  const candidateToSlot: (number | null)[] = candidates.map(() => null)
+
+  candidates.forEach((candidate, index) => {
+    if (candidate.team !== undefined) {
+      claimSlot(index, new Set<number>())
+    }
+  })
+
+  for (let slot = 0; slot < slots.length; ++slot) {
+    if (slotToCandidate[slot] === null) {
+      claimCandidate(slot, new Set<number>())
+    }
+  }
+
+  return { slots: slotToCandidate, candidates: candidateToSlot }
+
+  function claimCandidate(slot: number, visited: Set<number>): boolean {
+    for (let candidate = 0; candidate < candidates.length; ++candidate) {
+      if (visited.has(candidate) || !canFill(slots[slot]!, candidates[candidate]!)) {
+        continue
+      }
+
+      visited.add(candidate)
+      const takenBy = candidateToSlot[candidate] ?? null
+      if (takenBy === null || claimCandidate(takenBy, visited)) {
+        slotToCandidate[slot] = candidate
+        candidateToSlot[candidate] = slot
+        return true
+      }
+    }
+
+    return false
+  }
+
+  function claimSlot(candidate: number, visited: Set<number>): boolean {
+    for (let slot = 0; slot < slots.length; ++slot) {
+      if (visited.has(slot) || !canFill(slots[slot]!, candidates[candidate]!)) {
+        continue
+      }
+
+      visited.add(slot)
+      const takenBy = slotToCandidate[slot] ?? null
+      if (takenBy === null || claimSlot(takenBy, visited)) {
+        slotToCandidate[slot] = candidate
+        candidateToSlot[candidate] = slot
+        return true
+      }
+    }
+
+    return false
+  }
+}
+
+function canFill(slot: TeamSlot, candidate: DraftCandidate): boolean {
+  return (
+    candidate.gameClasses.includes(slot.gameClass) &&
+    (candidate.team === undefined || candidate.team === slot.team)
+  )
+}

--- a/src/queue-captains/matching/queue-readiness.test.ts
+++ b/src/queue-captains/matching/queue-readiness.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { _6v6 } from '../../queue-auto/configs/6v6'
+import { _9v9 } from '../../queue-auto/configs/9v9'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import type { DraftCandidate } from '../types/draft-candidate'
+import { queueReadiness } from './queue-readiness'
+
+const { scout, soldier, demoman, medic } = Tf2ClassName
+
+function player(name: string, ...gameClasses: Tf2ClassName[]): DraftCandidate {
+  return { steamId: name as unknown as SteamId64, gameClasses }
+}
+
+describe('queueReadiness()', () => {
+  it('needs twelve slots for 6v6 and eighteen for 9v9', () => {
+    expect(queueReadiness([], _6v6).required).toBe(12)
+    expect(queueReadiness([], _9v9).required).toBe(18)
+  })
+
+  it('reports an empty pool as filling nothing', () => {
+    const readiness = queueReadiness([], _6v6)
+    expect(readiness.fillable).toBe(0)
+    expect(readiness.missing).toHaveLength(12)
+  })
+
+  describe('with a pool that is one soldier and one medic short', () => {
+    // thirteen players, but only three can play soldier and only one can play medic
+    const pool = [
+      player('axolotl', soldier, scout),
+      player('bramble', scout),
+      player('cinder', soldier, demoman),
+      player('dusk', medic, scout),
+      player('ember', scout),
+      player('flint', soldier),
+      player('gale', scout, demoman),
+      player('harbor', scout, demoman),
+      player('ivy', scout),
+      player('juniper', demoman, scout),
+      player('kestrel', scout),
+      player('larch', scout),
+      player('moss', scout),
+    ]
+
+    it('fills ten of the twelve slots', () => {
+      expect(queueReadiness(pool, _6v6).fillable).toBe(10)
+    })
+
+    it('names the two classes it is waiting for', () => {
+      expect([...queueReadiness(pool, _6v6).missing].sort()).toEqual([medic, soldier])
+    })
+
+    it('does not count a headcount of thirteen as ready', () => {
+      const readiness = queueReadiness(pool, _6v6)
+      expect(pool.length).toBeGreaterThan(readiness.required)
+      expect(readiness.fillable).toBeLessThan(readiness.required)
+    })
+  })
+
+  it('is ready once the missing classes turn up', () => {
+    const pool = [
+      player('axolotl', soldier),
+      player('bramble', scout),
+      player('cinder', soldier),
+      player('dusk', medic),
+      player('ember', scout),
+      player('flint', soldier),
+      player('gale', demoman),
+      player('harbor', demoman),
+      player('ivy', scout),
+      player('juniper', soldier),
+      player('kestrel', scout),
+      player('larch', medic),
+    ]
+
+    const readiness = queueReadiness(pool, _6v6)
+    expect(readiness.fillable).toBe(readiness.required)
+    expect(readiness.missing).toEqual([])
+  })
+
+  it('counts a multi-class player towards one slot only', () => {
+    // one player who can cover everything still leaves eleven slots open
+    const readiness = queueReadiness([player('solo', scout, soldier, demoman, medic)], _6v6)
+    expect(readiness.fillable).toBe(1)
+  })
+})

--- a/src/queue-captains/matching/queue-readiness.ts
+++ b/src/queue-captains/matching/queue-readiness.ts
@@ -1,0 +1,42 @@
+import type { QueueConfig } from '../../queue/types/queue-config'
+import type { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import { teamSlots } from '../team-slots'
+import type { DraftCandidate } from '../types/draft-candidate'
+import { maxAssignment } from './max-assignment'
+
+export interface QueueReadiness {
+  // slots a finished game needs — 12 for 6v6, 18 for 9v9
+  required: number
+
+  // slots the current pool can actually fill
+  fillable: number
+
+  // the classes of the slots left over, i.e. what the queue is still waiting for
+  missing: Tf2ClassName[]
+}
+
+/**
+ * How close the pool is to being able to field two teams.
+ *
+ * "At least 12 players" needs no separate check: filling 12 slots takes 12 distinct players, so
+ * the headcount rule is implied by `fillable === required`.
+ *
+ * Captains are deliberately left unpinned here. Both teams have the same slots, so any assignment
+ * that ignores teams can be rearranged into one that respects a captain's team — swap whoever
+ * holds the captain's class on their side with the captain. The other captain can never be in the
+ * way, since they are pinned to the opposite team. So a pool that fills every slot without pinning
+ * also fills every slot with it, and readiness can ignore who ends up captaining.
+ */
+export function queueReadiness(pool: DraftCandidate[], config: QueueConfig): QueueReadiness {
+  const slots = teamSlots(config)
+  const assignment = maxAssignment(slots, pool)
+  const missing = slots
+    .filter((_, slot) => assignment.slots[slot] === null)
+    .map(slot => slot.gameClass)
+
+  return {
+    required: slots.length,
+    fillable: slots.length - missing.length,
+    missing,
+  }
+}

--- a/src/queue-captains/pick-order.test.ts
+++ b/src/queue-captains/pick-order.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { _6v6 } from '../queue-auto/configs/6v6'
+import { _9v9 } from '../queue-auto/configs/9v9'
+import { Tf2Team } from '../shared/types/tf2-team'
+import { pickOrder } from './pick-order'
+
+const { blu, red } = Tf2Team
+
+describe('pickOrder()', () => {
+  describe('6v6', () => {
+    it('runs BLU, then alternating pairs', () => {
+      expect(pickOrder(_6v6)).toEqual([blu, red, red, blu, blu, red, red, blu, blu, red])
+    })
+
+    it('leaves ten turns — twelve slots minus the two captains', () => {
+      expect(pickOrder(_6v6)).toHaveLength(10)
+    })
+  })
+
+  describe('9v9', () => {
+    it('keeps the same shape over sixteen turns', () => {
+      expect(pickOrder(_9v9)).toEqual([
+        blu,
+        red,
+        red,
+        blu,
+        blu,
+        red,
+        red,
+        blu,
+        blu,
+        red,
+        red,
+        blu,
+        blu,
+        red,
+        red,
+        blu,
+      ])
+    })
+  })
+
+  it.each([
+    ['6v6', _6v6],
+    ['9v9', _9v9],
+  ])('splits %s evenly between the teams', (_name, config) => {
+    const order = pickOrder(config)
+    expect(order.filter(team => team === blu)).toHaveLength(order.length / 2)
+    expect(order.filter(team => team === red)).toHaveLength(order.length / 2)
+  })
+})

--- a/src/queue-captains/pick-order.ts
+++ b/src/queue-captains/pick-order.ts
@@ -1,0 +1,17 @@
+import type { QueueConfig } from '../queue/types/queue-config'
+import { Tf2Team } from '../shared/types/tf2-team'
+import { teamSlots } from './team-slots'
+
+/**
+ * Who picks on each turn. BLU takes a single first pick, then the teams alternate in pairs:
+ * BLU, RED RED, BLU BLU, RED RED, … — ten turns for 6v6, sixteen for 9v9, split evenly.
+ *
+ * Both captains are already in the queue, so they account for two of the slots themselves and are
+ * never picked.
+ */
+export function pickOrder(config: QueueConfig): Tf2Team[] {
+  const turns = teamSlots(config).length - 2
+  return Array.from({ length: turns }, (_, turn) =>
+    turn === 0 || Math.floor((turn - 1) / 2) % 2 === 1 ? Tf2Team.blu : Tf2Team.red,
+  )
+}

--- a/src/queue-captains/team-slots.ts
+++ b/src/queue-captains/team-slots.ts
@@ -1,0 +1,15 @@
+import type { QueueConfig } from '../queue/types/queue-config'
+import { Tf2Team } from '../shared/types/tf2-team'
+import type { TeamSlot } from './types/team-slot'
+
+/**
+ * Every slot a finished game has to fill — for 6v6 that is 4 scouts, 4 soldiers, 2 demomen and
+ * 2 medics, split evenly across the two teams.
+ */
+export function teamSlots(config: QueueConfig): TeamSlot[] {
+  return [Tf2Team.blu, Tf2Team.red].flatMap(team =>
+    config.classes.flatMap(({ name, count }) =>
+      Array.from({ length: count }, () => ({ team, gameClass: name })),
+    ),
+  )
+}

--- a/src/queue-captains/types/draft-candidate.ts
+++ b/src/queue-captains/types/draft-candidate.ts
@@ -1,0 +1,13 @@
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import type { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import type { Tf2Team } from '../../shared/types/tf2-team'
+
+export interface DraftCandidate {
+  steamId: SteamId64
+
+  // every class this player signed up for
+  gameClasses: Tf2ClassName[]
+
+  // captains are locked to their own team; everyone else can end up on either side
+  team?: Tf2Team
+}

--- a/src/queue-captains/types/team-slot.ts
+++ b/src/queue-captains/types/team-slot.ts
@@ -1,0 +1,7 @@
+import type { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import type { Tf2Team } from '../../shared/types/tf2-team'
+
+export interface TeamSlot {
+  team: Tf2Team
+  gameClass: Tf2ClassName
+}


### PR DESCRIPTION
> **Stacking note.** This branch builds on #764 and so contains its two commits as well as its own. That is not by choice: every workflow in this repo triggers only on `pull_request: branches: ['master']`, so a PR based on a feature branch gets **no CI at all** — #765 sat with zero checks until I retargeted it here. Review #764 first (it is green and its diff is clean); once it merges, this diff narrows to the third commit on its own. If you would rather not carry that, merging #764 first and letting me rebase works too.
>
> Worth a one-line fix at some point: adding `feat/**` to those `pull_request.branches` lists, or dropping the filter, would let the rest of this series be reviewed as a proper stack.

---

Second of the captain-mode PRs. Pure functions, no I/O, nothing wired up yet.

## Why this exists before any UI

Captain mode breaks the assumption the auto queue is built on. Players sign up on *several* classes at once, so "is the queue full?" stops being a headcount and becomes a **maximum bipartite matching** between the pool and the class slots a game needs. Two consequences fall out:

- The readiness meter shows *fillable slots*, not players. A 13-player pool where only one person can play medic is 10/12, not 13/12. The slots the matching can't fill are exactly the bottleneck to display — no second calculation.
- **The two "queue is full" conditions you specified collapse into one.** Filling 12 slots takes 12 distinct players, so "at least 12 players" is implied by `fillable === required`.

## The dead-end hazard

This is the part I flagged as the real risk, and it's why the engine landed before anything depends on it.

Validating a pick against class counts alone is not enough. A captain can take the last player who covers some class and strand the draft in a position with no valid finish. So every candidate pick is provisionally applied and kept only if both teams can still be completed. `legalPicks()` is what greys out the locked chips in the design mockup.

## A bug the tests caught

My first cut of `isFeasible()` only required every *slot* to be filled. That silently accepted completions where a **captain gets squeezed out of their own game** — spare players sitting out is fine and expected, a captain sitting out is not.

The fix is in `maxAssignment()`: captains are matched first. Augmenting paths only ever reroute a matched vertex, never unmatch one, so filling the remaining slots afterwards can move a captain to a different slot but can never drop them. `isFeasible()` then checks both conditions.

Two further test failures turned out to be my *expectations* being wrong rather than the code — in both the feasibility check was correctly refusing a pick I had assumed was legal.

## The test that matters

`draft-simulation.test.ts` plays out complete drafts over generated pools — 126 of 150 for 6v6, 149 of 150 for 9v9, spanning pool sizes from exact-fit up to four spare players. For each it asserts the draft never dead-ends, never picks a captain or the same player twice, only picks classes players signed up for, and always leaves each captain a slot they can actually play. Seeded, so any failure is reproducible.

`legal-picks.test.ts` also pins the exact board from the design mockup (pick 8 of 10, BLU on the clock) and asserts the two locks it shows are reproduced for the right reasons — `larch` because RED still needs the last soldier, `juniper`-on-scout because it would strand BLU's own demoman slot.

## One thing worth knowing

`queueReadiness()` deliberately ignores which players volunteered to captain. Both teams have identical slots, so any assignment that ignores teams can be rearranged into one respecting a captain's team — swap whoever holds the captain's class on their side with the captain, and the other captain can never be in the way since they're pinned to the opposite team. So a pool that fills every slot unpinned also fills it pinned, and readiness needn't care who ends up captaining. The reasoning is in the docstring; the simulation exercises it by captaining the first two pool members regardless of pool shape.

## Plan change

The approved plan had queue-mode plumbing as PR 2. I've folded it into the pool PR instead: on its own it ships an admin toggle whose "captains" option leads to a placeholder page — a production footgun plus throwaway code. The config entry and route dispatch are ~15 lines and belong with the thing that makes them do something. Same total work, one fewer disposable artifact.

## Checks

`pnpm lint`, `pnpm xss-scan`, `pnpm test` (461 passed), `tsc -p tsconfig.build.json` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)