### PR TITLE
feat(queue): add the captain draft

### DIFF
--- a/src/database/collections.ts
+++ b/src/database/collections.ts
@@ -2,6 +2,7 @@ import { database } from './database'
 import type { AnnouncementModel } from './models/announcement.model'
 import type { ConfigurationEntryModel } from './models/configuration-entry.model'
 import type { DocumentModel } from './models/document.model'
+import type { DraftModel } from './models/draft.model'
 import type { GameLogsModel } from './models/game-logs.model'
 import type { GameModel } from './models/game.model'
 import type { KeyModel } from './models/key.model'
@@ -58,6 +59,7 @@ export const collections = {
   pendingImports: database.collection<PendingImportModel>('pendingimports'),
   playerActions: database.collection<PlayerActionEntryModel>('playeractions'),
   players: database.collection<PlayerModel>('players'),
+  queueCaptainsDrafts: database.collection<DraftModel>('queue.captains.drafts'),
   queueCaptainsPool: database.collection<CaptainsPoolEntryModel>('queue.captains.pool'),
   queueFriends: database.collection<QueueFriendshipModel>('queue.friends'),
   queueSlots: database.collection<QueueSlotModel>('queue.slots'),

--- a/src/database/ensure-indexes.ts
+++ b/src/database/ensure-indexes.ts
@@ -42,6 +42,10 @@ const definitions: Partial<Record<keyof typeof collections, IndexDefinition[]>> 
     { spec: { 'player.steamId': 1 }, options: { sparse: true } },
     { spec: { id: 1 }, options: { unique: true } },
   ],
+  queueCaptainsDrafts: [
+    { spec: { id: 1 }, options: { unique: true } },
+    { spec: { createdAt: -1 } },
+  ],
   queueCaptainsPool: [
     { spec: { 'player.steamId': 1 }, options: { unique: true } },
     { spec: { joinedAt: 1 } },

--- a/src/database/models/configuration-entry.model.ts
+++ b/src/database/models/configuration-entry.model.ts
@@ -229,6 +229,12 @@ export const configurationSchema = z.discriminatedUnion('key', [
       value: z.number().min(0).default(100),
     })
     .describe('Games a player must have played before they can volunteer to captain'),
+  z
+    .object({
+      key: z.literal('queue.captains.pick_timeout'),
+      value: z.number().positive().default(secondsToMilliseconds(30)),
+    })
+    .describe('Time a captain has to make each draft pick before one is made for them'),
   z.object({
     key: z.literal('queue.player_skill_threshold'),
     value: z.number().nullable().default(null),

--- a/src/database/models/draft.model.ts
+++ b/src/database/models/draft.model.ts
@@ -1,0 +1,52 @@
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import type { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import type { Tf2Team } from '../../shared/types/tf2-team'
+
+declare const _draftId: unique symbol
+export type DraftId = string & { [_draftId]: never }
+
+export enum DraftState {
+  // captains are taking turns picking players
+  picking = 'picking',
+
+  // every slot is spoken for
+  completed = 'completed',
+}
+
+export interface DraftPick {
+  team: Tf2Team
+  player: SteamId64
+  gameClass: Tf2ClassName
+  at: Date
+
+  // the captain ran out of time and a pick was made for them
+  auto?: boolean
+
+  // only one legal option was left, so the turn was committed without waiting
+  forced?: boolean
+}
+
+/**
+ * A draft is both the live state and its own permanent log: the pool is frozen when it starts and
+ * every turn is appended in order, so any finished draft can be replayed exactly as it happened.
+ */
+export interface DraftModel {
+  id: DraftId
+  state: DraftState
+  createdAt: Date
+
+  captains: Record<Tf2Team, SteamId64>
+
+  // frozen snapshot — the pool can change underneath, the draft cannot
+  pool: {
+    steamId: SteamId64
+    name: string
+    avatarUrl: string
+    gameClasses: Tf2ClassName[]
+  }[]
+
+  picks: DraftPick[]
+
+  // when the captain on the clock runs out of time; absent once the draft is over
+  turnEndsAt?: Date
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -3,6 +3,7 @@ import type { SteamId64 } from './shared/types/steam-id-64'
 import type { UserMetadata } from './shared/types/user-metadata'
 import { logger } from './logger'
 import type { CaptainsPoolEntryModel } from './database/models/captains-pool-entry.model'
+import type { DraftModel } from './database/models/draft.model'
 import type { QueueSlotModel } from './database/models/queue-slot.model'
 import { QueueState } from './database/models/queue-state.model'
 import type { GameModel, GameNumber } from './database/models/game.model'
@@ -204,6 +205,15 @@ export interface Events {
   }
   'queueCaptains/pool:left': {
     steamId: SteamId64
+  }
+  'queueCaptains/draft:started': {
+    draft: DraftModel
+  }
+  'queueCaptains/draft:updated': {
+    draft: DraftModel
+  }
+  'queueCaptains/draft:completed': {
+    draft: DraftModel
   }
 
   'queue/mapPool:reset': {

--- a/src/games/plugins/launch-new-game.ts
+++ b/src/games/plugins/launch-new-game.ts
@@ -2,7 +2,7 @@ import fp from 'fastify-plugin'
 import { events } from '../../events'
 import { QueueState } from '../../database/models/queue-state.model'
 import { logger } from '../../logger'
-import { queue } from '../../queue-auto'
+import { queue } from '../../queue'
 import { debounce } from 'es-toolkit'
 import { safe } from '../../utils/safe'
 import { launchGame } from '../launch-game'
@@ -11,20 +11,30 @@ import { configure } from '../rcon/configure'
 import { getOrphanedGames } from '../get-orphaned-games'
 import { collections } from '../../database/collections'
 import { GameState } from '../../database/models/game.model'
+import { QueueMode } from '../../shared/types/queue-mode'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
   async app => {
     const launchGameDebounced = debounce(safe(launchGame), 100)
 
-    events.on('queue/state:updated', ({ state }) => {
-      if (state === QueueState.launching) {
-        launchGameDebounced()
-      }
-    })
+    // Captain mode also parks the queue in `launching` for the duration of the draft, but its
+    // game is built from the draft result once the map is settled — not from the auto queue's
+    // slots, which are empty there.
+    events.on(
+      'queue/state:updated',
+      safe(async ({ state }) => {
+        if (state === QueueState.launching && (await queue.getMode()) === QueueMode.auto) {
+          launchGameDebounced()
+        }
+      }),
+    )
 
     app.addHook('onListen', async () => {
-      if ((await queue.getState()) === QueueState.launching) {
+      if (
+        (await queue.getState()) === QueueState.launching &&
+        (await queue.getMode()) === QueueMode.auto
+      ) {
         launchGameDebounced()
       }
 

--- a/src/queue-auto/views/html/ready-up-dialog.tsx
+++ b/src/queue-auto/views/html/ready-up-dialog.tsx
@@ -1,10 +1,18 @@
 import { nanoid } from 'nanoid'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
 import { players } from '../../../players'
+import { queue } from '../../../queue'
+import { QueueMode } from '../../../shared/types/queue-mode'
 
 const dialogId = 'ready-up-dialog'
 
-export function ReadyUpDialog() {
+// The dialog itself is shared by both queue modes — only the websocket fields its buttons submit
+// differ, since the two modes keep their queued players in different places.
+export async function ReadyUpDialog() {
+  const captains = (await queue.getMode()) === QueueMode.captains
+  const readyField = captains ? 'captainsreadyup' : 'ready'
+  const leaveField = captains ? 'captainsleave' : 'leave'
+
   return (
     <>
       <dialog
@@ -19,7 +27,7 @@ export function ReadyUpDialog() {
 
           <div class="flex flex-col gap-4">
             <button
-              name="ready"
+              name={readyField}
               value=""
               class="bg-accent-600 w-[242px] rounded-sm py-[12px] text-xl font-bold text-gray-50 uppercase"
               autofocus
@@ -29,7 +37,7 @@ export function ReadyUpDialog() {
               I'm ready
             </button>
             <button
-              name="leave"
+              name={leaveField}
               value=""
               class="bg-abru-light-5 w-[242px] rounded-sm py-[12px] text-xl font-bold text-gray-50"
               ws-send

--- a/src/queue-captains/draft/auto-pick.ts
+++ b/src/queue-captains/draft/auto-pick.ts
@@ -1,0 +1,75 @@
+import { collections } from '../../database/collections'
+import type { DraftModel } from '../../database/models/draft.model'
+import { logger } from '../../logger'
+import { config } from '../../queue-auto/config'
+import { withQueueLock } from '../../queue/with-queue-lock'
+import { legalPicks } from '../matching/legal-picks'
+import { currentTurn } from './current-turn'
+import { getCurrent } from './get-current'
+import { openSlots } from './open-slots'
+import { remainingCandidates } from './remaining-candidates'
+import { resolveTurns } from './resolve-turns'
+
+/**
+ * The captain ran out of time, so a pick is made for them: the longest-waiting player still
+ * available, on the first class of theirs that is legal.
+ *
+ * Deterministic rather than random, so a draft replays exactly from its log, and it rewards
+ * patience in the queue instead of rolling dice on someone's night.
+ */
+export async function autoPick(draftId: string, turn: number): Promise<DraftModel | null> {
+  return await withQueueLock('captains:auto-pick', async () => {
+    const draft = await getCurrent()
+    if (draft?.id !== draftId) {
+      return null
+    }
+
+    // the captain got there first; this timeout belongs to a turn that is already settled
+    if (draft.picks.length !== turn) {
+      return null
+    }
+
+    const current = currentTurn(draft, config)
+    if (current === null) {
+      return null
+    }
+
+    const legal = legalPicks({
+      openSlots: openSlots(draft, config),
+      candidates: remainingCandidates(draft),
+      team: current.team,
+    })
+    if (legal.length === 0) {
+      logger.error({ draft: draft.id, turn }, 'auto-pick found nothing legal')
+      return null
+    }
+
+    // pool order is join order, so the first match is the one who has waited longest
+    const pick =
+      draft.pool.flatMap(entry => legal.filter(option => option.steamId === entry.steamId))[0] ??
+      legal[0]!
+
+    logger.info({ draft: draft.id, turn, pick }, 'draft turn timed out, picking automatically')
+
+    const withPick = await collections.queueCaptainsDrafts.findOneAndUpdate(
+      { id: draft.id, [`picks.${turn}`]: { $exists: false } },
+      {
+        $push: {
+          picks: {
+            team: current.team,
+            player: pick.steamId,
+            gameClass: pick.gameClass,
+            at: new Date(),
+            auto: true,
+          },
+        },
+      },
+      { returnDocument: 'after' },
+    )
+    if (!withPick) {
+      return null
+    }
+
+    return await resolveTurns(withPick)
+  })
+}

--- a/src/queue-captains/draft/current-turn.test.ts
+++ b/src/queue-captains/draft/current-turn.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { DraftState, type DraftId, type DraftModel } from '../../database/models/draft.model'
+import { _6v6 } from '../../queue-auto/configs/6v6'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import { Tf2Team } from '../../shared/types/tf2-team'
+import { currentTurn } from './current-turn'
+import { openSlots } from './open-slots'
+
+const { scout, soldier, demoman, medic } = Tf2ClassName
+const { blu, red } = Tf2Team
+
+function draftWith(picks: { team: Tf2Team; gameClass: Tf2ClassName }[]): DraftModel {
+  return {
+    id: 'draft' as DraftId,
+    state: DraftState.picking,
+    createdAt: new Date(),
+    captains: { [blu]: 'a' as SteamId64, [red]: 'b' as SteamId64 },
+    pool: [],
+    picks: picks.map((pick, index) => ({
+      ...pick,
+      player: `p${index}` as SteamId64,
+      at: new Date(),
+    })),
+  }
+}
+
+describe('currentTurn()', () => {
+  it('starts with BLU', () => {
+    expect(currentTurn(draftWith([]), _6v6)).toEqual({ index: 0, team: blu, total: 10 })
+  })
+
+  it('follows the pick order', () => {
+    const teams = [blu, red, red, blu, blu, red, red, blu, blu, red]
+    for (let taken = 0; taken < teams.length; ++taken) {
+      const picks = teams.slice(0, taken).map(team => ({ team, gameClass: scout }))
+      expect(currentTurn(draftWith(picks), _6v6)?.team).toBe(teams[taken])
+    }
+  })
+
+  it('is over once every turn has been taken', () => {
+    const picks = Array.from({ length: 10 }, () => ({ team: blu, gameClass: scout }))
+    expect(currentTurn(draftWith(picks), _6v6)).toBeNull()
+  })
+})
+
+describe('openSlots()', () => {
+  it('starts with every slot in the game', () => {
+    expect(openSlots(draftWith([]), _6v6)).toHaveLength(12)
+  })
+
+  it('removes a slot per pick, on the right team', () => {
+    const slots = openSlots(draftWith([{ team: blu, gameClass: medic }]), _6v6)
+    expect(slots).toHaveLength(11)
+    expect(slots.filter(slot => slot.team === blu && slot.gameClass === medic)).toHaveLength(0)
+    expect(slots.filter(slot => slot.team === red && slot.gameClass === medic)).toHaveLength(1)
+  })
+
+  it('leaves one slot per team once every pick is in', () => {
+    const picks = [
+      ...[scout, scout, soldier, soldier, demoman].map(gameClass => ({ team: blu, gameClass })),
+      ...[scout, scout, soldier, soldier, demoman].map(gameClass => ({ team: red, gameClass })),
+    ]
+    const slots = openSlots(draftWith(picks), _6v6)
+    expect(slots).toHaveLength(2)
+    expect(slots.map(slot => slot.gameClass)).toEqual([medic, medic])
+  })
+})

--- a/src/queue-captains/draft/current-turn.ts
+++ b/src/queue-captains/draft/current-turn.ts
@@ -1,0 +1,20 @@
+import type { DraftModel } from '../../database/models/draft.model'
+import type { QueueConfig } from '../../queue/types/queue-config'
+import type { Tf2Team } from '../../shared/types/tf2-team'
+import { pickOrder } from '../pick-order'
+
+export interface DraftTurn {
+  // 0-based index into the pick order
+  index: number
+  team: Tf2Team
+  total: number
+}
+
+// Which turn the draft is on, or null once every pick has been made.
+export function currentTurn(draft: DraftModel, config: QueueConfig): DraftTurn | null {
+  const order = pickOrder(config)
+  const index = draft.picks.length
+  const team = order[index]
+
+  return team === undefined ? null : { index, team, total: order.length }
+}

--- a/src/queue-captains/draft/draw-captains.test.ts
+++ b/src/queue-captains/draft/draw-captains.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import type { CaptainsPoolEntryModel } from '../../database/models/captains-pool-entry.model'
+import { _6v6 } from '../../queue-auto/configs/6v6'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import { Tf2Team } from '../../shared/types/tf2-team'
+import { drawCaptains } from './draw-captains'
+
+const { scout, soldier, demoman, medic } = Tf2ClassName
+
+function entry(
+  name: string,
+  gameClasses: Tf2ClassName[],
+  wantsToCaptain = false,
+): CaptainsPoolEntryModel {
+  return {
+    player: { steamId: name as unknown as SteamId64, name, avatarUrl: '' },
+    gameClasses,
+    wantsToCaptain,
+    ready: true,
+    joinedAt: new Date(),
+  }
+}
+
+// a pool that can field two full 6v6 teams
+function fullPool(volunteers: string[]): CaptainsPoolEntryModel[] {
+  const roster: [string, Tf2ClassName[]][] = [
+    ['a', [scout]],
+    ['b', [scout]],
+    ['c', [scout]],
+    ['d', [scout]],
+    ['e', [soldier]],
+    ['f', [soldier]],
+    ['g', [soldier]],
+    ['h', [soldier]],
+    ['i', [demoman]],
+    ['j', [demoman]],
+    ['k', [medic]],
+    ['l', [medic]],
+  ]
+  return roster.map(([name, classes]) => entry(name, classes, volunteers.includes(name)))
+}
+
+describe('drawCaptains()', () => {
+  it('refuses to draw from fewer than two volunteers', () => {
+    expect(() => drawCaptains(fullPool(['a']), _6v6)).toThrow('not enough captain volunteers')
+  })
+
+  it('returns one captain per team, both volunteers', () => {
+    const captains = drawCaptains(fullPool(['a', 'e', 'k']), _6v6)
+    expect(['a', 'e', 'k']).toContain(captains[Tf2Team.blu] as unknown as string)
+    expect(['a', 'e', 'k']).toContain(captains[Tf2Team.red] as unknown as string)
+    expect(captains[Tf2Team.blu]).not.toBe(captains[Tf2Team.red])
+  })
+
+  it('spreads captaincy around rather than always picking the same pair', () => {
+    const seen = new Set<string>()
+    for (let attempt = 0; attempt < 60; ++attempt) {
+      const captains = drawCaptains(fullPool(['a', 'e', 'i', 'k']), _6v6)
+      seen.add([captains[Tf2Team.blu], captains[Tf2Team.red]].sort().join('+'))
+    }
+    expect(seen.size).toBeGreaterThan(1)
+  })
+
+  it('never draws a pair that could not both be fitted in', () => {
+    // only two players can medic, and both volunteered — whichever way round they are drawn they
+    // each have to take a medic slot, which works, so this must still succeed
+    for (let attempt = 0; attempt < 30; ++attempt) {
+      const captains = drawCaptains(fullPool(['k', 'l']), _6v6)
+      expect([captains[Tf2Team.blu], captains[Tf2Team.red]].sort()).toEqual(['k', 'l'])
+    }
+  })
+})

--- a/src/queue-captains/draft/draw-captains.ts
+++ b/src/queue-captains/draft/draw-captains.ts
@@ -1,0 +1,65 @@
+import { sample } from 'es-toolkit'
+import type { CaptainsPoolEntryModel } from '../../database/models/captains-pool-entry.model'
+import { errors } from '../../errors'
+import type { QueueConfig } from '../../queue/types/queue-config'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import { Tf2Team } from '../../shared/types/tf2-team'
+import { isFeasible } from '../matching/is-feasible'
+import { teamSlots } from '../team-slots'
+
+/**
+ * Pick two captains at random from the volunteers.
+ *
+ * Random rather than by rating: it cannot be gamed, and it spreads captaincy around instead of
+ * handing it to the same two players every night. Which side each gets is a coin flip too.
+ *
+ * A pair that could not both be fitted into the game is rejected and another drawn. In practice
+ * this never bites — both teams have the same slots, so any pool that fills them unpinned fills
+ * them pinned as well — but the draft is unrecoverable if it starts from an impossible position,
+ * so it is worth the few microseconds to be sure.
+ */
+export function drawCaptains(
+  pool: CaptainsPoolEntryModel[],
+  config: QueueConfig,
+): Record<Tf2Team, SteamId64> {
+  const volunteers = pool.filter(entry => entry.wantsToCaptain)
+  if (volunteers.length < 2) {
+    throw errors.conflict('not enough captain volunteers')
+  }
+
+  const slots = teamSlots(config)
+  const candidates = pool.map(({ player, gameClasses }) => ({
+    steamId: player.steamId,
+    gameClasses,
+  }))
+
+  const tried = new Set<string>()
+  const combinations = volunteers.length * (volunteers.length - 1)
+
+  while (tried.size < combinations) {
+    const [blu, red] = sample2(volunteers)
+    const key = `${blu}:${red}`
+    if (tried.has(key)) {
+      continue
+    }
+    tried.add(key)
+
+    const pinned = candidates.map(candidate => ({
+      ...candidate,
+      ...(candidate.steamId === blu && { team: Tf2Team.blu }),
+      ...(candidate.steamId === red && { team: Tf2Team.red }),
+    }))
+
+    if (isFeasible(slots, pinned)) {
+      return { [Tf2Team.blu]: blu, [Tf2Team.red]: red }
+    }
+  }
+
+  throw errors.conflict('no pair of volunteers can captain this pool')
+}
+
+function sample2(volunteers: CaptainsPoolEntryModel[]): [SteamId64, SteamId64] {
+  const blu = sample(volunteers)
+  const red = sample(volunteers.filter(entry => entry !== blu))
+  return [blu.player.steamId, red.player.steamId]
+}

--- a/src/queue-captains/draft/get-current.ts
+++ b/src/queue-captains/draft/get-current.ts
@@ -1,0 +1,10 @@
+import { collections } from '../../database/collections'
+import { DraftState, type DraftModel } from '../../database/models/draft.model'
+
+// There is at most one draft running at a time, since there is one queue.
+export async function getCurrent(): Promise<DraftModel | null> {
+  return await collections.queueCaptainsDrafts.findOne(
+    { state: DraftState.picking },
+    { sort: { createdAt: -1 } },
+  )
+}

--- a/src/queue-captains/draft/make-pick.ts
+++ b/src/queue-captains/draft/make-pick.ts
@@ -1,0 +1,60 @@
+import { collections } from '../../database/collections'
+import type { DraftModel } from '../../database/models/draft.model'
+import { errors } from '../../errors'
+import { logger } from '../../logger'
+import { config } from '../../queue-auto/config'
+import { withQueueLock } from '../../queue/with-queue-lock'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import type { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import { legalPicks } from '../matching/legal-picks'
+import { withLogLevel } from '../../utils/with-log-level'
+import { currentTurn } from './current-turn'
+import { getCurrent } from './get-current'
+import { openSlots } from './open-slots'
+import { remainingCandidates } from './remaining-candidates'
+import { resolveTurns } from './resolve-turns'
+
+export async function makePick(
+  actor: SteamId64,
+  player: SteamId64,
+  gameClass: Tf2ClassName,
+): Promise<DraftModel> {
+  return await withQueueLock('captains:make-pick', async () => {
+    logger.trace({ actor, player, gameClass }, 'queueCaptains.makePick()')
+
+    const draft = await getCurrent()
+    if (!draft) {
+      throw withLogLevel(errors.badRequest('no draft in progress'), 'debug')
+    }
+
+    const turn = currentTurn(draft, config)
+    if (turn === null) {
+      throw withLogLevel(errors.badRequest('the draft is over'), 'debug')
+    }
+
+    if (draft.captains[turn.team] !== actor) {
+      throw withLogLevel(errors.forbidden('it is not your turn'), 'debug')
+    }
+
+    const legal = legalPicks({
+      openSlots: openSlots(draft, config),
+      candidates: remainingCandidates(draft),
+      team: turn.team,
+    })
+    if (!legal.some(pick => pick.steamId === player && pick.gameClass === gameClass)) {
+      throw withLogLevel(errors.badRequest('that pick is not available'), 'debug')
+    }
+
+    const withPick = await collections.queueCaptainsDrafts.findOneAndUpdate(
+      // the turn index guards against two picks racing into the same turn
+      { id: draft.id, [`picks.${turn.index}`]: { $exists: false } },
+      { $push: { picks: { team: turn.team, player, gameClass, at: new Date() } } },
+      { returnDocument: 'after' },
+    )
+    if (!withPick) {
+      throw withLogLevel(errors.conflict('that turn has already been taken'), 'debug')
+    }
+
+    return await resolveTurns(withPick)
+  })
+}

--- a/src/queue-captains/draft/open-slots.ts
+++ b/src/queue-captains/draft/open-slots.ts
@@ -1,0 +1,21 @@
+import type { DraftModel } from '../../database/models/draft.model'
+import type { QueueConfig } from '../../queue/types/queue-config'
+import { teamSlots } from '../team-slots'
+import type { TeamSlot } from '../types/team-slot'
+
+// Slots nobody has been picked for yet, derived from the picks rather than stored, so the draft
+// document can never disagree with itself.
+export function openSlots(draft: DraftModel, config: QueueConfig): TeamSlot[] {
+  const remaining = teamSlots(config)
+
+  for (const pick of draft.picks) {
+    const index = remaining.findIndex(
+      slot => slot.team === pick.team && slot.gameClass === pick.gameClass,
+    )
+    if (index >= 0) {
+      remaining.splice(index, 1)
+    }
+  }
+
+  return remaining
+}

--- a/src/queue-captains/draft/remaining-candidates.ts
+++ b/src/queue-captains/draft/remaining-candidates.ts
@@ -1,0 +1,24 @@
+import type { DraftModel } from '../../database/models/draft.model'
+import { Tf2Team } from '../../shared/types/tf2-team'
+import type { DraftCandidate } from '../types/draft-candidate'
+
+/**
+ * Everyone still waiting to be given a slot, captains included. Captains carry their team so the
+ * matching keeps a slot on their own side free for them.
+ */
+export function remainingCandidates(draft: DraftModel): DraftCandidate[] {
+  const picked = new Set(draft.picks.map(pick => pick.player))
+
+  return draft.pool
+    .filter(entry => !picked.has(entry.steamId))
+    .map(entry => {
+      const team = ([Tf2Team.blu, Tf2Team.red] as const).find(
+        t => draft.captains[t] === entry.steamId,
+      )
+      return {
+        steamId: entry.steamId,
+        gameClasses: entry.gameClasses,
+        ...(team && { team }),
+      }
+    })
+}

--- a/src/queue-captains/draft/resolve-turns.ts
+++ b/src/queue-captains/draft/resolve-turns.ts
@@ -1,0 +1,110 @@
+import { collections } from '../../database/collections'
+import { DraftState, type DraftModel, type DraftPick } from '../../database/models/draft.model'
+import { configuration } from '../../configuration'
+import { events } from '../../events'
+import { logger } from '../../logger'
+import { config } from '../../queue-auto/config'
+import { tasks } from '../../tasks'
+import { legalPicks } from '../matching/legal-picks'
+import { currentTurn } from './current-turn'
+import { openSlots } from './open-slots'
+import { remainingCandidates } from './remaining-candidates'
+
+/**
+ * Settle the draft up to the next turn that needs a decision.
+ *
+ * Turns with only one legal pick are committed straight away instead of burning the clock on a
+ * non-choice, and that can cascade, so this loops until it reaches a turn with a real choice or
+ * runs out of turns entirely.
+ *
+ * Callers already hold the queue lock — this never takes it.
+ */
+export async function resolveTurns(draft: DraftModel): Promise<DraftModel> {
+  let current = draft
+
+  for (;;) {
+    const turn = currentTurn(current, config)
+    if (turn === null) {
+      return await complete(current)
+    }
+
+    const picks = legalPicks({
+      openSlots: openSlots(current, config),
+      candidates: remainingCandidates(current),
+      team: turn.team,
+    })
+
+    if (picks.length === 0) {
+      // legalPicks only ever offers picks that keep both teams completable, so reaching here means
+      // the draft started from an impossible position and cannot be finished.
+      logger.error({ draft: current.id, turn }, 'draft dead end: no legal picks')
+      throw new Error(`draft ${current.id} dead-ended on turn ${turn.index + 1}`)
+    }
+
+    if (picks.length > 1) {
+      return await awaitCaptain(current)
+    }
+
+    const only = picks[0]!
+    current = await append(current, {
+      team: turn.team,
+      player: only.steamId,
+      gameClass: only.gameClass,
+      at: new Date(),
+      forced: true,
+    })
+  }
+}
+
+async function append(draft: DraftModel, pick: DraftPick): Promise<DraftModel> {
+  const updated = await collections.queueCaptainsDrafts.findOneAndUpdate(
+    { id: draft.id },
+    { $push: { picks: pick } },
+    { returnDocument: 'after' },
+  )
+  if (!updated) {
+    throw new Error(`no such draft: ${draft.id}`)
+  }
+
+  return updated
+}
+
+async function awaitCaptain(draft: DraftModel): Promise<DraftModel> {
+  const timeout = await configuration.get('queue.captains.pick_timeout')
+  const turnEndsAt = new Date(Date.now() + timeout)
+
+  const updated = await collections.queueCaptainsDrafts.findOneAndUpdate(
+    { id: draft.id },
+    { $set: { turnEndsAt } },
+    { returnDocument: 'after' },
+  )
+  if (!updated) {
+    throw new Error(`no such draft: ${draft.id}`)
+  }
+
+  // the turn index is part of the args so a timeout that fires late, after the captain already
+  // picked, matches nothing and is ignored
+  await tasks.schedule('queueCaptains:draftTurnTimeout', timeout, {
+    draftId: updated.id,
+    turn: updated.picks.length,
+  })
+
+  events.emit('queueCaptains/draft:updated', { draft: updated })
+  return updated
+}
+
+async function complete(draft: DraftModel): Promise<DraftModel> {
+  const updated = await collections.queueCaptainsDrafts.findOneAndUpdate(
+    { id: draft.id },
+    { $set: { state: DraftState.completed }, $unset: { turnEndsAt: '' } },
+    { returnDocument: 'after' },
+  )
+  if (!updated) {
+    throw new Error(`no such draft: ${draft.id}`)
+  }
+
+  logger.info({ draft: updated.id }, 'draft completed')
+  events.emit('queueCaptains/draft:updated', { draft: updated })
+  events.emit('queueCaptains/draft:completed', { draft: updated })
+  return updated
+}

--- a/src/queue-captains/draft/start.ts
+++ b/src/queue-captains/draft/start.ts
@@ -1,0 +1,56 @@
+import { nanoid } from 'nanoid'
+import { collections } from '../../database/collections'
+import { DraftState, type DraftModel } from '../../database/models/draft.model'
+import { QueueState } from '../../database/models/queue-state.model'
+import { events } from '../../events'
+import { logger } from '../../logger'
+import { config } from '../../queue-auto/config'
+import { setState } from '../../queue/set-state'
+import { getPool } from '../get-pool'
+import { drawCaptains } from './draw-captains'
+import { resolveTurns } from './resolve-turns'
+
+/**
+ * Freeze the pool and start drafting.
+ *
+ * Must be called *without* the queue lock held: `setState` takes it, and the mutex is not
+ * reentrant.
+ *
+ * Closing the queue comes first on purpose. Joining requires the waiting state and leaving is
+ * refused while launching, so once the state flips the pool cannot move — which is what makes the
+ * snapshot taken a moment later trustworthy. From then on the draft only ever reads its own copy,
+ * so nothing happening in the live pool can disturb a draft in progress.
+ */
+export async function start(): Promise<DraftModel> {
+  await setState(QueueState.launching)
+
+  try {
+    const pool = await getPool()
+    const captains = drawCaptains(pool, config)
+
+    const draft: DraftModel = {
+      id: nanoid(),
+      state: DraftState.picking,
+      createdAt: new Date(),
+      captains,
+      pool: pool.map(({ player, gameClasses }) => ({
+        steamId: player.steamId,
+        name: player.name,
+        avatarUrl: player.avatarUrl,
+        gameClasses,
+      })),
+      picks: [],
+    }
+
+    await collections.queueCaptainsDrafts.insertOne(draft)
+    logger.info({ draft: draft.id, captains, pool: pool.length }, 'draft started')
+    events.emit('queueCaptains/draft:started', { draft })
+
+    return await resolveTurns(draft)
+  } catch (error) {
+    // never leave the queue closed with no draft to show for it
+    logger.error({ error }, 'failed to start the draft, reopening the queue')
+    await setState(QueueState.waiting)
+    throw error
+  }
+}

--- a/src/queue-captains/plugins/auto-update-queue-state.ts
+++ b/src/queue-captains/plugins/auto-update-queue-state.ts
@@ -1,0 +1,96 @@
+import fp from 'fastify-plugin'
+import { configuration } from '../../configuration'
+import { collections } from '../../database/collections'
+import { QueueState } from '../../database/models/queue-state.model'
+import { events } from '../../events'
+import { logger } from '../../logger'
+import { queue } from '../../queue'
+import { QueueMode } from '../../shared/types/queue-mode'
+import { tasks } from '../../tasks'
+import { safe } from '../../utils/safe'
+import { autoPick } from '../draft/auto-pick'
+import { start } from '../draft/start'
+import { getPool } from '../get-pool'
+import { getReadiness } from '../get-readiness'
+import { leave } from '../leave'
+import { unreadyPool } from '../unready-pool'
+
+export default fp(
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async () => {
+    async function maybeUpdateQueueState() {
+      if ((await queue.getMode()) !== QueueMode.captains) {
+        return
+      }
+
+      const state = await queue.getState()
+      switch (state) {
+        case QueueState.waiting: {
+          if ((await getReadiness()).isFull) {
+            logger.info('captains queue full, wait for players to ready up')
+            await queue.setState(QueueState.ready)
+            await tasks.schedule(
+              'queueCaptains:readyUpTimeout',
+              await configuration.get('queue.ready_up_timeout'),
+            )
+          }
+          break
+        }
+
+        case QueueState.ready: {
+          const pool = await getPool()
+          if (pool.length === 0) {
+            await unreadyPool()
+          } else if (pool.every(entry => entry.ready)) {
+            logger.info('all players ready, starting the draft')
+            await tasks.cancelAll('queueCaptains:readyUpTimeout')
+            await tasks.cancelAll('queueCaptains:unready')
+            await start()
+          }
+          break
+        }
+      }
+    }
+
+    // Everyone in the pool is a draft candidate, so everyone has to ready up — there are no
+    // passive reserves. Whoever did not is dropped, and if enough remain the draft goes ahead
+    // with a smaller pool rather than making the rest queue again.
+    async function readyUpTimeout() {
+      logger.info('captains ready up timeout, dropping players that are not ready')
+      const unready = (await collections.queueCaptainsPool.find({ ready: false }).toArray()).map(
+        entry => entry.player.steamId,
+      )
+      for (const steamId of unready) {
+        await leave(steamId)
+      }
+
+      if ((await getReadiness()).isFull) {
+        logger.info('still full after dropping unready players, starting the draft')
+        await start()
+        return
+      }
+
+      const readyStateTimeout = await configuration.get('queue.ready_state_timeout')
+      const readyUpTimeoutMs = await configuration.get('queue.ready_up_timeout')
+      const nextTimeout = readyStateTimeout - readyUpTimeoutMs
+      if (nextTimeout > 0) {
+        await tasks.schedule('queueCaptains:unready', nextTimeout)
+      } else {
+        await unreadyPool()
+      }
+    }
+
+    tasks.register('queueCaptains:readyUpTimeout', safe(readyUpTimeout))
+    tasks.register('queueCaptains:unready', safe(unreadyPool))
+    tasks.register(
+      'queueCaptains:draftTurnTimeout',
+      safe(async ({ draftId, turn }) => {
+        await autoPick(draftId, turn)
+      }),
+    )
+
+    events.on('queueCaptains/pool:updated', safe(maybeUpdateQueueState))
+    events.on('queueCaptains/pool:left', safe(maybeUpdateQueueState))
+  },
+  { name: 'auto update captains queue state' },
+)

--- a/src/queue-captains/plugins/gateway-listeners.ts
+++ b/src/queue-captains/plugins/gateway-listeners.ts
@@ -1,5 +1,4 @@
 import fp from 'fastify-plugin'
-import { collections } from '../../database/collections'
 import { errors } from '../../errors'
 import { FlashMessage } from '../../html/components/flash-message'
 import { queueWsCallDuration } from '../../queue/metrics'
@@ -7,8 +6,13 @@ import type { Tf2ClassName } from '../../shared/types/tf2-class-name'
 import { logError } from '../../utils/log-error'
 import { measureTime } from '../../utils/measure-time'
 import type { AppWebSocket } from '../../websocket/types'
-import { setGameClasses } from '../set-game-classes'
+import { makePick } from '../draft/make-pick'
+import { leave } from '../leave'
+import { readyUp } from '../ready-up'
+import { toggleGameClass } from '../toggle-game-class'
 import { toggleCaptain } from '../toggle-captain'
+import { ReadyUpDialog } from '../../queue-auto/views/html/ready-up-dialog'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -42,17 +46,44 @@ export default fp(
           throw errors.unauthorized('unauthorized')
         }
 
-        const entry = await collections.queueCaptainsPool.findOne({
-          'player.steamId': socket.player.steamId,
-        })
-        const current = new Set(entry?.gameClasses ?? [])
-        if (current.has(gameClass)) {
-          current.delete(gameClass)
-        } else {
-          current.add(gameClass)
+        await toggleGameClass(socket.player.steamId, gameClass)
+      }),
+    )
+
+    app.gateway.on(
+      'queue:captainspick',
+      wsSafe('captains:pick', async (socket, pick: string) => {
+        if (!socket.player) {
+          throw errors.unauthorized('unauthorized')
         }
 
-        await setGameClasses(socket.player.steamId, [...current])
+        const [player, gameClass] = pick.split(':') as [SteamId64, Tf2ClassName]
+        await makePick(socket.player.steamId, player, gameClass)
+      }),
+    )
+
+    app.gateway.on(
+      'queue:captainsreadyup',
+      wsSafe('captains:readyup', async socket => {
+        if (!socket.player) {
+          throw errors.unauthorized('unauthorized')
+        }
+
+        const [, close] = await Promise.all([readyUp(socket.player.steamId), ReadyUpDialog.close()])
+        app.gateway.to({ player: socket.player.steamId }).send(() => close)
+      }),
+    )
+
+    app.gateway.on(
+      'queue:captainsleave',
+      wsSafe('captains:leave', async socket => {
+        if (!socket.player) {
+          throw errors.unauthorized('unauthorized')
+        }
+
+        const close = await ReadyUpDialog.close()
+        await leave(socket.player.steamId)
+        app.gateway.to({ player: socket.player.steamId }).send(() => close)
       }),
     )
 

--- a/src/queue-captains/plugins/sync-clients.ts
+++ b/src/queue-captains/plugins/sync-clients.ts
@@ -1,6 +1,11 @@
 import fp from 'fastify-plugin'
+import { collections } from '../../database/collections'
+import { QueueState } from '../../database/models/queue-state.model'
 import { events } from '../../events'
 import { queue } from '../../queue'
+import { ReadyUpDialog } from '../../queue-auto/views/html/ready-up-dialog'
+import { getCurrent } from '../draft/get-current'
+import { DraftBoard } from '../views/html/draft-board'
 import { QueueMode } from '../../shared/types/queue-mode'
 import { safe } from '../../utils/safe'
 import type { AppWebSocket } from '../../websocket/types'
@@ -32,9 +37,26 @@ export default fp(
         return
       }
 
+      const actor = socket.player?.steamId
+      if (await getCurrent()) {
+        socket.send(await DraftBoard({ actor }))
+        return
+      }
+
       socket.send(await ReadinessMeter())
-      socket.send(await PoolList({ actor: socket.player?.steamId }))
-      socket.send(await ClassPicker({ actor: socket.player?.steamId }))
+      socket.send(await PoolList({ actor }))
+      socket.send(await ClassPicker({ actor }))
+
+      // a reconnect mid-ready-up should put the dialog back
+      if (actor && (await queue.getState()) === QueueState.ready) {
+        const entry = await collections.queueCaptainsPool.findOne({
+          'player.steamId': actor,
+          ready: false,
+        })
+        if (entry) {
+          socket.send(await ReadyUpDialog.show(actor))
+        }
+      }
     }
 
     app.gateway.on('ready', async socket => {

--- a/src/queue-captains/plugins/sync-draft.ts
+++ b/src/queue-captains/plugins/sync-draft.ts
@@ -1,0 +1,46 @@
+import fp from 'fastify-plugin'
+import { collections } from '../../database/collections'
+import { QueueState } from '../../database/models/queue-state.model'
+import { events } from '../../events'
+import { queue } from '../../queue'
+import { ReadyUpDialog } from '../../queue-auto/views/html/ready-up-dialog'
+import { QueueMode } from '../../shared/types/queue-mode'
+import { safe } from '../../utils/safe'
+import { DraftBoard } from '../views/html/draft-board'
+
+export default fp(
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async app => {
+    // The board is re-rendered per viewer: which picks are offered depends on whose turn it is,
+    // so there is no one piece of markup to broadcast.
+    const refreshBoard = () => {
+      app.gateway.to({ url: '/' }).send(actor => DraftBoard({ actor }))
+    }
+
+    events.on('queueCaptains/draft:started', refreshBoard)
+    events.on('queueCaptains/draft:updated', refreshBoard)
+
+    events.on(
+      'queue/state:updated',
+      safe(async ({ state }) => {
+        if (state !== QueueState.ready || (await queue.getMode()) !== QueueMode.captains) {
+          return
+        }
+
+        const players = (await collections.queueCaptainsPool.find({ ready: false }).toArray()).map(
+          entry => entry.player.steamId,
+        )
+        app.gateway.to({ players }).send(actor => ReadyUpDialog.show(actor!))
+      }),
+    )
+
+    events.on(
+      'queueCaptains/pool:left',
+      safe(async ({ steamId }) => {
+        const close = await ReadyUpDialog.close()
+        app.gateway.to({ player: steamId }).send(() => close)
+      }),
+    )
+  },
+  { name: 'captains draft sync' },
+)

--- a/src/queue-captains/ready-up.ts
+++ b/src/queue-captains/ready-up.ts
@@ -1,0 +1,32 @@
+import { collections } from '../database/collections'
+import type { CaptainsPoolEntryModel } from '../database/models/captains-pool-entry.model'
+import { QueueState } from '../database/models/queue-state.model'
+import { errors } from '../errors'
+import { events } from '../events'
+import { logger } from '../logger'
+import { preReady } from '../pre-ready'
+import { getState } from '../queue/get-state'
+import { withQueueLock } from '../queue/with-queue-lock'
+import type { SteamId64 } from '../shared/types/steam-id-64'
+
+export async function readyUp(steamId: SteamId64): Promise<CaptainsPoolEntryModel> {
+  return await withQueueLock('captains:ready-up', async () => {
+    logger.trace({ steamId }, 'queueCaptains.readyUp()')
+    if ((await getState()) !== QueueState.ready) {
+      throw errors.badRequest('wrong queue state')
+    }
+
+    const entry = await collections.queueCaptainsPool.findOneAndUpdate(
+      { 'player.steamId': steamId },
+      { $set: { ready: true } },
+      { returnDocument: 'after' },
+    )
+    if (!entry) {
+      throw errors.badRequest(`player not in queue: ${steamId}`)
+    }
+
+    events.emit('queueCaptains/pool:updated', { entries: [entry] })
+    await preReady.start(steamId)
+    return entry
+  })
+}

--- a/src/queue-captains/toggle-game-class.ts
+++ b/src/queue-captains/toggle-game-class.ts
@@ -1,39 +1,36 @@
 import { collections } from '../database/collections'
 import type { CaptainsPoolEntryModel } from '../database/models/captains-pool-entry.model'
 import { QueueState } from '../database/models/queue-state.model'
+import { configuration } from '../configuration'
 import { errors } from '../errors'
 import { events } from '../events'
 import { logger } from '../logger'
 import { players } from '../players'
-import { configuration } from '../configuration'
 import { config } from '../queue-auto/config'
 import { getState } from '../queue/get-state'
 import { withQueueLock } from '../queue/with-queue-lock'
+import { preReady } from '../pre-ready'
 import { playerAvatarUrl } from '../shared/player-avatar-url'
 import type { SteamId64 } from '../shared/types/steam-id-64'
 import type { Tf2ClassName } from '../shared/types/tf2-class-name'
 import { withLogLevel } from '../utils/with-log-level'
-import { leave } from './leave'
 
 /**
- * Set the classes a player is willing to play, joining the pool if they were not in it. Passing an
- * empty list leaves the queue, so the class toggles are the only control a player needs.
+ * Add or drop one class, joining the pool on the first and leaving it on the last. That makes the
+ * class toggles the only control a player needs.
+ *
+ * The read and the write happen together under the queue lock. Splitting them loses classes: two
+ * toggles sent in quick succession both read the same state and the second write wins, so a player
+ * who picks two classes in one go ends up signed on for one.
  */
-export async function setGameClasses(
+export async function toggleGameClass(
   steamId: SteamId64,
-  gameClasses: Tf2ClassName[],
+  gameClass: Tf2ClassName,
 ): Promise<CaptainsPoolEntryModel | null> {
-  logger.trace({ steamId, gameClasses }, 'queueCaptains.setGameClasses()')
+  logger.trace({ steamId, gameClass }, 'queueCaptains.toggleGameClass()')
 
-  const playable = config.classes.map(({ name }) => name)
-  const wanted = [...new Set(gameClasses)].filter(gameClass => playable.includes(gameClass))
-  if (wanted.length !== new Set(gameClasses).size) {
+  if (!config.classes.some(({ name }) => name === gameClass)) {
     throw errors.badRequest('class not played in this game mode')
-  }
-
-  if (wanted.length === 0) {
-    await leave(steamId)
-    return null
   }
 
   const player = await players.bySteamId(steamId, [
@@ -57,17 +54,31 @@ export async function setGameClasses(
     throw errors.badRequest('player is not verified')
   }
 
-  return await withQueueLock('captains:set-game-classes', async () => {
-    const state = await getState()
-    if (state !== QueueState.waiting) {
+  return await withQueueLock('captains:toggle-class', async () => {
+    if ((await getState()) !== QueueState.waiting) {
       throw withLogLevel(errors.badRequest('invalid queue state'), 'debug')
+    }
+
+    const existing = await collections.queueCaptainsPool.findOne({ 'player.steamId': steamId })
+    const gameClasses = new Set(existing?.gameClasses ?? [])
+    if (gameClasses.has(gameClass)) {
+      gameClasses.delete(gameClass)
+    } else {
+      gameClasses.add(gameClass)
+    }
+
+    if (gameClasses.size === 0) {
+      await collections.queueCaptainsPool.deleteOne({ 'player.steamId': steamId })
+      events.emit('queueCaptains/pool:left', { steamId })
+      await preReady.cancel(steamId)
+      return null
     }
 
     const entry = await collections.queueCaptainsPool.findOneAndUpdate(
       { 'player.steamId': steamId },
       {
         $set: {
-          gameClasses: wanted,
+          gameClasses: [...gameClasses],
           player: {
             steamId: player.steamId,
             name: player.name,

--- a/src/queue-captains/unready-pool.ts
+++ b/src/queue-captains/unready-pool.ts
@@ -1,0 +1,14 @@
+import { collections } from '../database/collections'
+import { QueueState } from '../database/models/queue-state.model'
+import { events } from '../events'
+import { logger } from '../logger'
+import { setState } from '../queue/set-state'
+import { getPool } from './get-pool'
+
+// Back to square one: the queue stays, everyone's classes stay, only the ready flags are dropped.
+export async function unreadyPool() {
+  logger.info('unready captains pool')
+  await setState(QueueState.waiting)
+  await collections.queueCaptainsPool.updateMany({}, { $set: { ready: false } })
+  events.emit('queueCaptains/pool:updated', { entries: await getPool() })
+}

--- a/src/queue-captains/views/html/captains-queue.page.tsx
+++ b/src/queue-captains/views/html/captains-queue.page.tsx
@@ -15,14 +15,16 @@ import { Sidebar } from '../../../queue-auto/views/html/sidebar'
 import { SoundBlockedAlert } from '../../../queue-auto/views/html/sound-blocked-alert'
 import { StreamList } from '../../../queue-auto/views/html/stream-list'
 import { SubstitutionRequests } from '../../../queue-auto/views/html/substitution-requests'
+import { getCurrent } from '../../draft/get-current'
 import { getReadiness } from '../../get-readiness'
 import { ClassPicker } from './class-picker'
+import { DraftBoard } from './draft-board'
 import { PoolList } from './pool-list'
 import { ReadinessMeter } from './readiness-meter'
 
 export async function CaptainsQueuePage() {
   const user = requestContext.get('user')
-  const readiness = await getReadiness()
+  const [readiness, draft] = await Promise.all([getReadiness(), getCurrent()])
 
   return (
     <Layout
@@ -50,9 +52,15 @@ export async function CaptainsQueuePage() {
           <div id="queue-content" class="tab-content lg:contents!">
             <div class="order-3 lg:order-2 lg:col-span-3">
               <div class="flex flex-col gap-6">
-                <ReadinessMeter />
-                <ClassPicker actor={user?.player.steamId} />
-                <PoolList actor={user?.player.steamId} />
+                {draft ? (
+                  <DraftBoard actor={user?.player.steamId} />
+                ) : (
+                  <>
+                    <ReadinessMeter />
+                    <ClassPicker actor={user?.player.steamId} />
+                    <PoolList actor={user?.player.steamId} />
+                  </>
+                )}
               </div>
             </div>
 

--- a/src/queue-captains/views/html/draft-board.css
+++ b/src/queue-captains/views/html/draft-board.css
@@ -4,131 +4,123 @@
   .draft-board {
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    gap: 16px;
   }
 
   .turn-bar {
-    border: 1px solid var(--color-abru-light-15);
-    border-radius: 10px;
-    background-color: var(--color-abru-light-5);
-    overflow: hidden;
-
-    &[data-team='blu'] {
-      border-color: color-mix(in srgb, var(--color-team-blu) 55%, transparent);
-      background-color: color-mix(in srgb, var(--color-team-blu) 13%, var(--color-abru-light-5));
-    }
-
-    &[data-team='red'] {
-      border-color: color-mix(in srgb, var(--color-team-red) 55%, transparent);
-      background-color: color-mix(in srgb, var(--color-team-red) 13%, var(--color-abru-light-5));
-    }
-
     .turn-bar-top {
       display: flex;
-      align-items: center;
+      align-items: baseline;
       justify-content: space-between;
       gap: 16px;
       flex-wrap: wrap;
-      padding: 14px 18px;
     }
 
     .turn-who {
       display: flex;
       align-items: baseline;
-      gap: 12px;
+      gap: 10px;
       flex-wrap: wrap;
     }
 
+    .turn-team {
+      align-self: center;
+      padding: 2px 10px;
+      border-radius: 4px;
+
+      font-size: 14px;
+      font-weight: 700;
+      text-transform: uppercase;
+      color: var(--color-ash);
+
+      &[data-team='blu'] {
+        background-color: var(--color-team-blu);
+      }
+
+      &[data-team='red'] {
+        background-color: var(--color-team-red);
+      }
+    }
+
     .turn-label {
-      font-size: 20px;
-      font-weight: 900;
-      letter-spacing: -0.01em;
+      font-size: 24px;
+      font-weight: 700;
+      line-height: normal;
       color: var(--color-ash);
     }
 
     .turn-sub {
-      font-size: 13.5px;
-      font-weight: 600;
-      color: var(--color-abru-light-60);
+      font-size: 14px;
+      font-weight: 300;
+      color: var(--color-abru-light-75);
     }
 
     .turn-clock {
-      font-size: 30px;
-      font-weight: 900;
-      line-height: 1;
-      letter-spacing: -0.02em;
+      font-size: 24px;
+      font-weight: 700;
+      line-height: normal;
       color: var(--color-ash);
       font-variant-numeric: tabular-nums;
     }
-  }
 
-  .turn-order {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    flex-wrap: wrap;
-    padding: 0 18px 14px;
+    .turn-order {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      flex-wrap: wrap;
 
-    b {
-      margin-right: 6px;
-      font-size: 10.5px;
-      font-weight: 800;
-      letter-spacing: 0.14em;
-      text-transform: uppercase;
-      color: var(--color-abru-light-35);
+      i {
+        display: block;
+        width: 20px;
+        height: 6px;
+        border-radius: 3px;
+        background-color: var(--color-abru-light-20);
+      }
+
+      i[data-team='blu'] {
+        background-color: var(--color-team-blu);
+      }
+
+      i[data-team='red'] {
+        background-color: var(--color-team-red);
+      }
+
+      i[data-state='done'] {
+        opacity: 0.4;
+      }
+
+      i[data-state='now'] {
+        height: 12px;
+        background-color: var(--color-ash);
+      }
     }
 
-    i {
-      display: block;
-      width: 22px;
-      height: 8px;
-      border-radius: 2px;
-      background-color: var(--color-abru-light-20);
+    .turn-timer {
+      height: 6px;
+      border-radius: 3px;
+      background-color: var(--color-abru-light-15);
+      overflow: hidden;
+
+      i {
+        display: block;
+        height: 100%;
+        width: 100%;
+        border-radius: 3px;
+        background-color: var(--color-abru-light-50);
+        transform-origin: left center;
+        animation-name: draft-turn-drain;
+        animation-timing-function: linear;
+        animation-fill-mode: forwards;
+      }
     }
 
-    i[data-team='blu'] {
+    &[data-team='blu'] .turn-timer i {
       background-color: var(--color-team-blu);
     }
 
-    i[data-team='red'] {
+    &[data-team='red'] .turn-timer i {
       background-color: var(--color-team-red);
     }
-
-    i[data-state='done'] {
-      opacity: 0.42;
-    }
-
-    i[data-state='now'] {
-      height: 14px;
-      border-radius: 3px;
-      box-shadow:
-        0 0 0 2px var(--color-abru-light-3),
-        0 0 0 4px var(--color-ash);
-    }
-  }
-
-  .turn-timer {
-    height: 5px;
-    background-color: var(--color-abru-dark-29);
-
-    i {
-      display: block;
-      height: 100%;
-      width: 100%;
-      background-color: var(--color-ash);
-      transform-origin: left center;
-      animation-name: draft-turn-drain;
-      animation-timing-function: linear;
-      animation-fill-mode: forwards;
-    }
-  }
-
-  .turn-bar[data-team='blu'] .turn-timer i {
-    background-color: #9ec9dc;
-  }
-
-  .turn-bar[data-team='red'] .turn-timer i {
-    background-color: #ff8b8b;
   }
 
   @keyframes draft-turn-drain {
@@ -149,72 +141,66 @@
   .draft-teams {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 14px;
+    gap: 8px;
 
     @media (width < theme(--breakpoint-md)) {
       grid-template-columns: 1fr;
     }
   }
 
+  /* team colour header over a translucent body, the same shape the game page uses */
   .draft-team {
-    border: 1px solid var(--color-abru-light-15);
-    border-radius: 10px;
-    background-color: var(--color-abru-light-5);
+    border-radius: 8px;
     overflow: hidden;
-
-    &[data-active='true'] {
-      box-shadow: 0 0 0 2px var(--color-ash);
-    }
 
     .draft-team-head {
       display: flex;
       align-items: center;
       justify-content: space-between;
       gap: 10px;
-      padding: 10px 14px;
+      padding: 8px 16px;
 
-      font-size: 14px;
-      font-weight: 900;
-      letter-spacing: 0.1em;
+      font-size: 20px;
+      font-weight: 700;
       text-transform: uppercase;
+      color: var(--color-ash);
     }
 
     &[data-team='blu'] .draft-team-head {
       background-color: var(--color-team-blu);
-      color: #eaf4f8;
     }
 
     &[data-team='red'] .draft-team-head {
       background-color: var(--color-team-red);
-      color: #fdeaea;
     }
 
     .draft-team-captain {
       display: flex;
       align-items: center;
-      gap: 5px;
-      font-size: 11.5px;
+      gap: 6px;
+
+      font-size: 14px;
       font-weight: 700;
-      letter-spacing: 0.04em;
       text-transform: none;
-      opacity: 0.92;
+      opacity: 0.9;
     }
 
     .draft-team-rows {
       display: flex;
       flex-direction: column;
-      gap: 6px;
+      gap: 8px;
       padding: 10px;
+      background-color: rgb(0 0 0 / 0.4);
     }
   }
 
   .draft-row {
     display: flex;
     align-items: center;
-    gap: 9px;
-    min-height: 44px;
-    padding: 5px 8px;
-    border-radius: 6px;
+    gap: 8px;
+    height: 48px;
+    padding: 8px;
+    border-radius: 8px;
     background-color: var(--color-abru-light-60);
 
     img {
@@ -222,18 +208,8 @@
       flex: 0 0 auto;
     }
 
-    &.draft-row-captain {
-      background-color: var(--color-abru-light-20);
-      border: 1px dashed var(--color-abru-light-30);
-
-      .draft-name {
-        color: var(--color-abru-light-85);
-      }
-    }
-
     &.draft-row-open {
-      background-color: var(--color-abru-light-15);
-      border: 1px dashed var(--color-abru-light-25);
+      background-color: var(--color-abru-light-30);
     }
   }
 
@@ -243,16 +219,14 @@
     flex: 0 0 auto;
 
     img {
-      opacity: 0.55;
+      opacity: 0.6;
     }
   }
 
   .draft-open-label {
-    font-size: 12.5px;
-    font-weight: 800;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--color-abru-light-35);
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--color-abru-light-50);
   }
 
   .draft-name {
@@ -262,23 +236,20 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 
-    font-size: 15px;
-    font-weight: 800;
-    letter-spacing: -0.01em;
+    font-size: 18px;
+    font-weight: 700;
     color: var(--color-abru-dark-3);
   }
 
   .draft-flag {
     flex: 0 0 auto;
-    padding: 2px 6px;
-    border-radius: 3px;
-    background-color: var(--color-abru-dark-3);
-    color: var(--color-alert);
+    padding: 2px 8px;
+    border-radius: 4px;
+    background-color: color-mix(in srgb, var(--color-abru-dark-3) 15%, transparent);
+    color: var(--color-abru-dark-3);
 
-    font-size: 10px;
-    font-weight: 900;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
+    font-size: 13px;
+    font-weight: 700;
   }
 
   .draft-available {
@@ -288,29 +259,26 @@
 
     .draft-available-head {
       display: flex;
-      align-items: baseline;
-      justify-content: space-between;
-      gap: 12px;
-      flex-wrap: wrap;
-    }
-
-    .draft-available-title {
-      font-size: 13px;
-      font-weight: 800;
-      letter-spacing: 0.16em;
-      text-transform: uppercase;
-      color: var(--color-abru-light-60);
+      flex-direction: column;
+      gap: 8px;
     }
 
     .draft-available-note {
-      font-size: 13px;
-      color: var(--color-abru-light-50);
+      font-size: 14px;
+      font-weight: 300;
+      color: var(--color-abru-light-75);
+    }
+
+    .draft-rule {
+      height: 2px;
+      border-radius: 2px;
+      background-color: var(--color-abru-light-25);
     }
 
     .draft-available-grid {
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-      gap: 10px;
+      gap: 8px;
     }
   }
 
@@ -318,22 +286,22 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    padding: 9px;
+    padding: 8px;
     border-radius: 8px;
     background-color: var(--color-abru-light-60);
 
     &[data-locked='true'] {
-      background-color: var(--color-abru-light-25);
+      background-color: var(--color-abru-light-30);
 
       .draft-name {
-        color: var(--color-abru-light-70);
+        color: var(--color-abru-light-85);
       }
     }
 
     .draft-card-top {
       display: flex;
       align-items: center;
-      gap: 10px;
+      gap: 8px;
 
       img {
         border-radius: 4px;
@@ -355,31 +323,26 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 5px 10px 5px 6px;
+    padding: 6px 12px 6px 8px;
 
-    border: 1px solid var(--color-abru-light-20);
-    border-radius: 6px;
+    border-radius: 4px;
     background-color: var(--color-abru-dark-20);
     color: var(--color-ash);
 
-    font-size: 12.5px;
-    font-weight: 800;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
+    font-size: 16px;
+    font-weight: 700;
 
     &:is(button):hover {
-      background-color: var(--color-accent-600);
-      border-color: var(--color-accent-600);
+      background-color: var(--color-accent);
     }
 
     &[data-locked='true'] {
-      background-color: var(--color-abru-light-10);
-      border-color: var(--color-abru-light-15);
-      color: var(--color-abru-light-35);
+      background-color: color-mix(in srgb, var(--color-abru-dark-3) 20%, transparent);
+      color: var(--color-abru-light-50);
       cursor: not-allowed;
 
       img {
-        opacity: 0.32;
+        opacity: 0.35;
       }
     }
   }

--- a/src/queue-captains/views/html/draft-board.css
+++ b/src/queue-captains/views/html/draft-board.css
@@ -1,0 +1,386 @@
+@reference '../../../html/styles/main.css';
+
+@layer components {
+  .draft-board {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .turn-bar {
+    border: 1px solid var(--color-abru-light-15);
+    border-radius: 10px;
+    background-color: var(--color-abru-light-5);
+    overflow: hidden;
+
+    &[data-team='blu'] {
+      border-color: color-mix(in srgb, var(--color-team-blu) 55%, transparent);
+      background-color: color-mix(in srgb, var(--color-team-blu) 13%, var(--color-abru-light-5));
+    }
+
+    &[data-team='red'] {
+      border-color: color-mix(in srgb, var(--color-team-red) 55%, transparent);
+      background-color: color-mix(in srgb, var(--color-team-red) 13%, var(--color-abru-light-5));
+    }
+
+    .turn-bar-top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      flex-wrap: wrap;
+      padding: 14px 18px;
+    }
+
+    .turn-who {
+      display: flex;
+      align-items: baseline;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .turn-label {
+      font-size: 20px;
+      font-weight: 900;
+      letter-spacing: -0.01em;
+      color: var(--color-ash);
+    }
+
+    .turn-sub {
+      font-size: 13.5px;
+      font-weight: 600;
+      color: var(--color-abru-light-60);
+    }
+
+    .turn-clock {
+      font-size: 30px;
+      font-weight: 900;
+      line-height: 1;
+      letter-spacing: -0.02em;
+      color: var(--color-ash);
+      font-variant-numeric: tabular-nums;
+    }
+  }
+
+  .turn-order {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    flex-wrap: wrap;
+    padding: 0 18px 14px;
+
+    b {
+      margin-right: 6px;
+      font-size: 10.5px;
+      font-weight: 800;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--color-abru-light-35);
+    }
+
+    i {
+      display: block;
+      width: 22px;
+      height: 8px;
+      border-radius: 2px;
+      background-color: var(--color-abru-light-20);
+    }
+
+    i[data-team='blu'] {
+      background-color: var(--color-team-blu);
+    }
+
+    i[data-team='red'] {
+      background-color: var(--color-team-red);
+    }
+
+    i[data-state='done'] {
+      opacity: 0.42;
+    }
+
+    i[data-state='now'] {
+      height: 14px;
+      border-radius: 3px;
+      box-shadow:
+        0 0 0 2px var(--color-abru-light-3),
+        0 0 0 4px var(--color-ash);
+    }
+  }
+
+  .turn-timer {
+    height: 5px;
+    background-color: var(--color-abru-dark-29);
+
+    i {
+      display: block;
+      height: 100%;
+      width: 100%;
+      background-color: var(--color-ash);
+      transform-origin: left center;
+      animation-name: draft-turn-drain;
+      animation-timing-function: linear;
+      animation-fill-mode: forwards;
+    }
+  }
+
+  .turn-bar[data-team='blu'] .turn-timer i {
+    background-color: #9ec9dc;
+  }
+
+  .turn-bar[data-team='red'] .turn-timer i {
+    background-color: #ff8b8b;
+  }
+
+  @keyframes draft-turn-drain {
+    from {
+      transform: scaleX(1);
+    }
+    to {
+      transform: scaleX(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .turn-timer i {
+      animation: none;
+    }
+  }
+
+  .draft-teams {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+
+    @media (width < theme(--breakpoint-md)) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .draft-team {
+    border: 1px solid var(--color-abru-light-15);
+    border-radius: 10px;
+    background-color: var(--color-abru-light-5);
+    overflow: hidden;
+
+    &[data-active='true'] {
+      box-shadow: 0 0 0 2px var(--color-ash);
+    }
+
+    .draft-team-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 10px 14px;
+
+      font-size: 14px;
+      font-weight: 900;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+
+    &[data-team='blu'] .draft-team-head {
+      background-color: var(--color-team-blu);
+      color: #eaf4f8;
+    }
+
+    &[data-team='red'] .draft-team-head {
+      background-color: var(--color-team-red);
+      color: #fdeaea;
+    }
+
+    .draft-team-captain {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      font-size: 11.5px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: none;
+      opacity: 0.92;
+    }
+
+    .draft-team-rows {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 10px;
+    }
+  }
+
+  .draft-row {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    min-height: 44px;
+    padding: 5px 8px;
+    border-radius: 6px;
+    background-color: var(--color-abru-light-60);
+
+    img {
+      border-radius: 4px;
+      flex: 0 0 auto;
+    }
+
+    &.draft-row-captain {
+      background-color: var(--color-abru-light-20);
+      border: 1px dashed var(--color-abru-light-30);
+
+      .draft-name {
+        color: var(--color-abru-light-85);
+      }
+    }
+
+    &.draft-row-open {
+      background-color: var(--color-abru-light-15);
+      border: 1px dashed var(--color-abru-light-25);
+    }
+  }
+
+  .draft-captain-classes {
+    display: flex;
+    gap: 2px;
+    flex: 0 0 auto;
+
+    img {
+      opacity: 0.55;
+    }
+  }
+
+  .draft-open-label {
+    font-size: 12.5px;
+    font-weight: 800;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-abru-light-35);
+  }
+
+  .draft-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    font-size: 15px;
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    color: var(--color-abru-dark-3);
+  }
+
+  .draft-flag {
+    flex: 0 0 auto;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background-color: var(--color-abru-dark-3);
+    color: var(--color-alert);
+
+    font-size: 10px;
+    font-weight: 900;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .draft-available {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    .draft-available-head {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .draft-available-title {
+      font-size: 13px;
+      font-weight: 800;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--color-abru-light-60);
+    }
+
+    .draft-available-note {
+      font-size: 13px;
+      color: var(--color-abru-light-50);
+    }
+
+    .draft-available-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      gap: 10px;
+    }
+  }
+
+  .draft-card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 9px;
+    border-radius: 8px;
+    background-color: var(--color-abru-light-60);
+
+    &[data-locked='true'] {
+      background-color: var(--color-abru-light-25);
+
+      .draft-name {
+        color: var(--color-abru-light-70);
+      }
+    }
+
+    .draft-card-top {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+
+      img {
+        border-radius: 4px;
+        flex: 0 0 auto;
+      }
+    }
+
+    .draft-card-picks {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+  }
+
+  .draft-pick {
+    @apply transition-colors;
+    @apply duration-75;
+
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 10px 5px 6px;
+
+    border: 1px solid var(--color-abru-light-20);
+    border-radius: 6px;
+    background-color: var(--color-abru-dark-20);
+    color: var(--color-ash);
+
+    font-size: 12.5px;
+    font-weight: 800;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+
+    &:is(button):hover {
+      background-color: var(--color-accent-600);
+      border-color: var(--color-accent-600);
+    }
+
+    &[data-locked='true'] {
+      background-color: var(--color-abru-light-10);
+      border-color: var(--color-abru-light-15);
+      color: var(--color-abru-light-35);
+      cursor: not-allowed;
+
+      img {
+        opacity: 0.32;
+      }
+    }
+  }
+}

--- a/src/queue-captains/views/html/draft-board.tsx
+++ b/src/queue-captains/views/html/draft-board.tsx
@@ -60,7 +60,7 @@ function TurnBar(props: {
   const { draft, turn } = props
   if (turn === null) {
     return (
-      <div class="turn-bar" data-team="done">
+      <div class="captains-panel turn-bar" data-team="done">
         <div class="turn-bar-top">
           <span class="turn-label">Teams are set</span>
         </div>
@@ -73,12 +73,13 @@ function TurnBar(props: {
   const captain = draft.pool.find(entry => entry.steamId === draft.captains[turn.team])
 
   return (
-    <div class="turn-bar" data-team={turn.team}>
+    <div class="captains-panel turn-bar" data-team={turn.team}>
       <div class="turn-bar-top">
         <div class="turn-who">
-          <span class="turn-label" safe>
-            {props.isMyTurn ? 'Your pick' : `${turn.team.toUpperCase()} is picking`}
+          <span class="turn-team" data-team={turn.team}>
+            {turn.team}
           </span>
+          <span class="turn-label">{props.isMyTurn ? 'Your pick' : 'is picking'}</span>
           <span class="turn-sub">
             {!props.isMyTurn && <span safe>{captain?.name ?? 'captain'} · </span>}
             pick {turn.index + 1} of {turn.total}
@@ -91,7 +92,6 @@ function TurnBar(props: {
       </div>
 
       <div class="turn-order" aria-hidden="true">
-        <b>order</b>
         {order.map((team, index) => (
           <i
             data-team={team}
@@ -113,7 +113,6 @@ function TeamPanel(props: { draft: DraftModel; team: Tf2Team; active: boolean })
   const captain = draft.pool.find(entry => entry.steamId === captainId)
   const picked = draft.picks.filter(pick => pick.team === team)
 
-  // slots this team still has open, which is also what the captain will end up playing one of
   const remaining = teamSlots(config).filter(slot => slot.team === team)
   for (const pick of picked) {
     const index = remaining.findIndex(slot => slot.gameClass === pick.gameClass)
@@ -121,9 +120,14 @@ function TeamPanel(props: { draft: DraftModel; team: Tf2Team; active: boolean })
       remaining.splice(index, 1)
     }
   }
+
+  // One of the remaining slots is the captain's. It has to be one they can actually play, so a
+  // class they cannot play always stays on the board as an open pick.
   const captainClasses = [...new Set(remaining.map(slot => slot.gameClass))].filter(gameClass =>
     captain?.gameClasses.includes(gameClass),
   )
+  const captainSlot = remaining.findIndex(slot => captainClasses.includes(slot.gameClass))
+  const openSlots = remaining.filter((_, index) => index !== captainSlot)
 
   return (
     <div class="draft-team" data-team={team} data-active={`${props.active}`}>
@@ -151,7 +155,7 @@ function TeamPanel(props: { draft: DraftModel; team: Tf2Team; active: boolean })
           )
         })}
 
-        <div class="draft-row draft-row-captain">
+        <div class="draft-row">
           <span class="draft-captain-classes">
             {captainClasses.map(gameClass => (
               <GameClassIcon gameClass={gameClass} size={22} />
@@ -164,9 +168,9 @@ function TeamPanel(props: { draft: DraftModel; team: Tf2Team; active: boolean })
           <span class="draft-flag">{captainClasses.length === 1 ? 'locked in' : 'class TBD'}</span>
         </div>
 
-        {Array.from({ length: Math.max(remaining.length - 1, 0) }, (_, index) => (
+        {openSlots.map(slot => (
           <div class="draft-row draft-row-open">
-            <GameClassIcon gameClass={remaining[index + 1]!.gameClass} size={22} />
+            <GameClassIcon gameClass={slot.gameClass} size={22} />
             <span class="draft-open-label">open</span>
           </div>
         ))}
@@ -192,13 +196,14 @@ function AvailablePool(props: {
   return (
     <div class="draft-available">
       <div class="draft-available-head">
-        <span class="draft-available-title">Available · {available.length}</span>
+        <span class="captains-panel-label">Available · {available.length}</span>
         {sittingOut > 0 && (
           <span class="draft-available-note" safe>
             {sittingOut === 1 ? 'One of these will' : `${sittingOut} of these will`} not play this
             game
           </span>
         )}
+        <div class="draft-rule"></div>
       </div>
 
       <form class="draft-available-grid" ws-send data-disable-when-offline>

--- a/src/queue-captains/views/html/draft-board.tsx
+++ b/src/queue-captains/views/html/draft-board.tsx
@@ -1,0 +1,257 @@
+import { GameClassIcon } from '../../../html/components/game-class-icon'
+import { IconCrown, IconLock } from '../../../html/components/icons'
+import type { DraftModel } from '../../../database/models/draft.model'
+import { config } from '../../../queue-auto/config'
+import type { SteamId64 } from '../../../shared/types/steam-id-64'
+import { Tf2Team } from '../../../shared/types/tf2-team'
+import { currentTurn } from '../../draft/current-turn'
+import { getCurrent } from '../../draft/get-current'
+import { openSlots } from '../../draft/open-slots'
+import { remainingCandidates } from '../../draft/remaining-candidates'
+import { legalPicks, type LegalPick } from '../../matching/legal-picks'
+import { pickOrder } from '../../pick-order'
+import { teamSlots } from '../../team-slots'
+
+export async function DraftBoard(props: { actor?: SteamId64 | undefined }) {
+  const draft = await getCurrent()
+  if (!draft) {
+    return <div id="draft-board"></div>
+  }
+
+  const turn = currentTurn(draft, config)
+  const isMyTurn = turn !== null && draft.captains[turn.team] === props.actor
+  const available = openSlots(draft, config)
+  const picks =
+    turn === null
+      ? []
+      : legalPicks({
+          openSlots: available,
+          candidates: remainingCandidates(draft),
+          team: turn.team,
+        })
+
+  return (
+    <div id="draft-board" class="draft-board">
+      <TurnBar draft={draft} turn={turn} isMyTurn={isMyTurn} />
+
+      <div class="draft-teams">
+        {[Tf2Team.blu, Tf2Team.red].map(team => (
+          <TeamPanel draft={draft} team={team} active={turn?.team === team} />
+        ))}
+      </div>
+
+      {turn !== null && (
+        <AvailablePool
+          draft={draft}
+          picks={picks}
+          isMyTurn={isMyTurn}
+          slotsLeft={available.length}
+        />
+      )}
+    </div>
+  )
+}
+
+function TurnBar(props: {
+  draft: DraftModel
+  turn: { index: number; team: Tf2Team; total: number } | null
+  isMyTurn: boolean
+}) {
+  const { draft, turn } = props
+  if (turn === null) {
+    return (
+      <div class="turn-bar" data-team="done">
+        <div class="turn-bar-top">
+          <span class="turn-label">Teams are set</span>
+        </div>
+      </div>
+    )
+  }
+
+  const order = pickOrder(config)
+  const remainingMs = Math.max((draft.turnEndsAt?.getTime() ?? 0) - Date.now(), 0)
+  const captain = draft.pool.find(entry => entry.steamId === draft.captains[turn.team])
+
+  return (
+    <div class="turn-bar" data-team={turn.team}>
+      <div class="turn-bar-top">
+        <div class="turn-who">
+          <span class="turn-label" safe>
+            {props.isMyTurn ? 'Your pick' : `${turn.team.toUpperCase()} is picking`}
+          </span>
+          <span class="turn-sub">
+            {!props.isMyTurn && <span safe>{captain?.name ?? 'captain'} · </span>}
+            pick {turn.index + 1} of {turn.total}
+            {props.isMyTurn && ' · choose a player and the class they will play'}
+          </span>
+        </div>
+        <span class="turn-clock" data-countdown={remainingMs} safe>
+          {formatClock(remainingMs)}
+        </span>
+      </div>
+
+      <div class="turn-order" aria-hidden="true">
+        <b>order</b>
+        {order.map((team, index) => (
+          <i
+            data-team={team}
+            data-state={index < turn.index ? 'done' : index === turn.index ? 'now' : 'next'}
+          ></i>
+        ))}
+      </div>
+
+      <div class="turn-timer">
+        <i style={`animation-duration: ${remainingMs}ms`}></i>
+      </div>
+    </div>
+  )
+}
+
+function TeamPanel(props: { draft: DraftModel; team: Tf2Team; active: boolean }) {
+  const { draft, team } = props
+  const captainId = draft.captains[team]
+  const captain = draft.pool.find(entry => entry.steamId === captainId)
+  const picked = draft.picks.filter(pick => pick.team === team)
+
+  // slots this team still has open, which is also what the captain will end up playing one of
+  const remaining = teamSlots(config).filter(slot => slot.team === team)
+  for (const pick of picked) {
+    const index = remaining.findIndex(slot => slot.gameClass === pick.gameClass)
+    if (index >= 0) {
+      remaining.splice(index, 1)
+    }
+  }
+  const captainClasses = [...new Set(remaining.map(slot => slot.gameClass))].filter(gameClass =>
+    captain?.gameClasses.includes(gameClass),
+  )
+
+  return (
+    <div class="draft-team" data-team={team} data-active={`${props.active}`}>
+      <div class="draft-team-head">
+        <span>{team}</span>
+        <span class="draft-team-captain">
+          <IconCrown size={14} />
+          <span safe>{captain?.name ?? '—'}</span>
+        </span>
+      </div>
+
+      <div class="draft-team-rows">
+        {picked.map(pick => {
+          const player = draft.pool.find(entry => entry.steamId === pick.player)
+          return (
+            <div class="draft-row" data-auto={`${Boolean(pick.auto)}`}>
+              <GameClassIcon gameClass={pick.gameClass} size={22} />
+              <img src={player?.avatarUrl} width="32" height="32" alt="" loading="lazy" />
+              <span class="draft-name" safe>
+                {player?.name ?? 'unknown'}
+              </span>
+              {!!pick.auto && <span class="draft-flag">auto</span>}
+              {!!pick.forced && <span class="draft-flag">forced</span>}
+            </div>
+          )
+        })}
+
+        <div class="draft-row draft-row-captain">
+          <span class="draft-captain-classes">
+            {captainClasses.map(gameClass => (
+              <GameClassIcon gameClass={gameClass} size={22} />
+            ))}
+          </span>
+          <img src={captain?.avatarUrl} width="32" height="32" alt="" loading="lazy" />
+          <span class="draft-name" safe>
+            {captain?.name ?? '—'}
+          </span>
+          <span class="draft-flag">{captainClasses.length === 1 ? 'locked in' : 'class TBD'}</span>
+        </div>
+
+        {Array.from({ length: Math.max(remaining.length - 1, 0) }, (_, index) => (
+          <div class="draft-row draft-row-open">
+            <GameClassIcon gameClass={remaining[index + 1]!.gameClass} size={22} />
+            <span class="draft-open-label">open</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function AvailablePool(props: {
+  draft: DraftModel
+  picks: LegalPick[]
+  isMyTurn: boolean
+  slotsLeft: number
+}) {
+  const { draft } = props
+  const pickedIds = new Set(draft.picks.map(pick => pick.player))
+  const captainIds = new Set(Object.values(draft.captains))
+  const available = draft.pool.filter(
+    entry => !pickedIds.has(entry.steamId) && !captainIds.has(entry.steamId),
+  )
+  const sittingOut = available.length - (props.slotsLeft - 2)
+
+  return (
+    <div class="draft-available">
+      <div class="draft-available-head">
+        <span class="draft-available-title">Available · {available.length}</span>
+        {sittingOut > 0 && (
+          <span class="draft-available-note" safe>
+            {sittingOut === 1 ? 'One of these will' : `${sittingOut} of these will`} not play this
+            game
+          </span>
+        )}
+      </div>
+
+      <form class="draft-available-grid" ws-send data-disable-when-offline>
+        {available.map(entry => {
+          const options = entry.gameClasses.map(gameClass => ({
+            gameClass,
+            legal: props.picks.some(
+              pick => pick.steamId === entry.steamId && pick.gameClass === gameClass,
+            ),
+          }))
+          const anyLegal = options.some(option => option.legal)
+
+          return (
+            <div class="draft-card" data-locked={`${!anyLegal}`}>
+              <div class="draft-card-top">
+                <img src={entry.avatarUrl} width="40" height="40" alt="" loading="lazy" />
+                <span class="draft-name" safe>
+                  {entry.name}
+                </span>
+              </div>
+              <div class="draft-card-picks">
+                {options.map(({ gameClass, legal }) =>
+                  legal && props.isMyTurn ? (
+                    <button
+                      class="draft-pick"
+                      name="captainspick"
+                      value={`${entry.steamId}:${gameClass}`}
+                      data-umami-event="captains-draft-pick"
+                      data-umami-event-class={gameClass}
+                    >
+                      <GameClassIcon gameClass={gameClass} size={20} />
+                      <span>{gameClass}</span>
+                    </button>
+                  ) : (
+                    <span class="draft-pick" data-locked={`${!legal}`}>
+                      {!legal && <IconLock size={13} />}
+                      <GameClassIcon gameClass={gameClass} size={20} />
+                      <span>{gameClass}</span>
+                    </span>
+                  ),
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </form>
+    </div>
+  )
+}
+
+function formatClock(ms: number): string {
+  const total = Math.ceil(ms / 1000)
+  const minutes = Math.floor(total / 60)
+  const seconds = total % 60
+  return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`
+}

--- a/src/queue-captains/views/html/style.css
+++ b/src/queue-captains/views/html/style.css
@@ -4,3 +4,4 @@
 @import '../../../queue-auto/views/html/sidebar.css';
 @import '../../../queue-auto/views/html/stream-list.css';
 @import './captains-queue.css';
+@import './draft-board.css';

--- a/src/queue/set-state.test.ts
+++ b/src/queue/set-state.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueueMode } from '../shared/types/queue-mode'
+
+const { mockGetMode } = vi.hoisted(() => ({ mockGetMode: vi.fn() }))
 
 vi.mock('../database/collections', () => ({
   collections: {
@@ -23,6 +26,8 @@ vi.mock('../pre-ready', () => ({
   preReady: { start: vi.fn() },
 }))
 
+vi.mock('./get-mode', () => ({ getMode: mockGetMode }))
+
 vi.mock('./with-queue-lock', () => ({
   withQueueLock: vi.fn(async (_operation: string, fn: () => Promise<unknown>) => await fn()),
 }))
@@ -35,6 +40,7 @@ import { events } from '../events'
 describe('setState()', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockGetMode.mockResolvedValue(QueueMode.auto)
   })
 
   describe('when transitioning to launching', () => {
@@ -61,6 +67,19 @@ describe('setState()', () => {
         state: QueueState.launching,
       })
     })
+  })
+
+  it('skips the slot check in captain mode, which has no slots yet', async () => {
+    mockGetMode.mockResolvedValue(QueueMode.captains)
+    vi.mocked(collections.queueSlots.countDocuments).mockResolvedValue(12)
+
+    await setState(QueueState.launching)
+
+    expect(collections.queueSlots.countDocuments).not.toHaveBeenCalled()
+    expect(collections.queueState.updateOne).toHaveBeenCalledWith(
+      {},
+      { $set: { state: QueueState.launching } },
+    )
   })
 
   it('does not verify slots for other transitions', async () => {

--- a/src/queue/set-state.ts
+++ b/src/queue/set-state.ts
@@ -5,14 +5,20 @@ import { errors } from '../errors'
 import { events } from '../events'
 import { logger } from '../logger'
 import { preReady } from '../pre-ready'
+import { QueueMode } from '../shared/types/queue-mode'
 import { withLogLevel } from '../utils/with-log-level'
+import { getMode } from './get-mode'
 import { withQueueLock } from './with-queue-lock'
 
 export async function setState(state: QueueState) {
   await withQueueLock('set-state', async () => {
     logger.trace({ state }, 'queue.setState()')
 
-    if (state === QueueState.launching) {
+    // The state machine is shared, but these two transitions reach into the auto queue's fixed
+    // slots. Captain mode has no slots until the draft, so it does the equivalent work itself.
+    const isAutoQueue = (await getMode()) === QueueMode.auto
+
+    if (isAutoQueue && state === QueueState.launching) {
       const notReadyCount = await collections.queueSlots.countDocuments({
         $or: [{ player: { $eq: null } }, { ready: { $eq: false } }],
       })
@@ -26,7 +32,7 @@ export async function setState(state: QueueState) {
 
     await collections.queueState.updateOne({}, { $set: { state } })
 
-    if (state === QueueState.ready) {
+    if (isAutoQueue && state === QueueState.ready) {
       const last = (await collections.queueState.findOne())?.last
       if (!last) {
         throw errors.internalServerError('invalid queue state: last undefined')

--- a/src/tasks/tasks.ts
+++ b/src/tasks/tasks.ts
@@ -41,6 +41,18 @@ export const tasksSchema = z.discriminatedUnion('name', [
     }),
   }),
   z.object({
+    name: z.literal('queueCaptains:draftTurnTimeout'),
+    args: z.object({ draftId: z.string(), turn: z.number() }),
+  }),
+  z.object({
+    name: z.literal('queueCaptains:readyUpTimeout'),
+    args: z.object({}),
+  }),
+  z.object({
+    name: z.literal('queueCaptains:unready'),
+    args: z.object({}),
+  }),
+  z.object({
     name: z.literal('queue:readyUpTimeout'),
     args: z.object({}),
   }),

--- a/src/websocket/gateway.ts
+++ b/src/websocket/gateway.ts
@@ -23,6 +23,9 @@ export interface ClientToServerEvents {
   'queue:togglepreready': () => void
   'queue:captainsclass': (gameClass: Tf2ClassName) => void
   'queue:captainsvolunteer': () => void
+  'queue:captainspick': (pick: string) => void
+  'queue:captainsreadyup': () => void
+  'queue:captainsleave': () => void
   'queue:audiostatus': (audioReady: boolean) => void
 }
 
@@ -77,6 +80,21 @@ const captainsVolunteer = z.object({
   HEADERS: htmxHeaders,
 })
 
+const captainsPick = z.object({
+  captainspick: z.string().regex(/^\d{17}:[a-z]+$/),
+  HEADERS: htmxHeaders,
+})
+
+const captainsReadyUp = z.object({
+  captainsreadyup: z.literal(''),
+  HEADERS: htmxHeaders,
+})
+
+const captainsLeave = z.object({
+  captainsleave: z.literal(''),
+  HEADERS: htmxHeaders,
+})
+
 const navigated = z.object({
   navigated: z.string(),
   HEADERS: htmxHeaders.optional(),
@@ -96,6 +114,9 @@ const clientMessage = z.union([
   preReadyToggle,
   captainsClass,
   captainsVolunteer,
+  captainsPick,
+  captainsReadyUp,
+  captainsLeave,
   navigated,
   audioStatus,
 ])
@@ -298,6 +319,12 @@ export class Gateway extends EventEmitter implements Broadcaster {
         this.emit('queue:captainsclass', socket, parsed.captainsclass)
       } else if ('captainsvolunteer' in parsed) {
         this.emit('queue:captainsvolunteer', socket)
+      } else if ('captainspick' in parsed) {
+        this.emit('queue:captainspick', socket, parsed.captainspick)
+      } else if ('captainsreadyup' in parsed) {
+        this.emit('queue:captainsreadyup', socket)
+      } else if ('captainsleave' in parsed) {
+        this.emit('queue:captainsleave', socket)
       } else if ('prereadytoggle' in parsed) {
         this.emit('queue:togglepreready', socket)
       } else if ('audioReady' in parsed) {


### PR DESCRIPTION
> **Stacking note.** Builds on #766, so this branch carries that commit too. Targeting `master` because CI only fires for PRs based on `master`. Merge #766 first and this narrows to its own commit.

Ready-up for the captain pool, then the draft — states **03** and **04** from the design.

## What works

Two captains are drawn at random from the volunteers and take turns picking players *and* the class each will play, on one board that every player and spectator watches live. Turns resolve through the matching engine from #765, so a captain is only ever offered picks that leave both teams completable.

- A turn with a **single legal option** commits immediately instead of burning the clock on a non-choice — and that cascades.
- A turn **nobody answers** is decided for them: the longest-waiting player still available, on their first legal class. Deterministic rather than random, so a draft replays exactly from its log and it rewards queue patience.
- **Captains are never pickable.** They take whatever slot their own team has left, which the matching guarantees they can play.

## Two bugs found by running it, not by reading it

**Class selection was racing.** The toggle read the pool entry, computed the new set, then wrote it back — all outside the queue lock. Two toggles sent together both read the same state and the second write won, so a player choosing two classes ended up signed on for one. The smoke test caught this immediately: all 14 players had a single class each, and `kilo` had silently lost `demoman`. Now one atomic toggle under the lock.

**Starting a draft made the auto queue eat itself.** Captain mode parks the queue in `launching` for the duration of the draft. `launch-new-game` listens for exactly that and builds a game from the *auto* queue's slots — which are empty in captain mode — so it threw and called `unreadyQueue()`, resetting everything. Now guarded by mode, as are the two transitions in `setState` that reach into the auto queue's fixed slots.

Both are the same cross-mode bleed I flagged in #766. It is the recurring hazard of one-mode-at-a-time and I would rather it stayed visible than got quietly patched.

## Verified against a running server

A script drove 14 players through the whole flow over real websockets — joining on multiple classes, readying up, then the two drafted captains picking by clicking **the buttons the server actually rendered**:

```
ok  queue went to ready-up          ok  no captain was ever picked
ok  a draft was created             ok  nobody was picked twice
ok  queue closed while drafting     ok  every pick on a signed-up class
ok  pool frozen at 14               ok  blu/red each made 5 picks
ok  draft completed                 ok  neither exceeded its class limits
ok  ten picks were made             ok  each captain left one slot they can play
  (1 forced, 0 timed out, 9 chosen by a captain)
```

Then the same run with a 1s pick timeout and captains deliberately silent — **9 auto-picks, 1 forced, teams still valid**. That path is otherwise untestable without waiting out real timers.

## Where it stops

The draft ends at `completed` with the teams known. Map bans and game creation are the next PR, so **the queue stays in `launching` after a draft finishes** until then — an admin would have to clear it. `queue.mode` defaults to `auto`, so nothing is reachable in production yet.

## Still open from before

Per-mode game counts for the captain K-factor. This PR does not touch ELO, so it is still the game-creation PR's to make.

## Checks

`pnpm lint`, `pnpm xss-scan`, `pnpm test` (472 passed), `tsc -p tsconfig.build.json` clean. Two existing tests needed a `getMode` mock added, since the new guards read configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)