### PR TITLE
feat(queue): add map bans and turn a finished draft into a game

### DIFF
--- a/src/database/models/configuration-entry.model.ts
+++ b/src/database/models/configuration-entry.model.ts
@@ -235,6 +235,12 @@ export const configurationSchema = z.discriminatedUnion('key', [
       value: z.number().positive().default(secondsToMilliseconds(30)),
     })
     .describe('Time a captain has to make each draft pick before one is made for them'),
+  z
+    .object({
+      key: z.literal('queue.captains.ban_timeout'),
+      value: z.number().positive().default(secondsToMilliseconds(30)),
+    })
+    .describe('Time a captain has to ban a map before one is banned for them'),
   z.object({
     key: z.literal('queue.player_skill_threshold'),
     value: z.number().nullable().default(null),

--- a/src/database/models/draft.model.ts
+++ b/src/database/models/draft.model.ts
@@ -1,3 +1,4 @@
+import type { GameNumber } from './game.model'
 import type { SteamId64 } from '../../shared/types/steam-id-64'
 import type { Tf2ClassName } from '../../shared/types/tf2-class-name'
 import type { Tf2Team } from '../../shared/types/tf2-team'
@@ -9,8 +10,20 @@ export enum DraftState {
   // captains are taking turns picking players
   picking = 'picking',
 
-  // every slot is spoken for
+  // teams are set; captains are banning maps down to the one they will play
+  banningMaps = 'banning maps',
+
+  // teams and map are settled, the game has been created
   completed = 'completed',
+}
+
+export interface DraftMapBan {
+  team: Tf2Team
+  map: string
+  at: Date
+
+  // the captain ran out of time and a map was banned for them
+  auto?: boolean
 }
 
 export interface DraftPick {
@@ -46,6 +59,15 @@ export interface DraftModel {
   }[]
 
   picks: DraftPick[]
+
+  // the three candidates, in the order they were offered
+  mapOptions: string[]
+
+  // one per ban, in order; whatever option is left unbanned is the map
+  mapBans: DraftMapBan[]
+
+  // the game this draft produced, once it exists
+  game?: GameNumber
 
   // when the captain on the clock runs out of time; absent once the draft is over
   turnEndsAt?: Date

--- a/src/database/models/game-slot.model.ts
+++ b/src/database/models/game-slot.model.ts
@@ -25,4 +25,5 @@ export interface GameSlotModel {
   shouldJoinBy?: Date
   voiceServerUrl?: string
   applyCooldown?: boolean // should apply cooldown to player if they get replaced
+  isCaptain?: boolean // drafted this team, in captain mode
 }

--- a/src/database/models/game.model.ts
+++ b/src/database/models/game.model.ts
@@ -1,3 +1,4 @@
+import type { DraftId } from './draft.model'
 import type { GameSlotModel } from './game-slot.model'
 import type { GameCreated, GameEventModel } from './game-event.model'
 import type { Tf2Team } from '../../shared/types/tf2-team'
@@ -63,6 +64,9 @@ export interface GameModel {
 
   slots: GameSlotModel[]
   events: [GameCreated, ...GameEventModel[]]
+
+  // set when the teams came out of a captain draft; its absence means auto-balanced
+  draft?: DraftId
   gameServer?: GameServer
 
   logsUrl?: string

--- a/src/games/create-from-slots.ts
+++ b/src/games/create-from-slots.ts
@@ -1,0 +1,65 @@
+import { collections } from '../database/collections'
+import { GameEventType } from '../database/models/game-event.model'
+import type { DraftId } from '../database/models/draft.model'
+import { PlayerConnectionStatus, SlotStatus } from '../database/models/game-slot.model'
+import { GameState, type GameModel, type GameNumber } from '../database/models/game.model'
+import { events } from '../events'
+import type { SteamId64 } from '../shared/types/steam-id-64'
+import type { Tf2ClassName } from '../shared/types/tf2-class-name'
+import type { Tf2Team } from '../shared/types/tf2-team'
+import type { GameSlotId } from '../shared/types/game-slot-id'
+
+export interface GameSlotSpec {
+  id: GameSlotId
+  player: SteamId64
+  team: Tf2Team
+  gameClass: Tf2ClassName
+  skill?: number
+  isCaptain?: boolean
+}
+
+/**
+ * Create a game from teams that are already decided. Auto mode gets here through `create()` once it
+ * has balanced them; captain mode hands over the roster its draft produced.
+ */
+export async function createFromSlots(
+  slots: GameSlotSpec[],
+  map: string,
+  draft?: DraftId,
+): Promise<GameModel> {
+  const { insertedId } = await collections.games.insertOne({
+    number: await getNextGameNumber(),
+    map,
+    state: GameState.created,
+    ...(draft && { draft }),
+    slots: slots.map(slot => ({
+      id: slot.id,
+      player: slot.player,
+      team: slot.team,
+      gameClass: slot.gameClass,
+      status: SlotStatus.active,
+      connectionStatus: PlayerConnectionStatus.offline,
+      ...(slot.skill !== undefined && { skill: slot.skill }),
+      ...(slot.isCaptain && { isCaptain: true }),
+    })),
+    events: [
+      {
+        at: new Date(),
+        event: GameEventType.gameCreated,
+      },
+    ],
+  })
+
+  const game = await collections.games.findOne({ _id: insertedId })
+  if (!game) {
+    throw new Error('failed creating game')
+  }
+
+  events.emit('game:created', { game })
+  return game
+}
+
+async function getNextGameNumber(): Promise<GameNumber> {
+  const latestGame = await collections.games.findOne({}, { sort: { 'events.0.at': -1 } })
+  return latestGame ? ((latestGame.number + 1) as GameNumber) : (1 as GameNumber)
+}

--- a/src/games/create.ts
+++ b/src/games/create.ts
@@ -1,12 +1,8 @@
 import { configuration } from '../configuration'
-import { collections } from '../database/collections'
-import { GameEventType } from '../database/models/game-event.model'
-import { PlayerConnectionStatus, SlotStatus } from '../database/models/game-slot.model'
-import { GameState, type GameNumber } from '../database/models/game.model'
 import type { QueueSlotModel } from '../database/models/queue-slot.model'
-import { events } from '../events'
 import { players } from '../players'
 import type { SteamId64 } from '../shared/types/steam-id-64'
+import { createFromSlots } from './create-from-slots'
 import { pickTeams, type PlayerSlot } from './pick-teams'
 
 export async function create(
@@ -15,36 +11,7 @@ export async function create(
   friends: SteamId64[][] = [],
 ) {
   const playerSlots: PlayerSlot[] = await Promise.all(queueSlots.map(queueSlotToPlayerSlot))
-  const slots = pickTeams(playerSlots, { friends })
-
-  const { insertedId } = await collections.games.insertOne({
-    number: await getNextGameNumber(),
-    map,
-    state: GameState.created,
-    slots: slots.map(slot => ({
-      id: slot.id,
-      player: slot.player,
-      team: slot.team,
-      gameClass: slot.gameClass,
-      status: SlotStatus.active,
-      connectionStatus: PlayerConnectionStatus.offline,
-      skill: slot.skill,
-    })),
-    events: [
-      {
-        at: new Date(),
-        event: GameEventType.gameCreated,
-      },
-    ],
-  })
-
-  const game = await collections.games.findOne({ _id: insertedId })
-  if (!game) {
-    throw new Error('failed creating game')
-  }
-
-  events.emit('game:created', { game })
-  return game
+  return await createFromSlots(pickTeams(playerSlots, { friends }), map)
 }
 
 async function queueSlotToPlayerSlot(queueSlot: QueueSlotModel): Promise<PlayerSlot> {
@@ -62,13 +29,4 @@ async function queueSlotToPlayerSlot(queueSlot: QueueSlotModel): Promise<PlayerS
   }
 
   return { player: player.steamId, gameClass, skill }
-}
-
-async function getNextGameNumber(): Promise<GameNumber> {
-  const latestGame = await collections.games.findOne({}, { sort: { 'events.0.at': -1 } })
-  if (latestGame) {
-    return (latestGame.number + 1) as GameNumber
-  } else {
-    return 1 as GameNumber
-  }
 }

--- a/src/games/plugins/update-player-elo.ts
+++ b/src/games/plugins/update-player-elo.ts
@@ -2,12 +2,38 @@ import fp from 'fastify-plugin'
 import { events } from '../../events'
 import type { Tf2ClassName } from '../../shared/types/tf2-class-name'
 import type { SteamId64 } from '../../shared/types/steam-id-64'
-import { type PlayerElo } from '../../database/models/player.model'
+import { type PlayerElo, type PlayerModel } from '../../database/models/player.model'
 import { collections } from '../../database/collections'
 import { players } from '../../players'
 import { safe } from '../../utils/safe'
 import { QueueMode } from '../../shared/types/queue-mode'
 import { calculateEloUpdates, defaultElo as defaultEloValue } from '../calculate-elo-updates'
+
+/**
+ * How many games in this mode have already moved a player's rating, per class.
+ *
+ * This drives the K-factor, so it has to be per mode: `stats.gamesByClass` counts both ladders,
+ * and a veteran of the auto queue would otherwise start their captain rating already out of its
+ * provisional period, barely moving from 1500 for months. The ELO history is per mode and one
+ * entry is exactly one rated game, so it is the count we want without a new field to maintain.
+ */
+function gamesRatedIn(
+  mode: QueueMode,
+  history: PlayerModel['eloHistory'],
+): Partial<Record<Tf2ClassName, number>> {
+  const counts: Partial<Record<Tf2ClassName, number>> = {}
+  for (const entry of history ?? []) {
+    if (entry.mode !== mode) {
+      continue
+    }
+
+    for (const gameClass of Object.keys(entry.elo) as Tf2ClassName[]) {
+      counts[gameClass] = (counts[gameClass] ?? 0) + 1
+    }
+  }
+
+  return counts
+}
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -15,7 +41,8 @@ export default fp(
     events.on(
       'game:ended',
       safe(async ({ game }) => {
-        const mode = QueueMode.auto
+        // captain games carry a draft; everything else came out of the auto queue
+        const mode = game.draft ? QueueMode.captains : QueueMode.auto
         const eloMap = new Map<SteamId64, Partial<Record<Tf2ClassName, number>>>()
         const gamesByClassMap = new Map<SteamId64, Partial<Record<Tf2ClassName, number>>>()
 
@@ -23,10 +50,10 @@ export default fp(
           game.slots.map(async slot => {
             const player = await collections.players.findOne(
               { steamId: slot.player },
-              { projection: { elo: 1, 'stats.gamesByClass': 1 } },
+              { projection: { elo: 1, eloHistory: 1 } },
             )
             eloMap.set(slot.player, player?.elo?.[mode] ?? {})
-            gamesByClassMap.set(slot.player, player?.stats.gamesByClass ?? {})
+            gamesByClassMap.set(slot.player, gamesRatedIn(mode, player?.eloHistory))
           }),
         )
 

--- a/src/queue-auto/plugins/auto-reset.ts
+++ b/src/queue-auto/plugins/auto-reset.ts
@@ -2,11 +2,19 @@ import fp from 'fastify-plugin'
 import { events } from '../../events'
 import { reset } from '../reset'
 import { applyMapCooldown } from '../../maps/apply-cooldown'
+import { queue } from '../../queue'
+import { QueueMode } from '../../shared/types/queue-mode'
 
 export default fp(
   // eslint-disable-next-line @typescript-eslint/require-await
   async () => {
     events.on('game:created', async ({ game }) => {
+      // Captain mode clears its own pool and reopens its own queue — running this as well would
+      // apply the map cooldown twice.
+      if ((await queue.getMode()) !== QueueMode.auto) {
+        return
+      }
+
       await applyMapCooldown(game.map)
       await reset()
     })

--- a/src/queue-captains/draft/auto-pick.ts
+++ b/src/queue-captains/draft/auto-pick.ts
@@ -1,21 +1,25 @@
+import { sample } from 'es-toolkit'
 import { collections } from '../../database/collections'
-import type { DraftModel } from '../../database/models/draft.model'
+import { DraftState, type DraftModel } from '../../database/models/draft.model'
 import { logger } from '../../logger'
 import { config } from '../../queue-auto/config'
 import { withQueueLock } from '../../queue/with-queue-lock'
 import { legalPicks } from '../matching/legal-picks'
+import { banOrder } from './ban-order'
 import { currentTurn } from './current-turn'
 import { getCurrent } from './get-current'
 import { openSlots } from './open-slots'
 import { remainingCandidates } from './remaining-candidates'
+import { remainingMaps } from './remaining-maps'
 import { resolveTurns } from './resolve-turns'
 
 /**
- * The captain ran out of time, so a pick is made for them: the longest-waiting player still
- * available, on the first class of theirs that is legal.
+ * The captain ran out of time, so the turn is taken for them.
  *
- * Deterministic rather than random, so a draft replays exactly from its log, and it rewards
- * patience in the queue instead of rolling dice on someone's night.
+ * For a player pick that is the longest-waiting player still available, on the first class of
+ * theirs that is legal — deterministic, so a draft replays exactly from its log, and it rewards
+ * patience in the queue rather than rolling dice on someone's night. A map ban has no such
+ * ordering to lean on, so it falls to chance.
  */
 export async function autoPick(draftId: string, turn: number): Promise<DraftModel | null> {
   return await withQueueLock('captains:auto-pick', async () => {
@@ -25,51 +29,73 @@ export async function autoPick(draftId: string, turn: number): Promise<DraftMode
     }
 
     // the captain got there first; this timeout belongs to a turn that is already settled
-    if (draft.picks.length !== turn) {
+    if (draft.picks.length + draft.mapBans.length !== turn) {
       return null
     }
 
-    const current = currentTurn(draft, config)
-    if (current === null) {
-      return null
-    }
+    return draft.state === DraftState.picking
+      ? await autoPickPlayer(draft, turn)
+      : await autoBanMap(draft)
+  })
+}
 
-    const legal = legalPicks({
-      openSlots: openSlots(draft, config),
-      candidates: remainingCandidates(draft),
-      team: current.team,
-    })
-    if (legal.length === 0) {
-      logger.error({ draft: draft.id, turn }, 'auto-pick found nothing legal')
-      return null
-    }
+async function autoPickPlayer(draft: DraftModel, turn: number): Promise<DraftModel | null> {
+  const current = currentTurn(draft, config)
+  if (current === null) {
+    return null
+  }
 
-    // pool order is join order, so the first match is the one who has waited longest
-    const pick =
-      draft.pool.flatMap(entry => legal.filter(option => option.steamId === entry.steamId))[0] ??
-      legal[0]!
+  const legal = legalPicks({
+    openSlots: openSlots(draft, config),
+    candidates: remainingCandidates(draft),
+    team: current.team,
+  })
+  if (legal.length === 0) {
+    logger.error({ draft: draft.id, turn }, 'auto-pick found nothing legal')
+    return null
+  }
 
-    logger.info({ draft: draft.id, turn, pick }, 'draft turn timed out, picking automatically')
+  // pool order is join order, so the first match is whoever has waited longest
+  const pick =
+    draft.pool.flatMap(entry => legal.filter(option => option.steamId === entry.steamId))[0] ??
+    legal[0]!
 
-    const withPick = await collections.queueCaptainsDrafts.findOneAndUpdate(
-      { id: draft.id, [`picks.${turn}`]: { $exists: false } },
-      {
-        $push: {
-          picks: {
-            team: current.team,
-            player: pick.steamId,
-            gameClass: pick.gameClass,
-            at: new Date(),
-            auto: true,
-          },
+  logger.info({ draft: draft.id, turn, pick }, 'draft turn timed out, picking automatically')
+
+  const withPick = await collections.queueCaptainsDrafts.findOneAndUpdate(
+    { id: draft.id, [`picks.${draft.picks.length}`]: { $exists: false } },
+    {
+      $push: {
+        picks: {
+          team: current.team,
+          player: pick.steamId,
+          gameClass: pick.gameClass,
+          at: new Date(),
+          auto: true,
         },
       },
-      { returnDocument: 'after' },
-    )
-    if (!withPick) {
-      return null
-    }
+    },
+    { returnDocument: 'after' },
+  )
 
-    return await resolveTurns(withPick)
-  })
+  return withPick ? await resolveTurns(withPick) : null
+}
+
+async function autoBanMap(draft: DraftModel): Promise<DraftModel | null> {
+  const team = banOrder(draft.mapOptions)[draft.mapBans.length]
+  const options = remainingMaps(draft)
+  if (team === undefined || options.length <= 1) {
+    return null
+  }
+
+  const map = sample(options)
+  logger.info({ draft: draft.id, team, map }, 'map ban timed out, banning automatically')
+
+  const withBan = await collections.queueCaptainsDrafts.findOneAndUpdate(
+    { id: draft.id, [`mapBans.${draft.mapBans.length}`]: { $exists: false } },
+    { $push: { mapBans: { team, map, at: new Date(), auto: true } } },
+    { returnDocument: 'after' },
+  )
+
+  return withBan ? await resolveTurns(withBan) : null
 }

--- a/src/queue-captains/draft/ban-map.ts
+++ b/src/queue-captains/draft/ban-map.ts
@@ -1,0 +1,47 @@
+import { collections } from '../../database/collections'
+import { DraftState, type DraftModel } from '../../database/models/draft.model'
+import { errors } from '../../errors'
+import { logger } from '../../logger'
+import { withQueueLock } from '../../queue/with-queue-lock'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import { withLogLevel } from '../../utils/with-log-level'
+import { banOrder } from './ban-order'
+import { getCurrent } from './get-current'
+import { remainingMaps } from './remaining-maps'
+import { resolveTurns } from './resolve-turns'
+
+export async function banMap(actor: SteamId64, map: string): Promise<DraftModel> {
+  return await withQueueLock('captains:ban-map', async () => {
+    logger.trace({ actor, map }, 'queueCaptains.banMap()')
+
+    const draft = await getCurrent()
+    if (draft?.state !== DraftState.banningMaps) {
+      throw withLogLevel(errors.badRequest('not banning maps right now'), 'debug')
+    }
+
+    const team = banOrder(draft.mapOptions)[draft.mapBans.length]
+    if (team === undefined) {
+      throw withLogLevel(errors.badRequest('there is nothing left to ban'), 'debug')
+    }
+
+    if (draft.captains[team] !== actor) {
+      throw withLogLevel(errors.forbidden('it is not your ban'), 'debug')
+    }
+
+    if (!remainingMaps(draft).includes(map)) {
+      throw withLogLevel(errors.badRequest('that map is not on the table'), 'debug')
+    }
+
+    const withBan = await collections.queueCaptainsDrafts.findOneAndUpdate(
+      // the ban count guards against two bans racing into the same turn
+      { id: draft.id, [`mapBans.${draft.mapBans.length}`]: { $exists: false } },
+      { $push: { mapBans: { team, map, at: new Date() } } },
+      { returnDocument: 'after' },
+    )
+    if (!withBan) {
+      throw withLogLevel(errors.conflict('that ban has already been made'), 'debug')
+    }
+
+    return await resolveTurns(withBan)
+  })
+}

--- a/src/queue-captains/draft/ban-order.test.ts
+++ b/src/queue-captains/draft/ban-order.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { Tf2Team } from '../../shared/types/tf2-team'
+import { banOrder } from './ban-order'
+
+const { blu, red } = Tf2Team
+
+describe('banOrder()', () => {
+  it('has RED ban first, evening out BLU picking first', () => {
+    expect(banOrder(['a', 'b', 'c'])).toEqual([red, blu])
+  })
+
+  it('leaves exactly one map standing', () => {
+    for (const size of [2, 3, 4, 5]) {
+      const options = Array.from({ length: size }, (_, i) => `map${i}`)
+      expect(banOrder(options)).toHaveLength(size - 1)
+    }
+  })
+
+  it('has nothing to ban when there is only one option', () => {
+    expect(banOrder(['only'])).toEqual([])
+    expect(banOrder([])).toEqual([])
+  })
+
+  it('keeps alternating past the usual three', () => {
+    expect(banOrder(['a', 'b', 'c', 'd', 'e'])).toEqual([red, blu, red, blu])
+  })
+})

--- a/src/queue-captains/draft/ban-order.ts
+++ b/src/queue-captains/draft/ban-order.ts
@@ -1,0 +1,13 @@
+import { Tf2Team } from '../../shared/types/tf2-team'
+
+/**
+ * Who bans each map, in order.
+ *
+ * RED bans first — BLU had the first player pick, so the first ban is what evens that out. With
+ * three options and two bans, whatever survives is the map.
+ */
+export function banOrder(mapOptions: string[]): Tf2Team[] {
+  return Array.from({ length: Math.max(mapOptions.length - 1, 0) }, (_, turn) =>
+    turn % 2 === 0 ? Tf2Team.red : Tf2Team.blu,
+  )
+}

--- a/src/queue-captains/draft/draft-to-slots.test.ts
+++ b/src/queue-captains/draft/draft-to-slots.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import { DraftState, type DraftId, type DraftModel } from '../../database/models/draft.model'
+import { _6v6 } from '../../queue-auto/configs/6v6'
+import type { SteamId64 } from '../../shared/types/steam-id-64'
+import { Tf2ClassName } from '../../shared/types/tf2-class-name'
+import { Tf2Team } from '../../shared/types/tf2-team'
+import { draftToSlots } from './draft-to-slots'
+
+const { scout, soldier, demoman, medic } = Tf2ClassName
+const { blu, red } = Tf2Team
+
+const id = (name: string) => name as unknown as SteamId64
+
+// a finished 6v6 draft: five picks a side, each captain left holding one slot
+const draft: DraftModel = {
+  id: 'd' as DraftId,
+  state: DraftState.completed,
+  createdAt: new Date(),
+  captains: { [blu]: id('cinder'), [red]: id('harbor') },
+  pool: [
+    ['cinder', [soldier, demoman]],
+    ['harbor', [scout, demoman]],
+    ['dusk', [medic]],
+    ['ivy', [medic]],
+    ['kestrel', [scout]],
+    ['bramble', [scout]],
+    ['gale', [scout]],
+    ['moss', [scout]],
+    ['axolotl', [soldier]],
+    ['flint', [soldier]],
+    ['larch', [soldier]],
+    ['ember', [soldier]],
+    ['juniper', [demoman]],
+  ].map(([name, gameClasses]) => ({
+    steamId: id(name as string),
+    name: name as string,
+    avatarUrl: '',
+    gameClasses: gameClasses as Tf2ClassName[],
+  })),
+  picks: [
+    { team: blu, player: id('dusk'), gameClass: medic, at: new Date() },
+    { team: red, player: id('ivy'), gameClass: medic, at: new Date() },
+    { team: blu, player: id('kestrel'), gameClass: scout, at: new Date() },
+    { team: blu, player: id('moss'), gameClass: scout, at: new Date() },
+    { team: red, player: id('bramble'), gameClass: scout, at: new Date() },
+    { team: blu, player: id('axolotl'), gameClass: soldier, at: new Date() },
+    { team: blu, player: id('juniper'), gameClass: demoman, at: new Date() },
+    { team: red, player: id('flint'), gameClass: soldier, at: new Date() },
+    { team: red, player: id('larch'), gameClass: soldier, at: new Date() },
+    { team: red, player: id('gale'), gameClass: scout, at: new Date() },
+  ],
+  mapOptions: ['a', 'b', 'c'],
+  mapBans: [
+    { team: red, map: 'c', at: new Date() },
+    { team: blu, map: 'b', at: new Date() },
+  ],
+}
+
+describe('draftToSlots()', () => {
+  const slots = draftToSlots(draft, _6v6)
+
+  it('fills every slot in the game', () => {
+    expect(slots).toHaveLength(12)
+    expect(slots.filter(slot => slot.team === blu)).toHaveLength(6)
+    expect(slots.filter(slot => slot.team === red)).toHaveLength(6)
+  })
+
+  it('gives every player exactly one slot', () => {
+    expect(new Set(slots.map(slot => slot.player)).size).toBe(12)
+  })
+
+  it('leaves the two unpicked players out', () => {
+    const playing = new Set(slots.map(slot => slot.player as unknown as string))
+    expect(playing.has('ember')).toBe(false)
+    expect(playing.size).toBe(12)
+  })
+
+  it('marks both captains and nobody else', () => {
+    const captains = slots.filter(slot => slot.isCaptain)
+    expect(captains.map(slot => slot.player as unknown as string).sort()).toEqual([
+      'cinder',
+      'harbor',
+    ])
+  })
+
+  it('gives each captain a class they signed up for', () => {
+    for (const slot of slots.filter(s => s.isCaptain)) {
+      const entry = draft.pool.find(p => p.steamId === slot.player)!
+      expect(entry.gameClasses).toContain(slot.gameClass)
+    }
+  })
+
+  it('numbers slot ids per team and class', () => {
+    const ids = slots.map(slot => slot.id).sort()
+    expect(new Set(ids).size).toBe(12)
+    expect(ids.filter(slotId => slotId.startsWith('blu-scout-'))).toEqual([
+      'blu-scout-1',
+      'blu-scout-2',
+    ])
+  })
+
+  it('respects the class counts the game mode needs', () => {
+    for (const team of [blu, red]) {
+      const counts = new Map<string, number>()
+      for (const slot of slots.filter(s => s.team === team)) {
+        counts.set(slot.gameClass, (counts.get(slot.gameClass) ?? 0) + 1)
+      }
+      expect(counts.get(scout)).toBe(2)
+      expect(counts.get(soldier)).toBe(2)
+      expect(counts.get(demoman)).toBe(1)
+      expect(counts.get(medic)).toBe(1)
+    }
+  })
+})

--- a/src/queue-captains/draft/draft-to-slots.ts
+++ b/src/queue-captains/draft/draft-to-slots.ts
@@ -1,0 +1,43 @@
+import type { DraftModel } from '../../database/models/draft.model'
+import type { GameSlotSpec } from '../../games/create-from-slots'
+import type { QueueConfig } from '../../queue/types/queue-config'
+import type { GameSlotId } from '../../shared/types/game-slot-id'
+import { Tf2Team } from '../../shared/types/tf2-team'
+import { openSlots } from './open-slots'
+
+/**
+ * Turn a finished draft into the game's roster.
+ *
+ * Every pick already carries its team and class. The two slots nobody was picked for are the
+ * captains' own — one per team, and the matching guaranteed each captain can play theirs.
+ */
+export function draftToSlots(draft: DraftModel, config: QueueConfig): GameSlotSpec[] {
+  const counts = new Map<string, number>()
+  const nextId = (team: Tf2Team, gameClass: string): GameSlotId => {
+    const key = `${team}-${gameClass}`
+    const n = (counts.get(key) ?? 0) + 1
+    counts.set(key, n)
+    return `${key}-${n}` as GameSlotId
+  }
+
+  const captainSlots = openSlots(draft, config).map(slot => ({
+    team: slot.team,
+    gameClass: slot.gameClass,
+    player: draft.captains[slot.team],
+    isCaptain: true,
+  }))
+
+  return [...draft.picks, ...captainSlots]
+    .sort((a, b) => teamOrder(a.team) - teamOrder(b.team))
+    .map(entry => ({
+      id: nextId(entry.team, entry.gameClass),
+      player: entry.player,
+      team: entry.team,
+      gameClass: entry.gameClass,
+      ...('isCaptain' in entry && entry.isCaptain ? { isCaptain: true } : {}),
+    }))
+}
+
+function teamOrder(team: Tf2Team): number {
+  return team === Tf2Team.blu ? 0 : 1
+}

--- a/src/queue-captains/draft/get-current.ts
+++ b/src/queue-captains/draft/get-current.ts
@@ -1,10 +1,11 @@
 import { collections } from '../../database/collections'
 import { DraftState, type DraftModel } from '../../database/models/draft.model'
 
-// There is at most one draft running at a time, since there is one queue.
+// The draft still being run — picking players or banning maps. There is at most one at a time,
+// since there is one queue.
 export async function getCurrent(): Promise<DraftModel | null> {
   return await collections.queueCaptainsDrafts.findOne(
-    { state: DraftState.picking },
+    { state: { $in: [DraftState.picking, DraftState.banningMaps] } },
     { sort: { createdAt: -1 } },
   )
 }

--- a/src/queue-captains/draft/remaining-maps.ts
+++ b/src/queue-captains/draft/remaining-maps.ts
@@ -1,0 +1,6 @@
+import type { DraftModel } from '../../database/models/draft.model'
+
+export function remainingMaps(draft: DraftModel): string[] {
+  const banned = new Set(draft.mapBans.map(ban => ban.map))
+  return draft.mapOptions.filter(map => !banned.has(map))
+}

--- a/src/queue-captains/draft/resolve-turns.ts
+++ b/src/queue-captains/draft/resolve-turns.ts
@@ -1,3 +1,4 @@
+import type { UpdateFilter } from 'mongodb'
 import { collections } from '../../database/collections'
 import { DraftState, type DraftModel, type DraftPick } from '../../database/models/draft.model'
 import { configuration } from '../../configuration'
@@ -6,14 +7,17 @@ import { logger } from '../../logger'
 import { config } from '../../queue-auto/config'
 import { tasks } from '../../tasks'
 import { legalPicks } from '../matching/legal-picks'
+import { banOrder } from './ban-order'
 import { currentTurn } from './current-turn'
 import { openSlots } from './open-slots'
 import { remainingCandidates } from './remaining-candidates'
+import { remainingMaps } from './remaining-maps'
 
 /**
- * Settle the draft up to the next turn that needs a decision.
+ * Settle the draft up to the next turn that needs a decision, moving from picking players to
+ * banning maps once the teams are full.
  *
- * Turns with only one legal pick are committed straight away instead of burning the clock on a
+ * Turns with only one legal option are committed straight away instead of burning the clock on a
  * non-choice, and that can cascade, so this loops until it reaches a turn with a real choice or
  * runs out of turns entirely.
  *
@@ -23,70 +27,71 @@ export async function resolveTurns(draft: DraftModel): Promise<DraftModel> {
   let current = draft
 
   for (;;) {
-    const turn = currentTurn(current, config)
-    if (turn === null) {
+    if (current.state === DraftState.picking) {
+      const turn = currentTurn(current, config)
+      if (turn === null) {
+        current = await beginMapBans(current)
+        continue
+      }
+
+      const picks = legalPicks({
+        openSlots: openSlots(current, config),
+        candidates: remainingCandidates(current),
+        team: turn.team,
+      })
+
+      if (picks.length === 0) {
+        // legalPicks only ever offers picks that keep both teams completable, so reaching here
+        // means the draft started from an impossible position and cannot be finished.
+        logger.error({ draft: current.id, turn }, 'draft dead end: no legal picks')
+        throw new Error(`draft ${current.id} dead-ended on turn ${turn.index + 1}`)
+      }
+
+      if (picks.length > 1) {
+        return await awaitCaptain(current, 'queue.captains.pick_timeout')
+      }
+
+      const only = picks[0]!
+      current = await appendPick(current, {
+        team: turn.team,
+        player: only.steamId,
+        gameClass: only.gameClass,
+        at: new Date(),
+        forced: true,
+      })
+      continue
+    }
+
+    const bans = banOrder(current.mapOptions)
+    if (current.mapBans.length >= bans.length || remainingMaps(current).length <= 1) {
       return await complete(current)
     }
 
-    const picks = legalPicks({
-      openSlots: openSlots(current, config),
-      candidates: remainingCandidates(current),
-      team: turn.team,
-    })
-
-    if (picks.length === 0) {
-      // legalPicks only ever offers picks that keep both teams completable, so reaching here means
-      // the draft started from an impossible position and cannot be finished.
-      logger.error({ draft: current.id, turn }, 'draft dead end: no legal picks')
-      throw new Error(`draft ${current.id} dead-ended on turn ${turn.index + 1}`)
-    }
-
-    if (picks.length > 1) {
-      return await awaitCaptain(current)
-    }
-
-    const only = picks[0]!
-    current = await append(current, {
-      team: turn.team,
-      player: only.steamId,
-      gameClass: only.gameClass,
-      at: new Date(),
-      forced: true,
-    })
+    return await awaitCaptain(current, 'queue.captains.ban_timeout')
   }
 }
 
-async function append(draft: DraftModel, pick: DraftPick): Promise<DraftModel> {
-  const updated = await collections.queueCaptainsDrafts.findOneAndUpdate(
-    { id: draft.id },
-    { $push: { picks: pick } },
-    { returnDocument: 'after' },
-  )
-  if (!updated) {
-    throw new Error(`no such draft: ${draft.id}`)
-  }
-
-  return updated
+async function appendPick(draft: DraftModel, pick: DraftPick): Promise<DraftModel> {
+  return await update(draft, { $push: { picks: pick } })
 }
 
-async function awaitCaptain(draft: DraftModel): Promise<DraftModel> {
-  const timeout = await configuration.get('queue.captains.pick_timeout')
-  const turnEndsAt = new Date(Date.now() + timeout)
+async function beginMapBans(draft: DraftModel): Promise<DraftModel> {
+  logger.info({ draft: draft.id }, 'teams are set, moving on to map bans')
+  return await update(draft, { $set: { state: DraftState.banningMaps } })
+}
 
-  const updated = await collections.queueCaptainsDrafts.findOneAndUpdate(
-    { id: draft.id },
-    { $set: { turnEndsAt } },
-    { returnDocument: 'after' },
-  )
-  if (!updated) {
-    throw new Error(`no such draft: ${draft.id}`)
-  }
+async function awaitCaptain(
+  draft: DraftModel,
+  timeoutKey: 'queue.captains.pick_timeout' | 'queue.captains.ban_timeout',
+): Promise<DraftModel> {
+  const timeout = await configuration.get(timeoutKey)
+  const updated = await update(draft, { $set: { turnEndsAt: new Date(Date.now() + timeout) } })
 
-  // the turn index is part of the args so a timeout that fires late, after the captain already
-  // picked, matches nothing and is ignored
+  // the turn number is part of the args so a timeout that fires late, after the captain already
+  // acted, matches nothing and is ignored
   await tasks.schedule('queueCaptains:draftTurnTimeout', timeout, {
     draftId: updated.id,
-    turn: updated.picks.length,
+    turn: updated.picks.length + updated.mapBans.length,
   })
 
   events.emit('queueCaptains/draft:updated', { draft: updated })
@@ -94,17 +99,31 @@ async function awaitCaptain(draft: DraftModel): Promise<DraftModel> {
 }
 
 async function complete(draft: DraftModel): Promise<DraftModel> {
+  const updated = await update(draft, {
+    $set: { state: DraftState.completed },
+    $unset: { turnEndsAt: '' },
+  })
+
+  logger.info(
+    { draft: updated.id, map: remainingMaps(updated)[0] },
+    'draft completed, teams and map are set',
+  )
+  events.emit('queueCaptains/draft:updated', { draft: updated })
+  events.emit('queueCaptains/draft:completed', { draft: updated })
+  return updated
+}
+
+async function update(draft: DraftModel, changes: UpdateFilter<DraftModel>): Promise<DraftModel> {
   const updated = await collections.queueCaptainsDrafts.findOneAndUpdate(
     { id: draft.id },
-    { $set: { state: DraftState.completed }, $unset: { turnEndsAt: '' } },
-    { returnDocument: 'after' },
+    changes,
+    {
+      returnDocument: 'after',
+    },
   )
   if (!updated) {
     throw new Error(`no such draft: ${draft.id}`)
   }
 
-  logger.info({ draft: updated.id }, 'draft completed')
-  events.emit('queueCaptains/draft:updated', { draft: updated })
-  events.emit('queueCaptains/draft:completed', { draft: updated })
   return updated
 }

--- a/src/queue-captains/draft/start.ts
+++ b/src/queue-captains/draft/start.ts
@@ -6,6 +6,7 @@ import { events } from '../../events'
 import { logger } from '../../logger'
 import { config } from '../../queue-auto/config'
 import { setState } from '../../queue/set-state'
+import { resetMapOptions } from '../../maps/reset-options'
 import { getPool } from '../get-pool'
 import { drawCaptains } from './draw-captains'
 import { resolveTurns } from './resolve-turns'
@@ -27,6 +28,12 @@ export async function start(): Promise<DraftModel> {
   try {
     const pool = await getPool()
     const captains = drawCaptains(pool, config)
+    // normally seeded at boot and after every game, but a draft with nothing to ban is not a
+    // draft, so make sure there is something on the table
+    if ((await collections.queueMapOptions.countDocuments()) === 0) {
+      await resetMapOptions()
+    }
+    const mapOptions = (await collections.queueMapOptions.find().toArray()).map(({ name }) => name)
 
     const draft: DraftModel = {
       id: nanoid(),
@@ -40,6 +47,8 @@ export async function start(): Promise<DraftModel> {
         gameClasses,
       })),
       picks: [],
+      mapOptions,
+      mapBans: [],
     }
 
     await collections.queueCaptainsDrafts.insertOne(draft)

--- a/src/queue-captains/plugins/gateway-listeners.ts
+++ b/src/queue-captains/plugins/gateway-listeners.ts
@@ -6,6 +6,7 @@ import type { Tf2ClassName } from '../../shared/types/tf2-class-name'
 import { logError } from '../../utils/log-error'
 import { measureTime } from '../../utils/measure-time'
 import type { AppWebSocket } from '../../websocket/types'
+import { banMap } from '../draft/ban-map'
 import { makePick } from '../draft/make-pick'
 import { leave } from '../leave'
 import { readyUp } from '../ready-up'
@@ -59,6 +60,17 @@ export default fp(
 
         const [player, gameClass] = pick.split(':') as [SteamId64, Tf2ClassName]
         await makePick(socket.player.steamId, player, gameClass)
+      }),
+    )
+
+    app.gateway.on(
+      'queue:captainsban',
+      wsSafe('captains:ban', async (socket, map: string) => {
+        if (!socket.player) {
+          throw errors.unauthorized('unauthorized')
+        }
+
+        await banMap(socket.player.steamId, map)
       }),
     )
 

--- a/src/queue-captains/plugins/launch-drafted-game.ts
+++ b/src/queue-captains/plugins/launch-drafted-game.ts
@@ -1,0 +1,51 @@
+import fp from 'fastify-plugin'
+import { collections } from '../../database/collections'
+import { events } from '../../events'
+import { assignGameServer } from '../../games/assign-game-server'
+import { createFromSlots } from '../../games/create-from-slots'
+import { configure } from '../../games/rcon/configure'
+import { logger } from '../../logger'
+import { applyMapCooldown } from '../../maps/apply-cooldown'
+import { resetMapOptions } from '../../maps/reset-options'
+import { config } from '../../queue-auto/config'
+import { safe } from '../../utils/safe'
+import { draftToSlots } from '../draft/draft-to-slots'
+import { remainingMaps } from '../draft/remaining-maps'
+import { unreadyPool } from '../unready-pool'
+
+export default fp(
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async () => {
+    events.on(
+      'queueCaptains/draft:completed',
+      safe(async ({ draft }) => {
+        const map = remainingMaps(draft)[0]
+        if (map === undefined) {
+          logger.error({ draft: draft.id }, 'draft finished with no map left standing')
+          return
+        }
+
+        const game = await createFromSlots(draftToSlots(draft, config), map, draft.id)
+        await collections.queueCaptainsDrafts.updateOne(
+          { id: draft.id },
+          { $set: { game: game.number } },
+        )
+        logger.info({ draft: draft.id, game: game.number, map }, 'drafted game created')
+
+        // Only the drafted players leave. Whoever went unpicked keeps their place and their
+        // classes, so sitting one out costs nothing but the wait.
+        await collections.queueCaptainsPool.deleteMany({
+          'player.steamId': { $in: game.slots.map(slot => slot.player) },
+        })
+
+        await applyMapCooldown(map)
+        await resetMapOptions()
+        await unreadyPool()
+
+        await assignGameServer(game.number, { retries: 3 })
+        void configure(game.number)
+      }),
+    )
+  },
+  { name: 'launch drafted game' },
+)

--- a/src/queue-captains/views/html/draft-board.css
+++ b/src/queue-captains/views/html/draft-board.css
@@ -347,3 +347,93 @@
     }
   }
 }
+
+@layer components {
+  .map-bans {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+
+    @media (width < theme(--breakpoint-md)) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .map-ban {
+    @apply transition-all;
+    @apply duration-75;
+
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-end;
+
+    aspect-ratio: 3 / 1;
+    padding: 13px;
+    border-radius: 8px;
+    overflow: hidden;
+
+    background: linear-gradient(90deg, var(--color-abru-light-25) 35%, transparent 90%);
+    color: var(--color-ash);
+
+    .map-ban-art {
+      position: absolute;
+      inset: 0 0 0 33%;
+      z-index: -2;
+    }
+
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      background: linear-gradient(90deg, var(--color-abru-light-25) 35%, transparent 90%);
+    }
+
+    .map-ban-name {
+      font-size: 20px;
+      font-weight: 700;
+    }
+
+    .map-ban-tag {
+      font-size: 14px;
+      font-weight: 300;
+      color: var(--color-abru-light-75);
+    }
+
+    &:is(button):hover {
+      background: linear-gradient(90deg, var(--color-team-red) 35%, transparent 90%);
+
+      &::before {
+        background: linear-gradient(90deg, var(--color-team-red) 35%, transparent 90%);
+      }
+    }
+
+    &[data-team='blu']:is(button):hover,
+    &[data-team='blu']:is(button):hover::before {
+      background: linear-gradient(90deg, var(--color-team-blu) 35%, transparent 90%);
+    }
+
+    &[data-state='banned'] {
+      filter: saturate(0.15) brightness(0.55);
+
+      .map-ban-name {
+        text-decoration: line-through;
+        text-decoration-thickness: 2px;
+      }
+    }
+
+    &[data-state='won'] {
+      box-shadow: inset 0 0 0 3px var(--color-ash);
+    }
+
+    .map-ban-x {
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      color: var(--color-team-red);
+    }
+  }
+}

--- a/src/queue-captains/views/html/draft-board.tsx
+++ b/src/queue-captains/views/html/draft-board.tsx
@@ -1,6 +1,6 @@
 import { GameClassIcon } from '../../../html/components/game-class-icon'
 import { IconCrown, IconLock } from '../../../html/components/icons'
-import type { DraftModel } from '../../../database/models/draft.model'
+import { DraftState, type DraftModel } from '../../../database/models/draft.model'
 import { config } from '../../../queue-auto/config'
 import type { SteamId64 } from '../../../shared/types/steam-id-64'
 import { Tf2Team } from '../../../shared/types/tf2-team'
@@ -9,6 +9,7 @@ import { getCurrent } from '../../draft/get-current'
 import { openSlots } from '../../draft/open-slots'
 import { remainingCandidates } from '../../draft/remaining-candidates'
 import { legalPicks, type LegalPick } from '../../matching/legal-picks'
+import { MapBans } from './map-bans'
 import { pickOrder } from '../../pick-order'
 import { teamSlots } from '../../team-slots'
 
@@ -18,7 +19,8 @@ export async function DraftBoard(props: { actor?: SteamId64 | undefined }) {
     return <div id="draft-board"></div>
   }
 
-  const turn = currentTurn(draft, config)
+  const banning = draft.state === DraftState.banningMaps
+  const turn = banning ? null : currentTurn(draft, config)
   const isMyTurn = turn !== null && draft.captains[turn.team] === props.actor
   const available = openSlots(draft, config)
   const picks =
@@ -32,13 +34,31 @@ export async function DraftBoard(props: { actor?: SteamId64 | undefined }) {
 
   return (
     <div id="draft-board" class="draft-board">
-      <TurnBar draft={draft} turn={turn} isMyTurn={isMyTurn} />
+      {banning ? (
+        <div class="captains-panel turn-bar">
+          <div class="turn-bar-top">
+            <div class="turn-who">
+              <MapBans.heading draft={draft} actor={props.actor} />
+            </div>
+            <span class="turn-clock" data-countdown={banClockMs(draft)} safe>
+              {formatClock(banClockMs(draft))}
+            </span>
+          </div>
+          <div class="turn-timer">
+            <i style={`animation-duration: ${banClockMs(draft)}ms`}></i>
+          </div>
+        </div>
+      ) : (
+        <TurnBar draft={draft} turn={turn} isMyTurn={isMyTurn} />
+      )}
 
       <div class="draft-teams">
         {[Tf2Team.blu, Tf2Team.red].map(team => (
           <TeamPanel draft={draft} team={team} active={turn?.team === team} />
         ))}
       </div>
+
+      {banning && <MapBans draft={draft} actor={props.actor} />}
 
       {turn !== null && (
         <AvailablePool
@@ -252,6 +272,10 @@ function AvailablePool(props: {
       </form>
     </div>
   )
+}
+
+function banClockMs(draft: DraftModel): number {
+  return Math.max((draft.turnEndsAt?.getTime() ?? 0) - Date.now(), 0)
 }
 
 function formatClock(ms: number): string {

--- a/src/queue-captains/views/html/map-bans.tsx
+++ b/src/queue-captains/views/html/map-bans.tsx
@@ -1,0 +1,95 @@
+import type { DraftModel } from '../../../database/models/draft.model'
+import { MapThumbnail } from '../../../html/components/map-thumbnail'
+import { IconX } from '../../../html/components/icons'
+import type { SteamId64 } from '../../../shared/types/steam-id-64'
+import { banOrder } from '../../draft/ban-order'
+import { remainingMaps } from '../../draft/remaining-maps'
+
+export function MapBans(props: { draft: DraftModel; actor?: SteamId64 | undefined }) {
+  const { draft } = props
+  const team = banOrder(draft.mapOptions)[draft.mapBans.length]
+  const isMyBan = team !== undefined && draft.captains[team] === props.actor
+  const surviving = remainingMaps(draft)
+  const decided = team === undefined || surviving.length <= 1
+
+  return (
+    <form class="map-bans" ws-send data-disable-when-offline>
+      {draft.mapOptions.map(map => {
+        const ban = draft.mapBans.find(entry => entry.map === map)
+        const isMap = decided && surviving[0] === map
+
+        if (ban) {
+          return (
+            <div class="map-ban" data-state="banned">
+              <div class="map-ban-art">
+                <MapThumbnail map={map} />
+              </div>
+              <span class="map-ban-x">
+                <IconX size={48} />
+              </span>
+              <span class="map-ban-tag">
+                banned by {ban.team}
+                {ban.auto ? ' · timed out' : ''}
+              </span>
+              <span class="map-ban-name" safe>
+                {map}
+              </span>
+            </div>
+          )
+        }
+
+        const content = (
+          <>
+            <div class="map-ban-art">
+              <MapThumbnail map={map} />
+            </div>
+            <span class="map-ban-tag">{isMap ? 'map' : isMyBan ? 'click to ban' : ''}</span>
+            <span class="map-ban-name" safe>
+              {map}
+            </span>
+          </>
+        )
+
+        return isMyBan ? (
+          <button
+            class="map-ban"
+            data-state="open"
+            data-team={team}
+            name="captainsban"
+            value={map}
+            data-umami-event="captains-ban-map"
+            data-umami-event-map={map}
+          >
+            {content}
+          </button>
+        ) : (
+          <div class="map-ban" data-state={isMap ? 'won' : 'open'}>
+            {content}
+          </div>
+        )
+      })}
+    </form>
+  )
+}
+
+MapBans.heading = function (props: { draft: DraftModel; actor?: SteamId64 | undefined }) {
+  const team = banOrder(props.draft.mapOptions)[props.draft.mapBans.length]
+  if (team === undefined) {
+    return <span class="turn-label">Map is set</span>
+  }
+
+  const isMyBan = props.draft.captains[team] === props.actor
+  return (
+    <>
+      <span class="turn-team" data-team={team}>
+        {team}
+      </span>
+      <span class="turn-label">{isMyBan ? 'Ban a map' : 'is banning'}</span>
+      <span class="turn-sub">
+        {props.draft.mapBans.length === 0
+          ? 'first of two bans'
+          : 'last ban — whatever is left is the map'}
+      </span>
+    </>
+  )
+}

--- a/src/websocket/gateway.ts
+++ b/src/websocket/gateway.ts
@@ -24,6 +24,7 @@ export interface ClientToServerEvents {
   'queue:captainsclass': (gameClass: Tf2ClassName) => void
   'queue:captainsvolunteer': () => void
   'queue:captainspick': (pick: string) => void
+  'queue:captainsban': (map: string) => void
   'queue:captainsreadyup': () => void
   'queue:captainsleave': () => void
   'queue:audiostatus': (audioReady: boolean) => void
@@ -85,6 +86,11 @@ const captainsPick = z.object({
   HEADERS: htmxHeaders,
 })
 
+const captainsBan = z.object({
+  captainsban: z.string(),
+  HEADERS: htmxHeaders,
+})
+
 const captainsReadyUp = z.object({
   captainsreadyup: z.literal(''),
   HEADERS: htmxHeaders,
@@ -115,6 +121,7 @@ const clientMessage = z.union([
   captainsClass,
   captainsVolunteer,
   captainsPick,
+  captainsBan,
   captainsReadyUp,
   captainsLeave,
   navigated,
@@ -321,6 +328,8 @@ export class Gateway extends EventEmitter implements Broadcaster {
         this.emit('queue:captainsvolunteer', socket)
       } else if ('captainspick' in parsed) {
         this.emit('queue:captainspick', socket, parsed.captainspick)
+      } else if ('captainsban' in parsed) {
+        this.emit('queue:captainsban', socket, parsed.captainsban)
       } else if ('captainsreadyup' in parsed) {
         this.emit('queue:captainsreadyup', socket)
       } else if ('captainsleave' in parsed) {


### PR DESCRIPTION
Completes the captain-mode flow: a draft now ends in an actual game.

## What happens now

Once the teams are full the draft moves to **banning maps**. RED bans first — BLU had first pick, so the first ban is what evens that out — and whichever of the three options survives is the map. A ban nobody makes in time falls to chance; unlike a player pick there is no queue order to lean on.

The game is then built **from the draft itself** rather than from balancing. Every pick already carries its team and class, and the two slots nobody was picked for are the captains' own — the matching guaranteed each can play theirs. Both are marked on the game so everyone can see who drafted.

Only the drafted players leave the pool. **Whoever went unpicked keeps their place and their classes**, so sitting one out costs nothing but the wait, and the queue reopens behind them.

## ELO finally routes by mode

A game with a draft moves `elo.captains`; everything else still moves `elo.auto`. More importantly the **K-factor now counts games rated in that mode**, which is the open question I flagged back in #764:

> a player with 200 auto games would start captain ELO at 1500 with K=16 instead of 32, converging too slowly to mean much

I'd said this needed a mode dimension on `stats.gamesByClass`, rippling into hall-of-fame, indexes and the player page. It doesn't — `eloHistory` is already per mode and one entry is exactly one rated game, so the count falls out of data we already keep, with no new field to maintain and no migration.

## A bug the end-to-end run caught

`getCurrent()` matched only `state: picking`. The instant the draft moved to `banningMaps` it returned null — the board vanished from the page, `banMap` rejected every ban, and the ban timeout found nothing to act on. The draft stalled dead. Nothing in the type system or the unit tests would have shown that; it took driving the whole thing.

Also guarded `auto-reset`, which fires on `game:created` for *any* game and would have applied the map cooldown a second time and reset a queue captain mode manages itself. That's the fourth instance of cross-mode bleed — it remains the defining hazard of one-mode-at-a-time.

## Verified against a running server

14 players over real websockets, from signing up through to the finished game — captains picking and banning **by clicking the buttons the server rendered**:

```
ok  draft completed                    ok  two slots are marked captain
ok  ten picks were made                ok  the marked captains are the ones who drafted
ok  three map options frozen           ok  nobody holds two slots
ok  two maps were banned               ok  everyone plays a class they signed up for
ok  RED banned first, BLU second       ok  blu/red each have six players
ok  one map survived                   ok  the two unpicked players stayed queued
ok  the game is on that map            ok  nobody in the game is still in the pool
ok  game and draft point at each other ok  the queue reopened for the next game
```

Then the same run with a 1.5s ban timeout and captains deliberately silent — **both maps banned automatically**, game still created correctly.

## Also

A draft starting with an empty map pool would have completed with no map. Normally impossible (options are seeded at boot and after every game), but `start()` now tops them up rather than producing a mapless draft.

## Checks

`pnpm lint`, `pnpm xss-scan`, `pnpm test` (483 passed, run with `.env` moved aside to match CI), `tsc -p tsconfig.build.json` all clean.

## What's left

The draft replay page and instrumentation — the last PR in the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)